### PR TITLE
Respect NO_NETWORK setting when building window menu on Windows

### DIFF
--- a/platforms/win32/vm/sqWin32Exports.c
+++ b/platforms/win32/vm/sqWin32Exports.c
@@ -7,7 +7,9 @@ int win32JoystickDebugInfo(void);
 int win32JoystickDebugPrintRawValues(void);
 int win32JoystickDebugPrintAlternativeValues(void);
 #endif
+#ifndef NO_NETWORK
 int win32DebugPrintSocketState(void);
+#endif
 int primitivePluginBrowserReady(void);
 int primitivePluginRequestURLStream(void);
 int primitivePluginRequestURL(void);
@@ -33,7 +35,9 @@ void *os_exports[][3] = {
 	XFN(win32JoystickDebugPrintRawValues)
 	XFN(win32JoystickDebugPrintAlternativeValues)
 #endif
+#ifndef NO_NETWORK
 	XFN(win32DebugPrintSocketState)
+#endif
 	XFND(primitivePluginBrowserReady,"\377")
 	XFND(primitivePluginRequestURLStream,"\001")
 	XFND(primitivePluginRequestURL,"\001")

--- a/platforms/win32/vm/sqWin32Prefs.c
+++ b/platforms/win32/vm/sqWin32Prefs.c
@@ -100,11 +100,12 @@ void SetAllowImageWrite() {
   CheckMenuItem(vmPrefsMenu, ID_IMAGEWRITE, MF_BYCOMMAND | 
 		(ioCanWriteImage() ? MF_CHECKED : MF_UNCHECKED));
 }
-
+#ifndef NO_NETWORK
 void SetAllowSocketAccess() {
   CheckMenuItem(vmPrefsMenu, ID_SOCKETACCESS, MF_BYCOMMAND | 
 		(ioHasSocketAccess() ? MF_CHECKED : MF_UNCHECKED));
 }
+#endif
 
 void SetShowAllocations() {
   CheckMenuItem(vmPrefsMenu, ID_SHOWALLOCATIONS, MF_BYCOMMAND | 
@@ -282,7 +283,9 @@ void SetAllPreferences() {
   SetUseDirectSound();
   SetAllowFileAccess();
   SetAllowImageWrite();
+#ifndef NO_NETWORK
   SetAllowSocketAccess();
+#endif
   SetShowAllocations();
   SetPriorityBoost();
   SetB3DXUsesOpenGL();
@@ -315,8 +318,11 @@ extern sqInt recordPrimTraceFunc();
     AppendMenu(hMenu, MF_STRING | MF_UNCHECKED, ID_FILEACCESS, 
 	       TEXT("Allow file access"));
     AppendMenu(hMenu, MF_STRING | MF_UNCHECKED, ID_IMAGEWRITE, 
-	       TEXT("Allow image writes"));    AppendMenu(hMenu, MF_STRING | MF_UNCHECKED, ID_SOCKETACCESS, 
+	       TEXT("Allow image writes"));    
+#ifndef NO_NETWORK
+	AppendMenu(hMenu, MF_STRING | MF_UNCHECKED, ID_SOCKETACCESS, 
 	       TEXT("Allow socket access"));
+#endif
     AppendMenu(pMenu, MF_STRING | MF_POPUP, (sqIntptr_t)hMenu,
 	       TEXT("Security Settings"));
   }
@@ -443,19 +449,19 @@ void HandlePrefsMenu(int cmd) {
     _ioSetImageWrite(!ioCanWriteImage());
     SetAllowImageWrite();
     break;
-  case ID_SOCKETACCESS:
-    _ioSetSocketAccess(!ioHasSocketAccess());
-    SetAllowSocketAccess();
-    break;
   case ID_SHOWALLOCATIONS:
     fShowAllocations = !fShowAllocations;
     SetShowAllocations();
     break;
-  case ID_DBGPRINTSOCKET:
 #ifndef NO_NETWORK
-    win32DebugPrintSocketState();
-#endif
+  case ID_SOCKETACCESS:
+    _ioSetSocketAccess(!ioHasSocketAccess());
+    SetAllowSocketAccess();
     break;
+  case ID_DBGPRINTSOCKET:
+    win32DebugPrintSocketState();
+   break;
+#endif
   case ID_DBGPRINTSTACK:
     printCallStack();
     break;


### PR DESCRIPTION
This enables building a VM without SocketPlugin in int or extplugins when NO_NETWORK is set.