### PR TITLE
Enable HostWindowPlugin for all supported Linux builds

### DIFF
--- a/build.linux32ARMv6/newspeak.cog.spur/plugins.int
+++ b/build.linux32ARMv6/newspeak.cog.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux32ARMv6/newspeak.stack.spur/plugins.int
+++ b/build.linux32ARMv6/newspeak.stack.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux32ARMv6/squeak.cog.spur/plugins.int
+++ b/build.linux32ARMv6/squeak.cog.spur/plugins.int
@@ -8,6 +8,7 @@ BitBltPlugin \
 BMPReadWriterPlugin \
 CameraPlugin \
 #CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32ARMv6/squeak.stack.spur/plugins.int
+++ b/build.linux32ARMv6/squeak.stack.spur/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CameraPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32ARMv6/squeak.stack.v3/plugins.int
+++ b/build.linux32ARMv6/squeak.stack.v3/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CameraPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32x86/newspeak.cog.spur/plugins.int
+++ b/build.linux32x86/newspeak.cog.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux32x86/newspeak.sista.spur/plugins.int
+++ b/build.linux32x86/newspeak.sista.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux32x86/newspeak.stack.spur/plugins.int
+++ b/build.linux32x86/newspeak.stack.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux32x86/nsnac.cog.spur/plugins.int
+++ b/build.linux32x86/nsnac.cog.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux32x86/squeak.cog.spur.immutability/plugins.int
+++ b/build.linux32x86/squeak.cog.spur.immutability/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32x86/squeak.cog.spur/plugins.int
+++ b/build.linux32x86/squeak.cog.spur/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32x86/squeak.cog.v3/plugins.int
+++ b/build.linux32x86/squeak.cog.v3/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32x86/squeak.sista.spur/plugins.int
+++ b/build.linux32x86/squeak.sista.spur/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32x86/squeak.stack.spur/plugins.int
+++ b/build.linux32x86/squeak.stack.spur/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux32x86/squeak.stack.v3/plugins.int
+++ b/build.linux32x86/squeak.stack.v3/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux64x64/newspeak.cog.spur/plugins.int
+++ b/build.linux64x64/newspeak.cog.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux64x64/newspeak.cog.spur/plugins.int
+++ b/build.linux64x64/newspeak.cog.spur/plugins.int
@@ -11,7 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
-HostWindowPlugin \
+# HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux64x64/newspeak.sista.spur/plugins.int
+++ b/build.linux64x64/newspeak.sista.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux64x64/newspeak.sista.spur/plugins.int
+++ b/build.linux64x64/newspeak.sista.spur/plugins.int
@@ -11,7 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
-HostWindowPlugin \
+# HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux64x64/newspeak.stack.spur/plugins.int
+++ b/build.linux64x64/newspeak.stack.spur/plugins.int
@@ -11,6 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
+HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux64x64/newspeak.stack.spur/plugins.int
+++ b/build.linux64x64/newspeak.stack.spur/plugins.int
@@ -11,7 +11,7 @@ FileCopyPlugin \
 FilePlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
-HostWindowPlugin \
+# HostWindowPlugin \
 ZipPlugin \
 JPEGReadWriter2Plugin \
 JPEGReaderPlugin \

--- a/build.linux64x64/squeak.cog.spur.immutability/plugins.int
+++ b/build.linux64x64/squeak.cog.spur.immutability/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux64x64/squeak.cog.spur.immutability/plugins.int
+++ b/build.linux64x64/squeak.cog.spur.immutability/plugins.int
@@ -7,7 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
-HostWindowPlugin \
+# HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux64x64/squeak.cog.spur/plugins.int
+++ b/build.linux64x64/squeak.cog.spur/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux64x64/squeak.cog.spur/plugins.int
+++ b/build.linux64x64/squeak.cog.spur/plugins.int
@@ -7,7 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
-HostWindowPlugin \
+# HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux64x64/squeak.stack.spur/plugins.int
+++ b/build.linux64x64/squeak.stack.spur/plugins.int
@@ -7,6 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
+HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \

--- a/build.linux64x64/squeak.stack.spur/plugins.int
+++ b/build.linux64x64/squeak.stack.spur/plugins.int
@@ -7,7 +7,7 @@ B2DPlugin \
 BitBltPlugin \
 BMPReadWriterPlugin \
 CroquetPlugin \
-HostWindowPlugin \
+# HostWindowPlugin \
 ZipPlugin \
 DropPlugin \
 DSAPrims \


### PR DESCRIPTION
HostWindowPlugin for 64bit Linux builds is not (yet) implemented.

Related discussion: http://forum.world.st/HostWindowPlugin-for-Linux-td4911988.html

@timrowledge 
