### PR TITLE
Prefix the drag event types with SQ

### DIFF
--- a/platforms/Cross/vm/sq.h
+++ b/platforms/Cross/vm/sq.h
@@ -460,11 +460,11 @@ typedef struct sqDragDropFilesEvent
   sqIntptr_t windowIndex;			/* host window structure */
 } sqDragDropFilesEvent;
 
-#define DragEnter	1 /* drag operation from OS entered Squeak window	 */
-#define DragMove	2 /* drag operation from OS moved within Squeak window */
-#define DragLeave	3 /* drag operation from OS left Squeak window	 */
-#define DragDrop	4 /* drag operation dropped contents onto Squeak.      */
-#define DragRequest	5 /* data request from other app. */
+#define SQDragEnter	1 /* drag operation from OS entered Squeak window	 */
+#define SQDragMove	2 /* drag operation from OS moved within Squeak window */
+#define SQDragLeave	3 /* drag operation from OS left Squeak window	 */
+#define SQDragDrop	4 /* drag operation dropped contents onto Squeak.      */
+#define SQDragRequest	5 /* data request from other app. */
 
 /* menu event */
 typedef struct sqMenuEvent

--- a/platforms/Mac OS/plugins/DropPlugin/sqMacDragDrop.c
+++ b/platforms/Mac OS/plugins/DropPlugin/sqMacDragDrop.c
@@ -315,7 +315,7 @@ MyDragTrackingHandler(DragTrackingMessage message, WindowPtr theWindow, void *re
 						theEvent.where = mouse;
                     	fn = interpreterProxy->ioLoadFunctionFrom("recordDragDropEvent", "");
                     	if (fn != 0) {
-                    	    ((int (*) (EventRecord *theEvent, int numberOfItems, int dragType)) fn)(&theEvent, gNumDropFiles,DragEnter);
+                    	    ((int (*) (EventRecord *theEvent, int numberOfItems, int dragType)) fn)(&theEvent, gNumDropFiles,SQDragEnter);
                     	}
 					} 
 				}
@@ -332,7 +332,7 @@ MyDragTrackingHandler(DragTrackingMessage message, WindowPtr theWindow, void *re
 				theEvent.where = mouse;
              	fn = interpreterProxy->ioLoadFunctionFrom("recordDragDropEvent", "");
             	if (fn != 0) {
-            	    ((int (*) (EventRecord *theEvent,  int numberOfItems, int dragType)) fn)(&theEvent,gNumDropFiles,DragMove);
+            	    ((int (*) (EventRecord *theEvent,  int numberOfItems, int dragType)) fn)(&theEvent,gNumDropFiles,SQDragMove);
             	    
             	}
 			}
@@ -349,7 +349,7 @@ MyDragTrackingHandler(DragTrackingMessage message, WindowPtr theWindow, void *re
 				theEvent.where = mouse;
             	fn = interpreterProxy->ioLoadFunctionFrom("recordDragDropEvent", "");
             	if (fn != 0) {
-            	    ((int (*) (EventRecord *theEvent, int numberOfItems, int dragType)) fn)(&theEvent, gNumDropFiles,DragLeave);
+            	    ((int (*) (EventRecord *theEvent, int numberOfItems, int dragType)) fn)(&theEvent, gNumDropFiles,SQDragLeave);
             	    
             	}
 			}
@@ -523,7 +523,7 @@ MyDragReceiveHandler(WindowPtr theWindow, void *refcon, DragReference theDragRef
 
 	fn = interpreterProxy->ioLoadFunctionFrom("recordDragDropEvent", "");
 	if (fn != 0) {
-	    ((int (*) (EventRecord *theEvent, int numberOfItems, int dragType)) fn)(&theEvent, gNumDropFiles,DragDrop);
+	    ((int (*) (EventRecord *theEvent, int numberOfItems, int dragType)) fn)(&theEvent, gNumDropFiles,SQDragDrop);
 	}
 	return noErr;
 }

--- a/platforms/Mac OS/vm/sqMacUIAppleEvents.c
+++ b/platforms/Mac OS/vm/sqMacUIAppleEvents.c
@@ -219,7 +219,7 @@ void processDocumentsButExcludeOne(AEDesc	*fileList,long whichToExclude) {
     sqSetNumberOfDropFiles(actualFilteredNumber);
     actualFilteredIndexNumber=1;
     
-    recordDragDropEvent(&theEvent, actualFilteredNumber, DragEnter);
+    recordDragDropEvent(&theEvent, actualFilteredNumber, SQDragEnter);
     for(i=1;i<=numFiles;i++) {
 	    err = AEGetNthPtr(fileList, i, typeFSRef,  &keyword, &type, (Ptr) &theFSRef, sizeof(FSRef), &size);
 	    if (err) 
@@ -244,9 +244,9 @@ void processDocumentsButExcludeOne(AEDesc	*fileList,long whichToExclude) {
         actualFilteredIndexNumber++;
     }
 	theEvent.where = where;
-    recordDragDropEvent(&theEvent, actualFilteredNumber, DragDrop);
+    recordDragDropEvent(&theEvent, actualFilteredNumber, SQDragDrop);
 	theEvent.where = where;
-    recordDragDropEvent(&theEvent, actualFilteredNumber, DragLeave);
+    recordDragDropEvent(&theEvent, actualFilteredNumber, SQDragLeave);
    
    done: 
    return;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -561,7 +561,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	self.dragCount = (int) [self countNumberOfNoneSqueakImageFilesInDraggedFiles: info];
 	
 	if [(self.dragCount)
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragEnter numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex] view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragEnter numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex] view: self];
 	
 	return NSDragOperationGeneric;
 }
@@ -569,14 +569,14 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 - (NSDragOperation) draggingUpdated: (id<NSDraggingInfo>)info
 {
 	if (self.dragCount)
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragMove numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragMove numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
 	return NSDragOperationGeneric;
 }
 
 - (void) draggingExited: (id<NSDraggingInfo>)info
 {
 	if (self.dragCount)
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragLeave numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragLeave numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
 	self.dragCount = 0;
 	self.dragInProgress = NO;
 	self.dragItems = NULL;
@@ -585,7 +585,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 - (BOOL) performDragOperation: (id<NSDraggingInfo>)info {
 	if (self.dragCount) {
 		self.dragItems = [self filterOutSqueakImageFilesFromDraggedFiles: info];
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
 	} 
 	
 	NSArray *images = [self filterSqueakImageFilesFromDraggedFiles: info];

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
@@ -643,7 +643,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 	self.dragCount = (int) [self countNumberOfNoneSqueakImageFilesInDraggedFiles: info];
 	
 	if (self.dragCount)
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragEnter numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragEnter numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	
 	return NSDragOperationGeneric;
 }
@@ -652,7 +652,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 {
 //    NSLog(@"draggingUpdated %@",info);
 	if (self.dragCount)
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragMove numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragMove numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	return NSDragOperationGeneric;
 }
 
@@ -660,7 +660,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 {
 //    NSLog(@"draggingExited %@",info);
 	if (self.dragCount)
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragLeave numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragLeave numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	self.dragCount = 0;
 	self.dragInProgress = NO;
 	self.dragItems = NULL;
@@ -670,7 +670,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 //    NSLog(@"performDragOperation %@",info);
 	if (self.dragCount) {
 		self.dragItems = [self filterOutSqueakImageFilesFromDraggedFiles: info];
-		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: DragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
+		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	} 
 	
 	NSArray *images = [self filterSqueakImageFilesFromDraggedFiles: info];

--- a/platforms/unix/vm-display-Quartz/SqueakView.m
+++ b/platforms/unix/vm-display-Quartz/SqueakView.m
@@ -102,7 +102,7 @@ static int     inputCharCode;
       int count= [[[info draggingPasteboard]
 		    propertyListForType: NSFilenamesPboardType] count];
       noteMousePoint([info draggingLocation]);
-      noteDragEvent(DragEnter, dragCount= count);
+      noteDragEvent(SQDragEnter, dragCount= count);
       return NSDragOperationCopy;
     }
   return NSDragOperationNone;
@@ -111,14 +111,14 @@ static int     inputCharCode;
 - (int) draggingUpdated: (id<NSDraggingInfo>)info
 {
   noteMousePoint([info draggingLocation]);
-  noteDragEvent(DragMove, dragCount);
+  noteDragEvent(SQDragMove, dragCount);
   return NSDragOperationCopy;
 }
 
 - (void) draggingExited: (id<NSDraggingInfo>)info
 {
   noteMousePoint([info draggingLocation]);
-  noteDragEvent(DragLeave, dragCount);
+  noteDragEvent(SQDragLeave, dragCount);
   dragCount= 0;
 }
 
@@ -147,7 +147,7 @@ static int     inputCharCode;
       for (i= 0;  i < uxDropFileCount;  ++i)
 	uxDropFileNames[i]= strdup([[files objectAtIndex: i] cString]);
     }
-  noteDragEvent(DragDrop, uxDropFileCount);
+  noteDragEvent(SQDragDrop, uxDropFileCount);
   dragCount= 0;
 
   return YES;	// under some duress, I might add (see sqUxDragDrop.c)

--- a/platforms/unix/vm-display-Quartz/sqUnixQuartz.m
+++ b/platforms/unix/vm-display-Quartz/sqUnixQuartz.m
@@ -2128,7 +2128,7 @@ static int     inputCharCode;
       int count= [[[info draggingPasteboard]
 		    propertyListForType: NSFilenamesPboardType] count];
       noteMousePoint([info draggingLocation]);
-      noteDragEvent(DragEnter, dragCount= count);
+      noteDragEvent(SQDragEnter, dragCount= count);
       return NSDragOperationCopy;
     }
   return NSDragOperationNone;
@@ -2137,14 +2137,14 @@ static int     inputCharCode;
 - (int) draggingUpdated: (id<NSDraggingInfo>)info
 {
   noteMousePoint([info draggingLocation]);
-  noteDragEvent(DragMove, dragCount);
+  noteDragEvent(SQDragMove, dragCount);
   return NSDragOperationCopy;
 }
 
 - (void) draggingExited: (id<NSDraggingInfo>)info
 {
   noteMousePoint([info draggingLocation]);
-  noteDragEvent(DragLeave, dragCount);
+  noteDragEvent(SQDragLeave, dragCount);
   dragCount= 0;
 }
 
@@ -2173,7 +2173,7 @@ static int     inputCharCode;
       for (i= 0;  i < uxDropFileCount;  ++i)
 	uxDropFileNames[i]= strdup([[files objectAtIndex: i] cString]);
     }
-  noteDragEvent(DragDrop, uxDropFileCount);
+  noteDragEvent(SQDragDrop, uxDropFileCount);
   dragCount= 0;
 
   return YES;	// under some duress, I might add (see sqUxDragDrop.c)

--- a/platforms/unix/vm-display-Quartz/zzz/sqUnixQuartz.m
+++ b/platforms/unix/vm-display-Quartz/zzz/sqUnixQuartz.m
@@ -2043,7 +2043,7 @@ static char *documentName= 0;
       int count= [[[info draggingPasteboard]
 		    propertyListForType: NSFilenamesPboardType] count];
       noteMousePoint([info draggingLocation]);
-      noteDragEvent(DragEnter, dragCount= count);
+      noteDragEvent(SQDragEnter, dragCount= count);
       return NSDragOperationCopy;
     }
   return NSDragOperationNone;
@@ -2052,14 +2052,14 @@ static char *documentName= 0;
 - (int) draggingUpdated: (id<NSDraggingInfo>)info
 {
   noteMousePoint([info draggingLocation]);
-  noteDragEvent(DragMove, dragCount);
+  noteDragEvent(SQDragMove, dragCount);
   return NSDragOperationCopy;
 }
 
 - (void) draggingExited: (id<NSDraggingInfo>)info
 {
   noteMousePoint([info draggingLocation]);
-  noteDragEvent(DragLeave, dragCount);
+  noteDragEvent(SQDragLeave, dragCount);
   dragCount= 0;
 }
 
@@ -2088,7 +2088,7 @@ static char *documentName= 0;
       for (i= 0;  i < uxDropFileCount;  ++i)
 	uxDropFileNames[i]= strdup([[files objectAtIndex: i] cString]);
     }
-  noteDragEvent(DragDrop, uxDropFileCount);
+  noteDragEvent(SQDragDrop, uxDropFileCount);
   dragCount= 0;
 
   return YES;	// under some duress, I might add (see sqUxDragDrop.c)

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -672,7 +672,7 @@ static int sendSelection(XSelectionRequestEvent *requestEv, int isMultiple)
    * the case of Xdnd, XSelectionEvent is answered asynchronously
    * after the image prepares data because target (data type) is
    * informed only when the SelectionRequest is sent.
-   * dndOutSelectionRequest() sends a DragRequest event to the image
+   * dndOutSelectionRequest() sends a SQDragRequest event to the image
    * for that.  Finally, the image calls
    * HandMorph>>primitiveDndOutSend: to send the SelectionRequest.
    */

--- a/platforms/unix/vm-display-X11/sqUnixXdnd.c
+++ b/platforms/unix/vm-display-X11/sqUnixXdnd.c
@@ -452,7 +452,7 @@ static enum XdndState dndOutSelectionRequest(enum XdndState state, XSelectionReq
       return state;
     }
   memcpy(&xdndOutRequestEvent, req, sizeof(xdndOutRequestEvent));
-  recordDragEvent(DragRequest, 1);
+  recordDragEvent(SQDragRequest, 1);
   return state;
 }
 
@@ -645,7 +645,7 @@ static enum XdndState dndInEnter(enum XdndState state, XClientMessageEvent *evt)
 static enum XdndState dndInLeave(enum XdndState state)
 {
   fdebugf((stderr, "Receive XdndLeave (input)\n"));
-  recordDragEvent(DragLeave, 1);
+  recordDragEvent(SQDragLeave, 1);
   return XdndStateIdle;
 }
 
@@ -669,7 +669,7 @@ static enum XdndState dndInPosition(enum XdndState state, XClientMessageEvent *e
     }
   
   if ((state == XdndStateEntered) && xdndWillAccept)
-    recordDragEvent(DragEnter, 1);
+    recordDragEvent(SQDragEnter, 1);
   
   if (xdndWillAccept)
     {
@@ -683,7 +683,7 @@ static enum XdndState dndInPosition(enum XdndState state, XClientMessageEvent *e
     {
       /*fdebugf((stderr, "  dndInPosition: accepting\n"));*/
       dndSendStatus(1, XdndActionCopy);
-      recordDragEvent(DragMove, 1);
+      recordDragEvent(SQDragMove, 1);
     }
   else /* won't accept */
     {
@@ -718,7 +718,7 @@ enum XdndState dndInDrop(enum XdndState state, XClientMessageEvent *evt)
   if (isUrlList == 0)
     {
       fdebugf((stderr, "  dndInDrop: no url list\n"));
-      recordDragEvent(DragDrop, 0);
+      recordDragEvent(SQDragDrop, 0);
       return state;
     }
   dndInDestroyTypes();
@@ -743,7 +743,7 @@ enum XdndState dndInDrop(enum XdndState state, XClientMessageEvent *evt)
     }
 
   dndSendFinished();
-  recordDragEvent(DragLeave, 1);
+  recordDragEvent(SQDragLeave, 1);
 
   return XdndStateIdle;
 }
@@ -845,7 +845,7 @@ static void
 generateSqueakDropEventIfDroppedFiles()
 {
 	if (uxDropFileCount)
-		recordDragEvent(DragDrop, uxDropFileCount);
+		recordDragEvent(SQDragDrop, uxDropFileCount);
 }
 
 static void dndGetSelection(Window owner, Atom property)
@@ -887,7 +887,7 @@ static enum XdndState dndInSelectionNotify(enum XdndState state, XSelectionEvent
 
   dndGetSelection(evt->requestor, evt->property);
   dndSendFinished();
-  recordDragEvent(DragLeave, 1);
+  recordDragEvent(SQDragLeave, 1);
   return XdndStateIdle;
 }
 
@@ -896,7 +896,7 @@ static enum XdndState dndInFinished(enum XdndState state)
 {
   fdebugf((stderr, "Internal signal DndInFinished (input)\n"));
   dndSendFinished();
-  recordDragEvent(DragLeave, 1);
+  recordDragEvent(SQDragLeave, 1);
   dndInDestroyTypes();
   return XdndStateIdle;
 }

--- a/platforms/win32/plugins/DropPlugin/sqWin32Drop.c
+++ b/platforms/win32/plugins/DropPlugin/sqWin32Drop.c
@@ -305,7 +305,7 @@ void signalDropEnter(POINTL pt)
   winPt.x = pt.x;
   winPt.y = pt.y;
   ScreenToClient(stWindow, &winPt);
-  recordDragDropEvent(stWindow, DragEnter, winPt.x, winPt.y, 0);
+  recordDragDropEvent(stWindow, SQDragEnter, winPt.x, winPt.y, 0);
 }
 
 STDMETHODIMP DropTarget_DragEnter(DropTarget *dt, 
@@ -464,14 +464,14 @@ STDMETHODIMP DropTarget_DragOver(DropTarget *dt,
     winPt.x = pt.x;
     winPt.y = pt.y;
     ScreenToClient(stWindow, &winPt);
-    recordDragDropEvent(stWindow, DragMove, winPt.x, winPt.y, 0);
+    recordDragDropEvent(stWindow, SQDragMove, winPt.x, winPt.y, 0);
   }
   return S_OK;
 }
 
 STDMETHODIMP DropTarget_DragLeave(DropTarget *dt) {
   DPRINTF(("DropTarget_DragLeave\n"));
-  recordDragDropEvent(stWindow, DragLeave, 0, 0, 0);
+  recordDragDropEvent(stWindow, SQDragLeave, 0, 0, 0);
   return S_OK;
 }
 
@@ -481,7 +481,7 @@ void signalDrop(POINTL pt)
   winPt.x = pt.x;
   winPt.y = pt.y;
   ScreenToClient(stWindow, &winPt);
-  recordDragDropEvent(stWindow, DragDrop, winPt.x, winPt.y, numDropFiles);
+  recordDragDropEvent(stWindow, SQDragDrop, winPt.x, winPt.y, numDropFiles);
 }
 
 STDMETHODIMP DropTarget_Drop(DropTarget *dt,
@@ -737,7 +737,7 @@ int dropLaunchFile(char *fileName) {
   dropFiles = calloc(1, sizeof(void*));
   dropFiles[0] = _strdup(fileName);
 
-  recordDragDropEvent(stWindow, DragDrop, 0, 0, numDropFiles);
+  recordDragDropEvent(stWindow, SQDragDrop, 0, 0, numDropFiles);
   return 1;
 }
 


### PR DESCRIPTION
This is required for compatibility with MSVC (2015), otherwise there's a namespace conflict:
>c:\program files (x86)\windows kits\8.1\include\um\oleidl.h(3541): error C2059: erreur de syntaxe : 'constant'

The offending code is:

        HRESULT ( STDMETHODCALLTYPE *DragEnter )(