### PR TITLE
Prepare Cocoa VM for High-DPI

### DIFF
--- a/platforms/iOS/vm/Common/Classes/sqSqueakScreenAndWindow.m
+++ b/platforms/iOS/vm/Common/Classes/sqSqueakScreenAndWindow.m
@@ -87,11 +87,11 @@ void MyProviderReleaseData (
 	sqInt w, h;
 	
 #if BUILD_FOR_OSX
-		NSRect screenSize = [gDelegateApp.mainView bounds];
+		NSRect
 #else
-		CGRect screenSize = [gDelegateApp.mainView bounds];
+		CGRect
 #endif
-		
+    screenSize = [gDelegateApp.mainView sqScreenSize];
 		w = (sqInt) screenSize.size.width;
 		h = (sqInt) screenSize.size.height;
 

--- a/platforms/iOS/vm/OSX/Squeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Squeak-Info.plist
@@ -375,6 +375,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>SqueakOSXApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -260,8 +260,8 @@ static int buttonState=0;
 	evt.type = EventTypeMouse;
 	evt.timeStamp = ioMSecs();
 	
-	NSPoint local_point = [aView convertPoint: [theEvent locationInWindow] fromView:nil];
-	
+	NSPoint local_point = [aView sqMousePosition: theEvent];
+
 	evt.x =  lrintf((float)local_point.x);
 	evt.y =  lrintf((float)local_point.y);
 	

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
@@ -157,6 +157,9 @@ static char *getVersionInfo(int verbose);
 		if ([argData compare:  @"-psn_" options: NSLiteralSearch range: NSMakeRange(0,5)] == NSOrderedSame) {
 			return 1;
 		}
+		if ([argData isEqualToString: @"-NSDocumentRevisionsDebugMode"]) {
+			return 1;
+		}
 	NS_HANDLER;
 	NS_ENDHANDLER;
 

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.h
@@ -85,6 +85,8 @@
 -(NSMutableArray *)filterOutSqueakImageFilesFromDraggedFiles: (id<NSDraggingInfo>)info;
 -(NSMutableArray *)filterSqueakImageFilesFromDraggedFiles: (id<NSDraggingInfo>)info;
 -(void) drawThelayers;
+-(NSRect) sqScreenSize;
+-(NSPoint) sqMousePosition: (NSEvent*)theEvent;
 @end
 
 #import	"SqViewClut.h"

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -48,14 +48,9 @@
 #import "sqVirtualMachine.h"
 
 #import <QuartzCore/QuartzCore.h>
-#import <QuartzCore/CIImage.h>
-
-//#import <OpenGL/CGLMacro.h>
 
 extern SqueakOSXAppDelegate *gDelegateApp;
 extern struct	VirtualMachine* interpreterProxy;
-
-#define max(x, y) (x > y? x: y)
 
 static NSString *stringWithCharacter(unichar character) {
 	return [NSString stringWithCharacters: &character length: 1];
@@ -64,17 +59,6 @@ static NSString *stringWithCharacter(unichar character) {
 @implementation sqSqueakOSXCGView
 @synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
 lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
-
-+ (NSOpenGLPixelFormat *)defaultPixelFormat {
-	NSOpenGLPixelFormatAttribute attrs[] =
-    {
-		NSOpenGLPFAAccelerated,
-		NSOpenGLPFANoRecovery,
-		NSOpenGLPFABackingStore,
-		0
-    };
-    return AUTORELEASEOBJ([[NSOpenGLPixelFormat alloc] initWithAttributes:attrs]);
-}
 
 - (id)initWithFrame:(NSRect)frameRect {
     self = [super initWithFrame:frameRect];
@@ -88,8 +72,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 }
 
 - (void)awakeFromNib {
-	//self = [self initWithFrame: self.frame pixelFormat: [[self class] defaultPixelFormat] ];
-//    self = [self initWithFrame: self.frame];
     [self initialize];
 }
 
@@ -127,6 +109,21 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 - (BOOL)isOpaque {
 	return YES;
 }
+
+- (NSRect) sqScreenSize {
+  return [self convertRectToBacking: [self bounds]];
+}
+
+
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent {
+	/* Our client expects the mouse coordinates in Squeak's coordinates,
+	 * but theEvent's location is in "user" coords. so we have to convert. */
+	NSPoint local_pt = [self convertPoint: [theEvent locationInWindow] fromView:nil];
+	NSPoint converted = [self convertPointToBacking: local_pt];
+	// Squeak is upside down
+	return NSMakePoint(converted.x, -converted.y);
+}
+
 
 - (void)viewDidMoveToWindow {
 	if (self.squeakTrackingRectForCursor)
@@ -194,7 +191,16 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 - (void) performDraw: (CGRect)rect {
 	sqInt form = interpreterProxy->displayObject(); // Form
 
-    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+    CGContextRef context;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1010 && defined(NSFoundationVersionNumber10_10)
+    if (floor(NSFoundationVersionNumber) >= NSFoundationVersionNumber10_10) {
+        context = [[NSGraphicsContext currentContext] CGContext];
+    } else { // Deprecated in OSX 10.10
+        context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+    }
+#else
+    context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+#endif
     CGContextSaveGState(context);
     
     int width = interpreterProxy->positive32BitValueOf(interpreterProxy->fetchPointerofObject(1, form));
@@ -203,43 +209,65 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	void* bits = (void*)interpreterProxy->firstIndexableField(formBits); // bits
     int bitSize = interpreterProxy->byteSizeOf(formBits);
     int bytePerRow = 4*width;
-    
-    CGRect r = NSRectToCGRect([self frame]);
-    int y2 = max(r.size.height - (rect.origin.y), 0);
-    int y1 = max(y2 - rect.size.height, 0);
-    
-    CGRect swapRect = CGRectIntersection(CGRectMake(0, 0, width, height), CGRectMake(rect.origin.x, y1, rect.size.width, y2));
-    [self swapColors: bits imageWidth:width clipRect: swapRect];
-    
-    CGDataProviderRef pref = CGDataProviderCreateWithData (NULL, bits, bitSize, NULL);
-    CGContextTranslateCTM(context, 0, height);
-    CGContextScaleCTM(context, 1, -1);
-    CGImageRef image = CGImageCreate(width, 
-                                     height, 
-                                     8, 
-                                     32, 
-                                     bytePerRow, 
-                                     colorspace, 
-                                     kCGBitmapByteOrder32Big | kCGImageAlphaLast, 
-                                     pref, 
-                                     NULL, 
-                                     NO, 
-                                     kCGRenderingIntentDefault);
-    
-    CGContextClipToRect(context,rect);
-    CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
 
-    [self swapColors:bits imageWidth:width clipRect: swapRect];
-    
-    CGImageRelease(image);
-    CGDataProviderRelease(pref);
-    
+
+	CGAffineTransform  deviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+
+	CGFloat frameHeight = [self frame].size.height * deviceTransform.d;
+    CGFloat y2 = MAX(frameHeight - rect.origin.y, 0);
+    CGFloat y1 = MAX(y2 - rect.size.height, 0);
+
+	CGRect swapRect = CGRectIntersection(CGRectMake(0, 0, width, height), CGRectMake(rect.origin.x, y1, rect.size.width, y2));
+	if (!CGRectIsNull(swapRect)) {
+		[self swapColors: bits imageWidth:width clipRect: swapRect];
+
+		CGDataProviderRef pref = CGDataProviderCreateWithData (NULL, bits, bitSize, NULL);
+		CGImageRef image = CGImageCreate(width,
+										 height,
+										 8,
+										 32,
+										 bytePerRow,
+										 colorspace,
+										 kCGBitmapByteOrder32Big | kCGImageAlphaLast,
+										 pref,
+										 NULL,
+										 NO,
+										 kCGRenderingIntentDefault);
+
+		CGRect userClipRect = CGRectMake(rect.origin.x / deviceTransform.a,
+										 rect.origin.y / deviceTransform.d,
+										 rect.size.width / deviceTransform.a,
+										 rect.size.height / deviceTransform.d);
+
+
+		CGContextTranslateCTM(context, 0, height / deviceTransform.d);
+		CGContextScaleCTM(context, 1 , -1);
+
+
+		CGContextClipToRect(context, userClipRect);
+
+		CGRect imageBounds = CGContextConvertRectToUserSpace(context, CGRectMake(deviceTransform.tx, deviceTransform.ty, width, height));
+
+		CGContextDrawImage(context, imageBounds, image);
+
+		[self swapColors:bits imageWidth:width clipRect: swapRect];
+
+	    CGImageRelease(image);
+		CGDataProviderRelease(pref);
+	}
     CGContextRestoreGState(context);
 }
 
 -(void)drawRect:(NSRect)rect
 {
-    [self performDraw:(clippyIsEmpty? NSRectToCGRect(rect):clippy)];
+	CGRect rectToDraw;
+	if (clippyIsEmpty) {
+		NSSize backingSize = [self convertRectToBacking:rect].size;
+		rectToDraw = CGRectMake(0, 0, backingSize.width, backingSize.height);
+	} else {
+		rectToDraw = clippy;
+	}
+	[self performDraw: rectToDraw];
     clippyIsEmpty = YES;
     syncNeeded = NO;
 }
@@ -634,6 +662,8 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	if ([self isInFullScreenMode] == NO && (fullScreen == 1)) {
 		self.savedScreenBoundsAtTimeOfFullScreen = (NSRect) [self bounds];
 		NSDictionary* options = [NSDictionary dictionaryWithObjectsAndKeys:
+			[NSNumber numberWithBool:NO],
+			NSFullScreenModeAllScreens,
 			[NSNumber numberWithInt:
 				NSApplicationPresentationHideDock |
 				NSApplicationPresentationHideMenuBar ],

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
@@ -84,6 +84,8 @@
 -(void)setupOpenGL;
 - (void) drawThelayers;
 - (void) preDrawThelayers;
+- (NSRect) sqScreenSize;
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
 @end
 
 #import	"SqViewClut.h"

--- a/platforms/iOS/vm/OSX/sqSqueakOSXView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXView.h
@@ -47,4 +47,7 @@
 -(void)drawThelayers;
 -(void)drawImageUsingClip:(CGRect)clip;
 
+- (NSRect) sqScreenSize;
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
+
 @end

--- a/platforms/iOS/vm/iPhone/Classes/SqueakUIView.h
+++ b/platforms/iOS/vm/iPhone/Classes/SqueakUIView.h
@@ -53,6 +53,8 @@ Some of this code was funded via a grant from the European Smalltalk User Group 
     - (void) preDrawThelayers;
 	- (void) drawThelayers;
 	- (void) drawImageUsingClip: (CGRect) clip;
+	- (CGRect) sqScreenSize;
+	- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
 	@property (nonatomic,assign) void *squeakTheDisplayBits;
     @property (nonatomic,strong) NSArray *arrowsNames;  // jdr
 @end

--- a/platforms/iOS/vm/iPhone/Classes/SqueakUIView.m
+++ b/platforms/iOS/vm/iPhone/Classes/SqueakUIView.m
@@ -74,6 +74,14 @@ SInt32 undoCounter=1, oldValue=0;  // jdr undo support
 - (void) drawImageUsingClip: (CGRect) clip {
 }
 
+- (CGRect) sqScreenSize {
+	return [self bounds];
+}
+
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent {
+	return [self convertPoint: [theEvent locationInWindow] fromView:nil];
+}
+
 // Handles the start of a touch
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {


### PR DESCRIPTION
- Works for both OpenGL and CoreGraphics backends (Why do we have
   both?)
 - Needs new abstractions for 'squeak-screen-size' and
   'squeak-mouse-position' in both backends/view. Is provided.