### PR TITLE
Changed scripts so they are explicitly interpreted by bash and not the default shell

### DIFF
--- a/image/buildsistareaderimage.sh
+++ b/image/buildsistareaderimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Build a Spur image that starts up in a simple REPL, which is
 # really useful for VMMaker simulation testing.
 . ./envvars.sh

--- a/image/buildspurtrunk64image.sh
+++ b/image/buildspurtrunk64image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 . ./envvars.sh
 
 test -f SpurVMMaker.image || ./buildspurtrunkvmmakerimage.sh

--- a/image/buildspurtrunkreader64image.sh
+++ b/image/buildspurtrunkreader64image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 . ./envvars.sh
 
 test -f spurreader.image || ./buildspurtrunkreaderimage.sh

--- a/image/buildspurtrunkreaderimage.sh
+++ b/image/buildspurtrunkreaderimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Build a Spur image that starts up in a simple REPL, which is
 # really useful for VMMaker simulation testing.
 . ./envvars.sh

--- a/image/buildspurtrunkvmmakerimage.sh
+++ b/image/buildspurtrunkvmmakerimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 . ./envvars.sh
 
 ./updatespurimage.sh

--- a/image/getGoodCogVM.sh
+++ b/image/getGoodCogVM.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Sets the VM env var to the r3692 Cog VM for the current platform.
 # will download and install the VM in this directory if necessary.
 

--- a/image/getGoodSpurNsvm.sh
+++ b/image/getGoodSpurNsvm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Sets the VM env var to the r3692 Newspeak Spur VM for the current platform.
 # will download and install the VM in this directory if necessary.
 

--- a/image/getGoodSpurVM.sh
+++ b/image/getGoodSpurVM.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Sets the VM env var to the r3692 Cog Spur VM for the current platform.
 # will download and install the VM in this directory if necessary.
 

--- a/image/resizesqueakwindow.sh
+++ b/image/resizesqueakwindow.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 if [ $# -ne 3 ]; then
 	echo "Usage: `basename $0` <image> <width> <height>"
 	exit 1

--- a/image/updatespurimage.sh
+++ b/image/updatespurimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Update the latest Spur image.
 . ./envvars.sh
 

--- a/image/updatevmmakerimage.sh
+++ b/image/updatevmmakerimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Update the latest Spur image.
 . ./envvars.sh
 

--- a/image/uploadspurimage.sh
+++ b/image/uploadspurimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Upload a trunk46-spur.image/.changes to mirandabanda.org
 RemoteUser=eliotmiranda@highland-park.dreamhost.com
 RemoteRoot=mirandabanda.org/files/Cog/SpurImages


### PR DESCRIPTION
Dash is the default shell for Debian and other Linux distributions, and it's unable to run most of the scripts provided to build a VMMaker trunk image. 