### PR TITLE
Modified the mechanism that validated the Display being a 'sane' object since it wans't appropriate for Spur's object format field

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -1332,12 +1332,13 @@ static sqInt display_clipboardReadIntoAt(sqInt count, sqInt byteArrayIndex, sqIn
 static void redrawDisplay(int l, int r, int t, int b)
 {
   extern sqInt displayObject(void);
+  extern sqInt isPointers(sqInt);
   extern sqInt lengthOf(sqInt);
   extern sqInt fetchPointerofObject(sqInt, sqInt);
 
   sqInt displayObj= displayObject();
 
-  if (lengthOf(displayObj) >= 4)
+  if (isPointers(displayObj) && lengthOf(displayObj) >= 4)
     {
       sqInt dispBits= fetchPointerofObject(0, displayObj);
       sqInt w= fetchIntegerofObject(1, displayObj);

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -1337,8 +1337,7 @@ static void redrawDisplay(int l, int r, int t, int b)
 
   sqInt displayObj= displayObject();
 
-  if ((((((unsigned)(oopAt(displayObj))) >> 8) & 15) <= 4)
-      && ((lengthOf(displayObj)) >= 4))
+  if (lengthOf(displayObj) >= 4)
     {
       sqInt dispBits= fetchPointerofObject(0, displayObj);
       sqInt w= fetchIntegerofObject(1, displayObj);


### PR DESCRIPTION
For such validation to be correct, one would have to shift the displayObject oop 24 bits, not 8 (see SpurMemoryManager>>#formatShift) but displayObject() is called and its result is used without validation on other parts of the codebase, so it seems simpler to get rid of it altogether.