### PR TITLE
Revise the win32 makefiles for a modern cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ platforms/unix/config/autom4te.cache/
 !makeallclean
 !makealldirty
 !Makefile
+!Makefile.plugin
+!Makefile.rules
+!Makefile.tools
 !makeproduct
 !makeproductclean
 !mkNamedPrims.sh

--- a/.travis_build.sh
+++ b/.travis_build.sh
@@ -21,34 +21,12 @@ if [[ "${APPVEYOR}" ]]; then
 
     # Appveyor's GCC is pretty new, patch the Makefiles and replace the tools to
     # make it work
-    for i in gcc ar dlltool dllwrap strip objcopy nm windres; do
-	OLD=$(which $i)
-	NEW=$(which i686-w64-mingw32-$i)
-	if [[ -z $OLD ]]; then
-	    OLD=/usr/bin/$i
-	    echo "No $i, setting..."
-	fi
-	echo "Setting $OLD as $NEW"
-	rm $OLD
-	ln -s $NEW $OLD
-    done
 
     echo
-    echo "Using gcc $(gcc --version)"
+    echo "Using gcc $(i686-w64-mingw32-gcc --version)"
     echo
     test -d /usr/i686-w64-mingw32/sys-root/mingw/lib || echo "No lib dir"
     test -d /usr/i686-w64-mingw32/sys-root/mingw/include || echo "No inc dir"
-
-    for i in build.win32x86/common/Makefile build.win32x86/common/Makefile.plugin; do
-	sed -i 's#-L/usr/lib/mingw#-L/usr/i686-w64-mingw32/sys-root/mingw/lib#g' $i
-	sed -i 's#INCLUDEPATH:=.*#INCLUDEPATH:= -I/usr/i686-w64-mingw32/sys-root/mingw/include#g' $i
-	# sed -i 's/-fno-builtin-fprintf/-fno-builtin-fprintf -fno-builtin-bzero/g' $i
-	sed -i 's/-lcrtdll/-lmsvcrt -lws2_32/g' $i
-	sed -i 's/-mno-accumulate-outgoing-args/-maccumulate-outgoing-args -mstack-arg-probe/g' $i
-	sed -i 's/-mno-cygwin//g' $i
-	sed -i 's/#EXPORT:=--export-all-symbols/EXPORT:=--export-all-symbols/g' $i
-	sed -i 's/EXPORT:=--export-dynamic/#EXPORT:=--export-dynamic/g' $i
-    done
 
 else
     PLATFORM="$(uname -s)"

--- a/build.win32x86/HowToBuild
+++ b/build.win32x86/HowToBuild
@@ -68,16 +68,15 @@ Check-out the repository from github:
 Building out of the box
 -----------------------
 1. Install the tools:
-- Install cygwin from www.cygwin.com.  As of writing the VM is built using
-CYGWIN_NT-5.1 mcstalkerxp 1.5.24(0.156/4/2) 2007-01-31 10:57 i686 Cygwin
+- Install cygwin from www.cygwin.com.
 Make sure you install the MinGW support, which is in the list of packages called
-"mingw-binutils: Binutils for MinGW.org Win32 toolchain".
-If on compiling you see the error
-	--export-dynamic is not supported for PE targets, did you mean --export-all-symbols?
-then replace --export-dynamic with --export-all-symbols in the makefiles.
+"mingw64-i686-gcc-core,mingw64-i686-gcc-g++,mingw64-i686-headers,mingw64-i686-runtime".
+Note that the .appveyor.yml file may be used as example to automate installation of these tools
+
+Alternatively, an installation of mingw32 and msys may work, but has not been tested.
 
 Then cd to the build directory of your choice, e.g.
-	build.win32x86/squeak.cog.spur/build
+	build.win32x86/squeak.cog.spur/
 Then execute
 	./mvm
 This builds debug, assert and production versions of the VM in builddbg/vm,
@@ -86,6 +85,12 @@ it will also create VMs in buildmtdbg/vm, buildmtast/vm and buildmt/vm.  The
 system builds two VMs in each build/vm directory, e.g. Squeak.exe and
 SqueakConsole.exe.  The latter is to be used with console applications that wish
 to access standard i/o.
+
+For building with clang instead of gcc, it is possible to pass options to make via mvm after --:
+	./mvm -f -- CC=i686-w64-mingw32-clang
+	
+If building from mingw32, it may be necessary to omit the tool prefix:
+	./mvm -f -- TOOLPREFIX=''
 
 Each build directory contains two files
 	plugins.int
@@ -140,10 +145,11 @@ for the VM.  First build the VM then cd to the installer and make, e.g.:
 
 Optimization level and gcc version
 ----------------------------------
-There are issues with gcc version > 4.2.1.  Any of the following flags may break the build at -O2:
+There used to be issues with gcc version > 4.2.1.  Any of the following flags may break the build at -O2:
 -ftree-pre
 -fpartial-inlining
 -fcaller-saves
+However, with removal of some Undefined Behavior in source code, this list might well be out of date.
 
 See http://smallissimo.blogspot.fr/2013/02/compiling-squeak-cog-virtual-machine-on.html
 

--- a/build.win32x86/common/Makefile
+++ b/build.win32x86/common/Makefile
@@ -1,5 +1,5 @@
 #############################################################################
-# COmmon Makefile for Win32 VM using gcc-3.4.x, cygwin and gnu make
+# COmmon Makefile for Win32 VM using gcc, cygwin and gnu make
 # Do make init to allow make -n to function.
 #############################################################################
 
@@ -109,85 +109,11 @@ ETOBJ:= $(OBJDIR)/etext.o
 DXDIR:=     $(PLATDIR)/win32/third-party/dx9sdk/Include
 
 #############################################################################
-# C compiler settings (gcc-3.4.4 cygwin 19.24)
+# Toolchain
 #
-CC:=gcc
-
-# VM config flags.
-ifeq ($(CONFIGURATION),product)
-OFLAGS:= -D_MT -O2 -march=pentium4 -momit-leaf-frame-pointer -funroll-loops
-NDEBUG:=-DNDEBUG -D'VM_LABEL(foo)=0' # Define NDEBUG for production to exclude asserts
-DEBUGVM=0
-else ifeq ($(CONFIGURATION),assert)
-OFLAGS:= -D_MT -O1 -march=pentium4 -fno-omit-frame-pointer
-DEBUGVM=0
-NDEBUG:=-DAllocationCheckFiller=0xADD4E55 -D'VM_LABEL(foo)=0'
-else
-OFLAGS:= -D_MT -march=pentium4
-DEBUGVM=1
-NDEBUG:=-DAllocationCheckFiller=0xADD4E55 -D'VM_LABEL(foo)=0'
-endif
-
-ifeq ($(THREADING),multi)
-COGDEFS:=-DCOGMTVM=1 -DDEBUGVM=$(DEBUGVM)
-else
-COGDEFS:=-DCOGMTVM=0 -DDEBUGVM=$(DEBUGVM)
-endif
-
-# Set minimum version to WindowsXP (see /cygwin/usr/include//w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0501 -DWINVER=0x0501
-
-INCLUDEPATH:= -isystem/usr/include/mingw -I/usr/include/w32api
-# define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
-NOBUILTIN:= -D_MT -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
-CFLAGS:= $(INCLUDEPATH) -msse2 -ggdb2 -mwindows -mthreads -mno-cygwin -mwin32 \
-	-mno-rtd -mms-bitfields -mno-accumulate-outgoing-args $(OFLAGS) $(NOBUILTIN)
-TZ:=$(shell date +%Z)
-DEFS:=	$(COGDEFS) $(WINVER) -DWIN32 -DWIN32_FILE_SUPPORT -DNO_ISNAN \
-		-DNO_SERVICE -DNO_STD_FILE_SUPPORT -D'TZ="$(TZ)"' \
-		$(NDEBUG) -DLSB_FIRST -D'VM_NAME="$(VM_NAME)"' -DX86 $(XDEFS) $(CROQUET)
-XDEFS:=	-DSQUEAK_BUILTIN_PLUGIN
+include ../common/Makefile.tools
+ 
 INCLUDES:= -I. -I$(VMSRCDIR) -I$(WIN32DIR) -I$(CROSSDIR) -I$(DXDIR) $(XINC)
-
-#############################################################################
-# Linker settings
-#
-# Note: I had to use 'gcc' instead of 'ld' to prevent unresolved symbols
-#       The switch '-mwindows' gives us a GUI app instead of a console app.
-#		Newer cygwins want --export-all-symbols in place of --export-dynamic.
-#
-LD:=	 $(CC)
-EXPORT:=--export-dynamic
-#EXPORT:=--export-all-symbols
-BASELDFLAGS:=-mno-cygwin -mthreads -Wl,--large-address-aware,$(EXPORT) -L/usr/lib/mingw
-LDFLAGS:= -mwindows $(BASELDFLAGS)
-CONSOLELDFLAGS:= -mconsole $(BASELDFLAGS)
-STDLIBS:= -lddraw -ldinput -lopengl32 -lwsock32 -lcomdlg32 -lole32 -lwinmm \
-	-lversion -lwininet -luser32 -lgdi32 -lpsapi -lkernel32 -lcrtdll \
-	-ldsound -lsecur32
-
-#############################################################################
-# Tools to use
-#
-AR:= ar rc
-CP:= cp
-RM:= rm
-DLLTOOL:=	dlltool
-DLLWRAP:=	dllwrap
-STRIP:=	strip
-OBJCOPY:=	objcopy
-
-#############################################################################
-# RC settings
-#
-# Note: RC compiles the .rc files into linkable .o files
-#
-RC:=	 windres
-SVNMAJOR := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: \([0-9][0-9][0-9][0-9]\).*/\\1/p" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
-SVNMINOR := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: [0-9][0-9][0-9][0-9]\([0-9][0-9]\).*/\\1/p" -e "s/^0*//" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
-SVNREV := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: [0-9][0-9][0-9][0-9][0-9][0-9]\([0-9][0-9]\).*/\\1/p" -e "s/^0*//" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
-SVNBUILD := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]\([0-9][0-9]*\).*/\\1/p" -e "s/^0*//" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
-RCFLAGS:= --include-dir $(PLATDIR)/win32/misc -D_WIN32 -DFILEVERSIONVALUES=$(SVNMAJOR),$(SVNMINOR),$(SVNREV),$(SVNBUILD) '-DFILEVERSIONSTRING=\"$(SVNMAJOR).$(SVNMINOR).$(SVNREV).$(SVNBUILD)\\0\"'
 
 .SUFFIXES:
 .SUFFIXES:	.ccg .cc .c .o .s .i .rc .res .cg .hg .ccg .cpp
@@ -266,10 +192,10 @@ print-objects:
 	@echo -----------------------------------------------------
 
 mingw32ver.exe: $(WIN32UTILDIR)/mingw32ver.c
-	$(CC) -o $@ -O1 -mconsole -mno-cygwin $<
+	$(CC) -o $@ -O1 -mconsole -m32 $<
 
 mkNamedPrims.exe: $(WIN32UTILDIR)/mkNamedPrims.c
-	$(CC) -o $@ -mconsole -mno-cygwin $<
+	$(CC) -o $@ -mconsole -m32 $<
 
 $(BTOBJ):	$(WIN32MISCDIR)/btext.c
 	$(CC) -c -o $@ -fomit-frame-pointer -O2 $<
@@ -283,13 +209,13 @@ $(VMEXE): $(OBJDIR) $(VMOBJ) $(LIBS) $(VMEXP) resource.o $(BTOBJ) $(ETOBJ)
 	$(CC) -o $(OBJDIR)/version.o $(CFLAGS) $(INCLUDES) $(DEFS) -c $(WIN32DIR)/version.c
 	$(LD) $(LDFLAGS) -o $(VMEXE) \
 			$(BTOBJ) $(VMOBJ) $(VMEXP) $(OBJDIR)/resource.o $(LIBS) $(STDLIBS) $(ETOBJ)
-	nm --numeric-sort --defined-only -f bsd $(VMEXE) >$(VMMAP)
+	$(NM) --numeric-sort --defined-only -f bsd $(VMEXE) >$(VMMAP)
 
 $(CONSOLEVMEXE): $(VMOBJ) $(LIBS) $(VMEXP) resource.o $(BTOBJ) $(ETOBJ)
 	$(CC) -o $(OBJDIR)/version.o $(CFLAGS) $(INCLUDES) $(DEFS) -c $(WIN32DIR)/version.c
 	$(LD) $(CONSOLELDFLAGS) -o $(CONSOLEVMEXE) \
 			$(BTOBJ) $(VMOBJ) $(VMEXP) $(OBJDIR)/resource.o $(LIBS) $(STDLIBS) $(ETOBJ)
-	nm --numeric-sort --defined-only -f bsd $(CONSOLEVMEXE) >$(CONSOLEVMMAP)
+	$(NM) --numeric-sort --defined-only -f bsd $(CONSOLEVMEXE) >$(CONSOLEVMMAP)
 
 ifneq ($STRIPEXE,)
 $(STRIPEXE): $(VMEXE)

--- a/build.win32x86/common/Makefile.plugin
+++ b/build.win32x86/common/Makefile.plugin
@@ -1,9 +1,6 @@
 #############################################################################
 # Generic Makefile for plugins
 #############################################################################
-AR:= ar rc
-CP:= cp
-RM:= rm
 
 # The following are the four key locations (set via invocation):
 # PLUGINSRCDIR: Where is the root of the src plugins source tree?
@@ -43,34 +40,34 @@ MAKERSRC:= $(wildcard $(MAKERDIR)/*.c)
 LIBSRC:= $(notdir $(MAKERSRC) $(WIN32SRC) $(CROSSSRC))
 
 #############################################################################
-# C compiler settings (gcc-3.4.4 cygwin 19.24)
+# C compiler settings (gcc 4.x)
 #
-NDEBUG:=-DNDEBUG
-# Set minimum version to WindowsXP (see /cygwin/usr/include//w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0501 -DWINVER=0x0501
-INCLUDEPATH:= -isystem/usr/include/mingw -I/usr/include/w32api
-CFLAGS:= $(INCLUDEPATH) -msse2 -ggdb2 -mwindows -mdll -mno-cygwin -mwin32 \
-	-mno-rtd -mms-bitfields -mno-accumulate-outgoing-args $(OFLAGS)
-DEFS:=	$(WINVER) -DWIN32 -DWIN32_FILE_SUPPORT -DNO_ISNAN \
-		-DNO_SERVICE -DNO_STD_FILE_SUPPORT \
-		$(NDEBUG) -DLSB_FIRST -DVM_NAME=\"$(VM)\" -DX86 $(XDEFS)
-# define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
+include ../common/Makefile.tools
+
+# overrides of default toolchain settings
+
 ifeq ($(CONFIGURATION),product)
-OFLAGS:= -D_MT -O1 -march=pentium4 -momit-leaf-frame-pointer -funroll-loops \
-		-fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
+OFLAGS:= -O1 -march=pentium4 -momit-leaf-frame-pointer -funroll-loops 
 NDEBUG:=-DNDEBUG
 DEBUGVM=0
 else ifeq ($(CONFIGURATION),assert)
-OFLAGS:= -D_MT -O1 -march=pentium4 -fno-omit-frame-pointer \
-		-fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
+OFLAGS:= -O1 -march=pentium4 -fno-omit-frame-pointer
 DEBUGVM=0
 NDEBUG:=
 else
-OFLAGS:= -D_MT -march=pentium4 \
-		-fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
+OFLAGS:= -march=pentium4 
 DEBUGVM=1
 NDEBUG:=
 endif
+
+XDEFS:=	
+DEFS:=	$(WINVER) -DWIN32 -DWIN32_FILE_SUPPORT -DNO_ISNAN \
+		-DNO_SERVICE -DNO_STD_FILE_SUPPORT \
+		$(NDEBUG) -DLSB_FIRST -DVM_NAME=\"$(VM)\" -DX86 $(XDEFS)
+
+	
+CFLAGS:= -msse2 -ggdb2 -m32 -mdll \
+	-mno-rtd -mms-bitfields $(OFLAGS) $(NOBUILTIN) $(WARNINGS)
 
 
 #############################################################################
@@ -79,10 +76,8 @@ endif
 # Note: By default DLLTOOL/DLLWRAP do the work for everything related to plugins
 # but if LINK_WITH_GCC we use gcc and if LINK_WITH_GPP we use g++.
 #
-DLLTOOL:=	dlltool
-DLLWRAP:=	dllwrap -mno-cygwin
-#OPTSTRIP:=	strip # for production
 OPTSTRIP:=	echo not doing strip
+
 
 .SUFFIXES:	.c .cpp .o .s .rc .res .dep
 
@@ -141,16 +136,16 @@ $(PLUGINDLL): $(VMDIR) $(OBJDIR) $(LIBOBJ)
 		$(DLLTOOLEXTRAS) \
 		$(LIBOBJ)
 ifneq ($(LINK_WITH_GCC),)
-	gcc -shared \
-		-mno-cygwin \
+	$(CC) -shared \
+		-m32 \
 		-def $(OBJDIR)/$(LIBNAME).def \
 		-o   $(VMDIR)/$(LIBNAME).dll \
 		--entry _DllMain@12 \
 		$(GCCLINKEXTRAS) \
 		$(LIBOBJ) $(EXTRALIBS)
 else ifneq ($(LINK_WITH_GPP),)
-	g++ -shared \
-		-mno-cygwin \
+	$(CXX) -shared \
+		-m32 \
 		-def $(OBJDIR)/$(LIBNAME).def \
 		-o   $(VMDIR)/$(LIBNAME).dll \
 		--entry _DllMain@12 \

--- a/build.win32x86/common/Makefile.rules
+++ b/build.win32x86/common/Makefile.rules
@@ -1,33 +1,23 @@
 #############################################################################
-# Compilation rules for Mac OS X
+# Compilation rules for Microsoft Windows
 #
 # See http://make.mad-scientist.net/papers/advanced-auto-dependency-generation
 # for an explanation of the dependency management scheme.
-
-# gcc 3.4.x
-# Note: I had to use 'gcc' instead of 'ld' to prevent unresolved symbols
-#       The switch '-mwindows' gives us a GUI app instead of a console app.
-#		Newer cygwins want --export-all-symbols in place of --export-dynamic.
-#
-CC := gcc
-CXX:= g++
-LD := $(CC)
-LDCXX := clang++ # For linking c++ bundles
 
 DEPFLAGS = -MT $@ -MMD -MP -MF deps/$(*F).Td
 ALLFLAGS = $(DEPFLAGS) $(CFLAGS) $(INCLUDES) $(DEFS)
 POSTCOMPILE = sed '/^$$/d' <deps/$(*F).Td | sed '/^.*:$$/d' | sed 's/ [^ ]*:/:/' | sed 's/^build[^/]*/$$(BUILD)/' > deps/$(*F).d; rm deps/$(*F).Td; touch -r $< deps/$(*F).d
 
 $(OBJDIR)/%.o: %.c deps/%.d
-	$(CC) -x c $(ALLFLAGS) $(INCLUDES) -c $< -o $@
+	$(CC) -x c $(ALLFLAGS) -c $< -o $@
 	$(POSTCOMPILE)
 
 $(OBJDIR)/%.o: %.m deps/%.d
-	$(CC) -x objective-c $(ALLFLAGS) $(INCLUDES) -c $< -o $@
+	$(CC) -x objective-c $(ALLFLAGS) -c $< -o $@
 	$(POSTCOMPILE)
 
 $(OBJDIR)/%.o: %.cpp deps/%.d
-	$(CXX) $(ALLFLAGS) $(INCLUDES) -c $< -o $@
+	$(CXX) $(ALLFLAGS) -c $< -o $@
 	$(POSTCOMPILE)
 
 %res: %.rc
@@ -43,4 +33,3 @@ deps/%.d: ;
 #.cpp.o:
 #		$(CXX) -c $(CXXFLAGS) $(CXXINCLUDES) $<
 #
-#CXX:=g++

--- a/build.win32x86/common/Makefile.tools
+++ b/build.win32x86/common/Makefile.tools
@@ -1,0 +1,90 @@
+#############################################################################
+# Compilation rules for Cygwin/mingw compiler on Microsoft Windows
+#
+
+TOOLPREFIX:=i686-w64-mingw32-
+
+#############################################################################
+# C compiler settings (gcc 4.x)
+#
+CC:= $(TOOLPREFIX)gcc
+CXX:= $(TOOLPREFIX)g++
+
+WARNINGS:= -Wall -Wno-unused-variable -Wno-unknown-pragmas -Wno-unused-value -Wno-unused-function -Wno-unused-but-set-variable
+
+# VM config flags.
+ifeq ($(CONFIGURATION),product)
+OFLAGS:= -O2 -march=pentium4 -momit-leaf-frame-pointer -funroll-loops
+NDEBUG:= -DNDEBUG -D'VM_LABEL(foo)=0' # Define NDEBUG for production to exclude asserts
+DEBUGVM=0
+else ifeq ($(CONFIGURATION),assert)
+OFLAGS:= -O1 -march=pentium4 -fno-omit-frame-pointer
+DEBUGVM=0
+NDEBUG:= -DAllocationCheckFiller=0xADD4E55 -D'VM_LABEL(foo)=0'
+else
+OFLAGS:= -march=pentium4
+DEBUGVM=1
+NDEBUG:= -DAllocationCheckFiller=0xADD4E55 -D'VM_LABEL(foo)=0'
+endif
+
+ifeq ($(THREADING),multi)
+COGDEFS:= -DCOGMTVM=1 -DDEBUGVM=$(DEBUGVM)
+else
+COGDEFS:= -DCOGMTVM=0 -DDEBUGVM=$(DEBUGVM)
+endif
+
+# Set minimum version to WindowsXP (see /cygwin/usr/include//w32api/w32api.h)
+WINVER:=-D_WIN32_WINNT=0x0501 -DWINVER=0x0501
+
+# define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
+NOBUILTIN:= -D_MT -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
+CFLAGS:= -msse2 -ggdb2 -m32 \
+	-mno-rtd -mms-bitfields $(OFLAGS) $(NOBUILTIN) $(WARNINGS)
+
+TZ:=$(shell date +%Z)
+XDEFS:=	-DSQUEAK_BUILTIN_PLUGIN
+DEFS:=	$(COGDEFS) $(WINVER) -DWIN32 -DWIN32_FILE_SUPPORT -DNO_ISNAN \
+		-DNO_SERVICE -DNO_STD_FILE_SUPPORT -D'TZ="$(TZ)"' \
+		$(NDEBUG) -DLSB_FIRST -D'VM_NAME="$(VM_NAME)"' $(XDEFS) $(CROQUET)
+
+#############################################################################
+# Linker settings
+#
+# Note: I had to use 'gcc' instead of 'ld' to prevent unresolved symbols
+#       The switch '-mwindows' gives us a GUI app instead of a console app.
+#		Newer cygwins want --export-all-symbols in place of --export-dynamic.
+#
+LD:=	 $(CC)
+LDCXX := $(TOOLPREFIX)clang++ # For linking c++ bundles
+
+EXPORT:=--export-all-symbols
+BASELDFLAGS:=-m32 -mthreads -Wl,--large-address-aware,$(EXPORT)
+LDFLAGS:= -mwindows $(BASELDFLAGS)
+CONSOLELDFLAGS:= -mconsole $(BASELDFLAGS)
+STDLIBS:= -lddraw -ldinput -lopengl32 -lws2_32 -lcomdlg32 -lole32 -lwinmm \
+	-lversion -lwininet -luser32 -lgdi32 -lpsapi -lkernel32 \
+	-ldsound -lsecur32
+
+#############################################################################
+# Tools to use
+#
+AR:= $(TOOLPREFIX)ar rc
+CP:= cp
+RM:= rm
+NM:= $(TOOLPREFIX)nm
+DLLTOOL:=	$(TOOLPREFIX)dlltool
+DLLWRAP:=	$(TOOLPREFIX)dllwrap
+STRIP:= 	$(TOOLPREFIX)strip
+OBJCOPY:=	$(TOOLPREFIX)objcopy
+
+#############################################################################
+# RC settings
+#
+# Note: RC compiles the .rc files into linkable .o files
+#
+RC:=	 $(TOOLPREFIX)windres
+SVNMAJOR := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: \([0-9][0-9][0-9][0-9]\).*/\\1/p" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
+SVNMINOR := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: [0-9][0-9][0-9][0-9]\([0-9][0-9]\).*/\\1/p" -e "s/^0*//" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
+SVNREV := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: [0-9][0-9][0-9][0-9][0-9][0-9]\([0-9][0-9]\).*/\\1/p" -e "s/^0*//" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
+SVNBUILD := $(shell sed -e "s/^static.*GitRawRevisionString.*Rev: [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]\([0-9][0-9]*\).*/\\1/p" -e "s/^0*//" -e d $(PLATDIR)/Cross/vm/sqSCCSVersion.h | sed -e 's/^0*//')
+RCFLAGS:= --include-dir $(PLATDIR)/win32/misc -D_WIN32 -DFILEVERSIONVALUES=$(SVNMAJOR),$(SVNMINOR),$(SVNREV),$(SVNBUILD) '-DFILEVERSIONSTRING=\"$(SVNMAJOR).$(SVNMINOR).$(SVNREV).$(SVNBUILD)\\0\"'

--- a/platforms/win32/plugins/BochsIA32Plugin/Makefile
+++ b/platforms/win32/plugins/BochsIA32Plugin/Makefile
@@ -15,10 +15,9 @@ CXXINCLUDES:= -I$(PLATDIR)/../processors/IA32/winbochs \
 			  -I$(PLATDIR)/../processors/IA32/bochs \
 			  -I$(PLATDIR)/../processors/IA32/bochs/instrument/stubs
 
-CXXFLAGS:=	-m32 -mno-cygwin -DWIN32 -msse2 -ggdb2 -mwindows -mthreads -mwin32 \
-			-mno-rtd -mms-bitfields -mno-accumulate-outgoing-args
+CXXFLAGS:=	-m32 -DWIN32 -msse2 -ggdb2 \
+			-mno-rtd -mms-bitfields
 
 .cpp.o:
 		$(CXX) -c $(CXXFLAGS) $(CXXINCLUDES) $<
 
-CXX:=g++

--- a/platforms/win32/plugins/BochsIA32Plugin/Makefile.plugin
+++ b/platforms/win32/plugins/BochsIA32Plugin/Makefile.plugin
@@ -13,5 +13,5 @@ INCLUDES+=-I../bochsx86 \
          -I../../processors/IA32/bochs \
 		 -I../../processors/IA32/bochs/instrument/stubs
 
-CFLAGS:=	-m32 -mno-cygwin -DWIN32 -msse2 -ggdb2 -mwindows -mthreads -mwin32 \
-			-mno-rtd -mms-bitfields -mno-accumulate-outgoing-args
+CFLAGS:=	-m32 -DWIN32 -msse2 -ggdb2 \
+			-mno-rtd -mms-bitfields

--- a/platforms/win32/plugins/BochsX64Plugin/Makefile.plugin
+++ b/platforms/win32/plugins/BochsX64Plugin/Makefile.plugin
@@ -13,5 +13,5 @@ INCLUDES+=-I../bochsx64 \
          -I../../processors/IA32/bochs \
 		 -I../../processors/IA32/bochs/instrument/stubs
 
-CFLAGS:=	-m32 -mno-cygwin -DWIN32 -msse2 -ggdb2 -mwindows -mthreads -mwin32 \
-			-mno-rtd -mms-bitfields -mno-accumulate-outgoing-args
+CFLAGS:=	-m32 -DWIN32 -msse2 -ggdb2  \
+			-mno-rtd -mms-bitfields 


### PR DESCRIPTION
Hacks in .travis_build.sh have been incorporated in the makefiles and can now be removed.
The toolchain config has been separated in its own file (Makefile.tools).

Note that the Bochs plugins production has not been tested by the author
It's also not yet tested by appveyor (the .travis_build.sh remove them from plugins.ext)