### PR TITLE
VM support changes required by the LowcodeVM

### DIFF
--- a/platforms/Cross/vm/sqLowcodeFFI-Unsupported.h
+++ b/platforms/Cross/vm/sqLowcodeFFI-Unsupported.h
@@ -1,0 +1,41 @@
+/* sqLowcodeFFI-i386 -- i386 Platform specific definitions for the FFI.
+ *
+ * Author: Ronie Salgado (roniesalg@gmail.com)
+ */
+
+
+#ifndef _SQ_LOWCODE_FFI_I386_H_
+#define _SQ_LOWCODE_FFI_I386_H_
+
+typedef struct _sqLowcodeCalloutState
+{
+    /* No callout state */
+
+} sqLowcodeCalloutState;
+
+#define lowcodeCalloutStatepointerRegister(calloutState, registerId) 0
+#define lowcodeCalloutStatepointerRegistervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStateint32Register(calloutState, registerId) 0
+#define lowcodeCalloutStateint32Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStateint64Register(calloutState, registerId) 0
+#define lowcodeCalloutStateint64Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStatefloat32Register(calloutState, registerId) 0
+#define lowcodeCalloutStatefloat32Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStatefloat64Register(calloutState, registerId) 0
+#define lowcodeCalloutStatefloat64Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStateFetchResultInt32(calloutState) 0
+#define lowcodeCalloutStateFetchResultInt64(calloutState) 0
+#define lowcodeCalloutStateFetchResultPointer(calloutState) 0
+
+#define lowcodeCalloutStateFetchResultFloat32(calloutState) 0
+#define lowcodeCalloutStateFetchResultFloat64(calloutState) 0
+#define lowcodeCalloutStateFetchResultStructure(calloutState) 0
+
+#define lowcodeCalloutStatestackPointerstackSizecallFunction(calloutState, stackPointer, stackSize, functionPointer)
+
+#endif /*_SQ_LOWCODE_FFI_I386_H_*/

--- a/platforms/Cross/vm/sqLowcodeFFI-i386.h
+++ b/platforms/Cross/vm/sqLowcodeFFI-i386.h
@@ -1,0 +1,104 @@
+/* sqLowcodeFFI-i386 -- i386 Platform specific definitions for the FFI.
+ *
+ * Author: Ronie Salgado (roniesalg@gmail.com)
+ */
+
+
+#ifndef _SQ_LOWCODE_FFI_I386_H_
+#define _SQ_LOWCODE_FFI_I386_H_
+
+typedef struct _sqLowcodeCalloutState
+{
+    union
+    {
+        struct
+        {
+            uint32_t eax, ecx, edx, ebx, esp, ebp, esi, edi;
+        };
+
+        uint32_t intRegisters[8];
+    };
+
+    double floatResult;
+} sqLowcodeCalloutState;
+
+#define lowcodeCalloutStatepointerRegister(calloutState, registerId) ((char*)(calloutState)->intRegisters[registerId])
+#define lowcodeCalloutStatepointerRegistervalue(calloutState, registerId, value) ((calloutState)->intRegisters[registerId] = (uint32_t) (value))
+
+#define lowcodeCalloutStateint32Register(calloutState, registerId) ((calloutState)->intRegisters[registerId])
+#define lowcodeCalloutStateint32Registervalue(calloutState, registerId, value) ((calloutState)->intRegisters[registerId] = (value))
+
+#define lowcodeCalloutStateint64Register(calloutState, registerId) 0
+#define lowcodeCalloutStateint64Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStatefloat32Register(calloutState, registerId) 0
+#define lowcodeCalloutStatefloat32Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStatefloat64Register(calloutState, registerId) 0
+#define lowcodeCalloutStatefloat64Registervalue(calloutState, registerId, value) 0
+
+#define lowcodeCalloutStateFetchResultInt32(calloutState) (calloutState)->eax
+#define lowcodeCalloutStateFetchResultInt64(calloutState) 0
+#define lowcodeCalloutStateFetchResultPointer(calloutState) ((char*)(calloutState)->eax)
+
+#define lowcodeCalloutStateFetchResultFloat32(calloutState) (calloutState)->floatResult
+#define lowcodeCalloutStateFetchResultFloat64(calloutState) (calloutState)->floatResult
+#define lowcodeCalloutStateFetchResultStructure(calloutState) ((char*)(calloutState)->eax)
+
+__asm__ (
+".section .text                                                              \n\
+lowcodeCalloutStatestackPointerstackSizecallFunction:                        \n\
+    pusha                                                                    \n\
+    movl %esp, %ebp                                                          \n\
+    /* Align the stack */                                                    \n\
+    andl $-16, %esp                                                          \n\
+    /* Copy the stack arguments */                                           \n\
+    movl 40(%ebp), %esi                                                      \n\
+    movl 44(%ebp), %ecx                                                      \n\
+    subl %ecx, %esp                                                          \n\
+    shr $2, %ecx                                                             \n\
+    movl %esp, %edi                                                          \n\
+    cld                                                                      \n\
+    rep movsd                                                                \n\
+    /* Fetch the function pointer */                                         \n\
+    movl 48(%ebp), %eax                                                      \n\
+    movl %eax, -8(%esp)                                                      \n\
+    /* Fetch the registers */                                                \n\
+    movl 36(%ebp), %eax                                                      \n\
+    movl 4(%eax), %ecx                                                       \n\
+    movl 8(%eax), %edx                                                       \n\
+    movl 12(%eax), %ebx                                                      \n\
+    movl 24(%eax), %esi                                                      \n\
+    movl 28(%eax), %edi                                                      \n\
+    movl 0(%eax), %eax                                                       \n\
+    /* Perform the callout */                                                \n\
+    call .LcallTrap                                                          \n\
+    /* Store the registers in the stack */                                   \n\
+    subl $8, %esp                                                            \n\
+    fstpl (%esp)                                                             \n\
+    pushl %edi                                                               \n\
+    pushl %esi                                                               \n\
+    pushl %esp                                                               \n\
+    pushl %ebp                                                               \n\
+    pushl %ebx                                                               \n\
+    pushl %edx                                                               \n\
+    pushl %ecx                                                               \n\
+    pushl %eax                                                               \n\
+    /* Copy the registers back to the callout state */                       \n\
+    movl $10, %ecx                                                           \n\
+    movl %esp, %esi                                                          \n\
+    movl 36(%ebp), %edi                                                      \n\
+    cld                                                                      \n\
+    rep movsd                                                                \n\
+    /* Return */                                                             \n\
+    movl %ebp, %esp                                                          \n\
+    popa                                                                     \n\
+    ret                                                                      \n\
+.LcallTrap:                                                                  \n\
+    subl $4, %esp                                                            \n\
+    ret                                                                      \n\
+");
+
+static void lowcodeCalloutStatestackPointerstackSizecallFunction(sqLowcodeCalloutState *calloutState, char *stackPointer, size_t stackSize, char* functionPointer);
+
+#endif /*_SQ_LOWCODE_FFI_I386_H_*/

--- a/platforms/Cross/vm/sqLowcodeFFI-x86_64.h
+++ b/platforms/Cross/vm/sqLowcodeFFI-x86_64.h
@@ -1,0 +1,206 @@
+/* sqLowcodeFFI-i386 -- i386 Platform specific definitions for the FFI.
+ *
+ * Author: Ronie Salgado (roniesalg@gmail.com)
+ */
+
+
+#ifndef _SQ_LOWCODE_FFI_X86_64_H_
+#define _SQ_LOWCODE_FFI_X86_64_H_
+
+typedef union __attribute__((aligned(16))) _sqLowcodeVectorRegister
+{
+    float singleComponents[4];
+    double doubleComponents[2];
+} sqLowcodeVectorRegister;
+
+typedef struct __attribute__((aligned(16))) _sqLowcodeCalloutState
+{
+    union
+    {
+        struct
+        {
+            uint64_t rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi;
+            uint64_t r8, r9, r10, r11, r12, r13, r14, r15;
+        };
+
+        uint64_t intRegisters[16];
+    };
+
+    union
+    {
+        struct
+        {
+            sqLowcodeVectorRegister xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+            sqLowcodeVectorRegister xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15;
+        };
+
+        sqLowcodeVectorRegister vectorRegisters[16];
+    };
+
+} sqLowcodeCalloutState;
+
+#define lowcodeCalloutStatepointerRegister(calloutState, registerId) ((char*)(calloutState)->intRegisters[registerId])
+#define lowcodeCalloutStatepointerRegistervalue(calloutState, registerId, value) ((calloutState)->intRegisters[registerId] = (uint64_t) (value))
+
+#define lowcodeCalloutStateint32Register(calloutState, registerId) ((calloutState)->intRegisters[registerId])
+#define lowcodeCalloutStateint32Registervalue(calloutState, registerId, value) ((calloutState)->intRegisters[registerId] = (value))
+
+#define lowcodeCalloutStateint64Register(calloutState, registerId) ((calloutState)->intRegisters[registerId])
+#define lowcodeCalloutStateint64Registervalue(calloutState, registerId, value) ((calloutState)->intRegisters[registerId] = (value))
+
+#define lowcodeCalloutStatefloat32Register(calloutState, registerId) ((calloutState)->vectorRegisters[registerId].singleComponents[0])
+#define lowcodeCalloutStatefloat32Registervalue(calloutState, registerId, value) ((calloutState)->vectorRegisters[registerId].singleComponents[0] = (value))
+
+#define lowcodeCalloutStatefloat64Register(calloutState, registerId) ((calloutState)->vectorRegisters[registerId].doubleComponents[0])
+#define lowcodeCalloutStatefloat64Registervalue(calloutState, registerId, value) ((calloutState)->vectorRegisters[registerId].doubleComponents[0] = (value))
+
+#ifdef _WIN32
+#define ARGUMENT_calloutState "104(%rbp)"        /* RCX */
+#define ARGUMENT_stackPointer "96(%rbp)"         /* RDX*/
+#define ARGUMENT_stackSize    "56(%rbp)"         /* R8 */
+#define ARGUMENT_functionPointer "48%(rbp)"      /* R9 */
+#else
+#define ARGUMENT_calloutState "64(%rbp)"         /* RDI*/
+#define ARGUMENT_stackPointer "72(%rbp)"         /* RSI */
+#define ARGUMENT_stackSize    "96(%rbp)"         /* RDX*/
+#define ARGUMENT_functionPointer  "104(%rbp)"    /* RCX */
+#endif
+
+__asm__ (
+".section .text                                                              \n\
+lowcodeCalloutStatestackPointerstackSizecallFunction:                        \n\
+    push %rax                                                                \n\
+    push %rcx                                                                \n\
+    push %rdx                                                                \n\
+    push %rbx                                                                \n\
+    push %rbp                                                                \n\
+    push %rsi                                                                \n\
+    push %rdi                                                                \n\
+    push %r8                                                                 \n\
+    push %r9                                                                 \n\
+    push %r10                                                                \n\
+    push %r11                                                                \n\
+    push %r12                                                                \n\
+    push %r13                                                                \n\
+    push %r14                                                                \n\
+    push %r15                                                                \n\
+    movq %rsp, %rbp                                                          \n\
+    /* Align the stack */                                                    \n\
+    andq $-16, %rsp                                                          \n\
+    /* Copy the stack arguments */                                           \n\
+    movq " ARGUMENT_stackPointer ", %rsi                                     \n\
+    movq " ARGUMENT_stackSize ", %rcx                                        \n\
+    subq %rcx, %rsp                                                          \n\
+    shrq $3, %rcx                                                            \n\
+    movq %rsp, %rdi                                                          \n\
+    cld                                                                      \n\
+    rep movsq                                                                \n\
+    /* Fetch the function pointer */                                         \n\
+    movq " ARGUMENT_functionPointer ", %rax                                  \n\
+    movq %rax, -16(%rsp)                                                     \n\
+    /* Fetch the registers */                                                \n\
+    movq " ARGUMENT_calloutState ", %rax                                     \n\
+    movaps 128(%rax), %xmm0                                                  \n\
+    movaps 144(%rax), %xmm1                                                  \n\
+    movaps 160(%rax), %xmm2                                                  \n\
+    movaps 176(%rax), %xmm3                                                  \n\
+    movaps 192(%rax), %xmm4                                                  \n\
+    movaps 208(%rax), %xmm5                                                  \n\
+    movaps 224(%rax), %xmm6                                                  \n\
+    movaps 240(%rax), %xmm7                                                  \n\
+    movaps 256(%rax), %xmm8                                                  \n\
+    movaps 272(%rax), %xmm9                                                  \n\
+    movaps 288(%rax), %xmm10                                                 \n\
+    movaps 304(%rax), %xmm11                                                 \n\
+    movaps 320(%rax), %xmm12                                                 \n\
+    movaps 336(%rax), %xmm13                                                 \n\
+    movaps 352(%rax), %xmm14                                                 \n\
+    movaps 368(%rax), %xmm15                                                 \n\
+    movq 8(%rax), %rcx                                                       \n\
+    movq 16(%rax), %rdx                                                      \n\
+    movq 24(%rax), %rbx                                                      \n\
+    movq 48(%rax), %rsi                                                      \n\
+    movq 56(%rax), %rdi                                                      \n\
+    movq 64(%rax), %r8                                                       \n\
+    movq 72(%rax), %r9                                                       \n\
+    movq 80(%rax), %r10                                                      \n\
+    movq 88(%rax), %r11                                                      \n\
+    movq 96(%rax), %r12                                                      \n\
+    movq 104(%rax), %r13                                                     \n\
+    movq 112(%rax), %r14                                                     \n\
+    movq 120(%rax), %r15                                                     \n\
+    movq 0(%rax), %rax                                                       \n\
+    /* Perform the callout */                                                \n\
+    call .LcallTrap                                                          \n\
+    /* Store the registers in the stack */                                   \n\
+    push %r15                                                                \n\
+    push %r14                                                                \n\
+    push %r13                                                                \n\
+    push %r12                                                                \n\
+    push %r11                                                                \n\
+    push %r10                                                                \n\
+    push %r9                                                                 \n\
+    push %r8                                                                 \n\
+    push %rdi                                                                \n\
+    push %rsi                                                                \n\
+    push %rsp                                                                \n\
+    push %rbp                                                                \n\
+    push %rbx                                                                \n\
+    push %rdx                                                                \n\
+    push %rcx                                                                \n\
+    push %rax                                                                \n\
+    /* Copy the registers back to the callout state */                       \n\
+    movq $16, %rcx                                                           \n\
+    movq %rsp, %rsi                                                          \n\
+    movq " ARGUMENT_calloutState ", %rax                                     \n\
+    movq %rax, %rdi                                                          \n\
+    cld                                                                      \n\
+    rep movsq                                                                \n\
+    /* Copy the vector registers back to the callout state */                \n\
+    movaps %xmm0, 128(%rax)                                                  \n\
+    movaps %xmm1, 144(%rax)                                                  \n\
+    movaps %xmm2, 160(%rax)                                                  \n\
+    movaps %xmm3, 176(%rax)                                                  \n\
+    movaps %xmm4, 192(%rax)                                                  \n\
+    movaps %xmm5, 208(%rax)                                                  \n\
+    movaps %xmm6, 224(%rax)                                                  \n\
+    movaps %xmm7, 240(%rax)                                                  \n\
+    movaps %xmm8, 256(%rax)                                                  \n\
+    movaps %xmm9, 272(%rax)                                                  \n\
+    movaps %xmm10, 288(%rax)                                                 \n\
+    movaps %xmm11, 304(%rax)                                                 \n\
+    movaps %xmm12, 320(%rax)                                                 \n\
+    movaps %xmm13, 336(%rax)                                                 \n\
+    movaps %xmm14, 352(%rax)                                                 \n\
+    movaps %xmm15, 368(%rax)                                                 \n\
+    /* Return */                                                             \n\
+    movq %rbp, %rsp                                                          \n\
+    pop %r15                                                                 \n\
+    pop %r14                                                                 \n\
+    pop %r13                                                                 \n\
+    pop %r12                                                                 \n\
+    pop %r11                                                                 \n\
+    pop %r10                                                                 \n\
+    pop %r9                                                                  \n\
+    pop %r8                                                                  \n\
+    pop %rdi                                                                 \n\
+    pop %rsi                                                                 \n\
+    pop %rbp                                                                 \n\
+    pop %rbx                                                                 \n\
+    pop %rdx                                                                 \n\
+    pop %rcx                                                                 \n\
+    pop %rax                                                                 \n\
+    ret                                                                      \n\
+.LcallTrap:                                                                  \n\
+    subq $8, %rsp                                                            \n\
+    ret                                                                      \n\
+");
+
+static void lowcodeCalloutStatestackPointerstackSizecallFunction(sqLowcodeCalloutState *calloutState, char *stackPointer, size_t stackSize, char* functionPointer);
+
+#undef ARGUMENT_calloutState
+#undef ARGUMENT_stackPointer
+#undef ARGUMENT_stackSize
+#undef ARGUMENT_functionPointer
+
+#endif /*_SQ_LOWCODE_FFI_X86_64_H_*/

--- a/platforms/Cross/vm/sqLowcodeFFI.h
+++ b/platforms/Cross/vm/sqLowcodeFFI.h
@@ -1,0 +1,20 @@
+/* sqLowcodeFFI -- Platform specific definitions for the FFI.
+ *
+ * Author: Ronie Salgado (roniesalg@gmail.com)
+ */
+
+
+#ifndef _SQ_LOWCODE_FFI_H_
+#define _SQ_LOWCODE_FFI_H_
+
+#include <stdint.h>
+
+#if defined(__i386__)
+#include "sqLowcodeFFI-i386.h"
+#elif defined(__x86_64__)
+#include "sqLowcodeFFI-x86_64.h"
+#else
+#include "sqLowcodeFFI-Unsupported.h"
+#endif
+
+#endif /*_SQ_LOWCODE_FFI_H_*/

--- a/platforms/Cross/vm/sqMemoryAccess.h
+++ b/platforms/Cross/vm/sqMemoryAccess.h
@@ -159,6 +159,32 @@ typedef unsigned long long usqIntptr_t;
   static inline sqLong long64Atput(sqInt oop, sqLong val)		{ return long64AtPointerput(pointerForOop(oop), val); }
   static inline sqInt oopAt(sqInt oop)				{ return oopAtPointer(pointerForOop(oop)); }
   static inline sqInt oopAtput(sqInt oop, sqInt val)		{ return oopAtPointerput(pointerForOop(oop), val); }
+
+  static inline char* pointerAtPointer(char *ptr)			{ return *(char **)ptr; }
+  static inline char* pointerAtPointerput(char *ptr, char* val)	{ return *(char **)ptr = val; }
+
+  static inline signed char int8AtPointer(char *ptr)			            { return (*((signed char *)ptr)); }
+  static inline signed char int8AtPointerput(char *ptr, signed char val)	{ return (*((signed char *)ptr)= val); }
+  static inline unsigned char uint8AtPointer(char *ptr)			            { return (*((unsigned char *)ptr)); }
+  static inline unsigned char uint8AtPointerput(char *ptr, unsigned char val)	{ return (*((unsigned char *)ptr)= val); }
+
+  static inline short int16AtPointer(char *ptr)			                    { return (*((short *)ptr)); }
+  static inline short int16AtPointerput(char *ptr, short val)	            { return (*((short *)ptr)= val); }
+  static inline unsigned short uint16AtPointer(char *ptr)			                    { return (*((unsigned short *)ptr)); }
+  static inline unsigned short uint16AtPointerput(char *ptr, unsigned short val)	    { return (*((unsigned short *)ptr)= val); }
+
+  static inline int int32AtPointer(char *ptr)			    { return (*((int *)ptr)); }
+  static inline int int32AtPointerput(char *ptr, int val)	{ return (*((int *)ptr)= val); }
+  static inline unsigned int uint32AtPointer(char *ptr)			    { return (*((unsigned int *)ptr)); }
+  static inline unsigned int uint32AtPointerput(char *ptr, unsigned int val)	{ return (*((unsigned int *)ptr)= val); }
+
+  static inline sqLong int64AtPointer(char *ptr)			    { return (*((sqLong *)ptr)); }
+  static inline sqLong int64AtPointerput(char *ptr, int val)	{ return (*((sqLong *)ptr)= val); }
+  static inline usqLong uint64AtPointer(char *ptr)			    { return (*((usqLong *)ptr)); }
+  static inline usqLong uint64AtPointerput(char *ptr, usqLong val)	{ return (*((usqLong *)ptr)= val); }
+
+  static inline sqLong asIEEE64BitWord(double val) {return *((sqLong*)&val); }
+  static inline unsigned int asIEEE32BitWord(float val) {return *((unsigned int*)&val); }
 #else /* USE_INLINE_MEMORY_ACCESSORS */
   /* Use macros when static inline functions aren't efficient. */
 # define byteAtPointer(ptr)			((sqInt)(*((unsigned char *)(ptr))))
@@ -171,6 +197,12 @@ typedef unsigned long long usqIntptr_t;
 # define longAtPointerput(ptr,val)	(*(sqInt *)(ptr)= (sqInt)(val))
 # define long64AtPointer(ptr)			(*(sqLong *)(ptr))
 # define long64AtPointerput(ptr,val)	(*(sqLong *)(ptr)= (sqLong)(val))
+# define singleFloatAtPointer(ptr)		(*(float*)(ptr))
+# define singleFloatAtPointerput(ptr, val)		(*(float*)(ptr) = val)
+# define floatAtPointer(ptr)		        (*(double*)(ptr))
+# define floatAtPointerput(ptr, val)		(*(double*)(ptr) = val)
+# define pointerAtPointer(ptr)		        (*(char**)(ptr))
+# define pointerAtPointerput(ptr, val)		(*(char**)(ptr) = val)
 # define oopAtPointer(ptr)			(*(sqInt *)(ptr))
 # define oopAtPointerput(ptr,val)	(*(sqInt *)(ptr)= (sqInt)(val))
 # if defined(sqMemoryBase) && !sqMemoryBase
@@ -194,6 +226,29 @@ typedef unsigned long long usqIntptr_t;
 # define intAtput(oop,val)			intAtPointerput(atPointerArg(oop), val)
 # define oopAt(oop)					oopAtPointer(atPointerArg(oop))
 # define oopAtput(oop,val)			oopAtPointerput(atPointerArg(oop), val)
+
+# define int8AtPointer(ptr)          (*(signed char*)(ptr))
+# define int8AtPointerput(ptr, val)  (*(signed char*)(ptr) = val)
+# define uint8AtPointer(ptr)          (*(unsigned char*)(ptr))
+# define uint8AtPointerput(ptr, val)  (*(unsigned char*)(ptr) = val)
+
+# define int16AtPointer(ptr)          (*(signed short*)(ptr))
+# define int16AtPointerput(ptr, val)  (*(signed short*)(ptr) = val)
+# define uint16AtPointer(ptr)          (*(unsigned short*)(ptr))
+# define uint16AtPointerput(ptr, val)  (*(unsigned short*)(ptr) = val)
+
+# define int32AtPointer(ptr)          (*(signed int*)(ptr))
+# define int32AtPointerput(ptr, val)  (*(signed int*)(ptr) = val)
+# define uint32AtPointer(ptr)          (*(unsigned int*)(ptr))
+# define uint32AtPointerput(ptr, val)  (*(unsigned int*)(ptr) = val)
+
+# define int64AtPointer(ptr)          (*(sqLong*)(ptr))
+# define int64AtPointerput(ptr, val)  (*(sqLong*)(ptr) = val)
+# define uint64AtPointer(ptr)          (*(usqLong*)(ptr))
+# define uint64AtPointerput(ptr, val)  (*(usqLong*)(ptr) = val)
+
+# define asIEEE64BitWord(val) (*((sqLong*)&val))
+# define asIEEE32BitWord(val) (*((unsigned int*)&val))
 #endif /* USE_INLINE_MEMORY_ACCESSORS */
 
 #define long32At	intAt

--- a/specs/lowcode.xml
+++ b/specs/lowcode.xml
@@ -1,0 +1,5910 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<lowcode>
+    <description>
+    The Lowcode instruction set defines a register based virtual machine for
+    C like low-level operations and Smalltalk object oriented pointer
+    manipulations. 
+        
+        
+        
+        <br />
+
+    Lowcode has different set of registers, one for integer, another for
+    object-oriented pointers and another for floating point numbers.
+        
+        
+        
+        <br />
+    Lowcode is encoded using the Sista inline primitives and they starting with
+    opcode inline primitive.
+        
+        
+        
+        <br /></description>
+    <!--Sista extended bytecode instructions-->
+    <!--Lowcode  instructions-->
+    <instruction opcode="0" mnemonic="boolean32ToOop" kind="operation">
+        <name>Boolean to Oop</name>
+        <description>It converts an integer representing a boolean into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic locals="trueJump cont inst" language="Smalltalk/Cog">
+            self CmpCq: 0 R: value.
+            trueJump := self JumpNonZero: 0.
+
+            "False"
+            self annotate: (self MoveCw: objectMemory falseObject R: value) objRef: objectMemory falseObject.
+            cont := self Jump: 0.
+
+            "True"
+            inst := self MoveCw: objectMemory trueObject R: value.
+            trueJump jmpTarget: inst.
+            self annotate: inst objRef: objectMemory trueObject.
+
+            cont jmpTarget: self Label.
+            self ssPushRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := value ~= 0 ifTrue: [ objectMemory trueObject ] ifFalse: [objectMemory falseObject].
+        </semantic>
+    </instruction>
+    <instruction opcode="1" mnemonic="boolean64ToOop" kind="operation">
+        <name>Boolean to Oop</name>
+        <description>It converts an integer representing a boolean into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := value ~= 0 ifTrue: [ objectMemory trueObject ] ifFalse: [objectMemory falseObject].
+        </semantic>
+        <semantic locals="trueJump trueJump2 cont inst" language="Smalltalk/Cog/32">
+            self OrR: valueLow R: valueHigh.
+            trueJump := self JumpNonZero: 0.
+
+            "False"
+            self annotate: (self MoveCw: objectMemory falseObject R: valueLow) objRef: objectMemory falseObject.
+            cont := self Jump: 0.
+
+            "True"
+            inst := self MoveCw: objectMemory trueObject R: valueLow.
+            trueJump jmpTarget: inst.
+            self annotate: inst objRef: objectMemory trueObject.
+
+            cont jmpTarget: self Label.
+            self ssPushRegister: valueLow.
+        </semantic>
+        <semantic locals="trueJump cont inst" language="Smalltalk/Cog/64">
+            self CmpCq: 0 R: value.
+            trueJump := self JumpNonZero: 0.
+
+            "False"
+            self annotate: (self MoveCw: objectMemory falseObject R: value) objRef: objectMemory falseObject.
+            cont := self Jump: 0.
+
+            "True"
+            inst := self MoveCw: objectMemory trueObject R: value.
+            trueJump jmpTarget: inst.
+            self annotate: inst objRef: objectMemory trueObject.
+
+            cont jmpTarget: self Label.
+            self ssPushRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="2" mnemonic="float32ToOop" kind="operation">
+        <name>float32 to Opp</name>
+        <description>It converts a single precision IEEE 754 floating point number into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="singleFloatValue" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcFloat32: singleFloatValue toOop: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory floatObjectOf: singleFloatValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="3" mnemonic="float64ToOop" kind="operation">
+        <name>float64 to Opp</name>
+        <description>It converts a double precision IEEE 754 floating point number into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="floatValue" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcFloat64: floatValue toOop: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory floatObjectOf: floatValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="4" mnemonic="int32ToOop" kind="operation">
+        <name>Int32 to Opp</name>
+        <description>It converts a signed integer into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+        	self ssFlushAll.
+            objectRepresentation genLcInt32ToOop: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory signed32BitIntegerFor: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="5" mnemonic="int64ToOop" kind="operation">
+        <name>Int32 to Opp</name>
+        <description>It converts a signed 64-bit integer into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory signed64BitIntegerFor: value.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssFlushAll.
+            objectRepresentation genLcInt64ToOop: valueLow highPart: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssFlushAll.
+            objectRepresentation genLcInt64ToOop: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="6" mnemonic="pointerToOop" kind="operation">
+        <name>Pointer to Oop</name>
+        <description>Encapsulates a pointer in an object</description>
+        <arguments>
+            <literal name="pointerClassLiteral" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcPointerToOop: pointer class: pointerClassLiteral.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory instantiateClass: pointerClassLiteral indexableSize: BytesPerWord.
+            self pointerAtPointer: (objectMemory firstIndexableField: object) put: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="7" mnemonic="pointerToOopReinterprer" kind="operation">
+        <name>Casts Pointer to Oop Reinterpret</name>
+        <description>Reinterpret casts a pointer into an Oop.
+        </description>
+        <warning>Reinterpret casts a pointer into an Oop.
+        </warning>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            "TODO: Generate a nop here"
+            self ssPushRegister: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := self cCoerce: pointer to: 'sqInt'.
+        </semantic>
+    </instruction>
+    <instruction opcode="8" mnemonic="smallInt32ToOop" kind="operation">
+        <name>SmallInteger32 to Opp</name>
+        <description>It converts a small integer into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self LogicalShiftLeftCq: 1 R: value.
+            self OrCq: 1 R: value.
+            self ssPushRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory integerObjectOf: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="9" mnemonic="uint32ToOop" kind="operation">
+        <name>UInt32 to Opp</name>
+        <description>It converts an unsigned integer into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+        	self ssFlushAll.
+            objectRepresentation genLcUInt32ToOop: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory positive32BitIntegerFor: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="10" mnemonic="uint64ToOop" kind="operation">
+        <name>UInt64 to Opp</name>
+        <description>It converts an unsigned integer into an oop</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := self positive64BitIntegerFor: value.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssFlushAll.
+            objectRepresentation genLcUInt64ToOop: valueLow highPart: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssFlushAll.
+            objectRepresentation genLcUInt64ToOop: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1000" mnemonic="add32" kind="operation">
+        <name>Integer Addition</name>
+        <description>It performs integer addition without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AddR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first + second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1001" mnemonic="add64" kind="operation">
+        <name>Integer Addition</name>
+        <description>It performs integer addition without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first + second.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self AddR: secondLow R: firstLow.
+            self AddcR: secondHigh R: firstHigh.
+			self ssPushNativeRegister: firstLow secondRegister: firstHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self AddR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1002" mnemonic="alloca32" kind="operation">
+        <name>Alloca</name>
+        <description>
+            It allocates variable sized memory in the stack.
+        </description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="size" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveAw: coInterpreter nativeStackPointerAddress R: TempReg.
+            self SubR: size R: TempReg.
+            self AndCq: -16 R: TempReg.
+
+            self MoveR: TempReg R: size.
+            self MoveR: size Aw: coInterpreter nativeStackPointerAddress.
+            self ssPushNativeRegister: size.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            nativeStackPointer := self cCoerce:
+                            ((self cCoerce: nativeStackPointer - size to: 'size_t') bitAnd: -16)
+                        to: 'char*'.
+            pointer := nativeStackPointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1003" mnemonic="alloca64" kind="operation">
+        <name>Alloca</name>
+        <description>
+            It allocates variable sized memory in the stack.
+        </description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="size" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            nativeStackPointer := nativeStackPointer - size.
+            pointer := nativeStackPointer.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self SubR: sizeLow R: SPReg.
+            self MoveR: SPReg R: sizeLow.
+            self ssPushNativeRegister: sizeLow.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self SubR: size R: SPReg.
+            self MoveR: SPReg R: size.
+            self ssPushNativeRegister: size.
+        </semantic>
+    </instruction>
+    <instruction opcode="1004" mnemonic="and32" kind="operation">
+        <name>Bitwise And</name>
+        <description>It performs a bitwise and operation.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AndR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first bitAnd: second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1005" mnemonic="and64" kind="operation">
+        <name>Bitwise And</name>
+        <description>Performs a bitwise and operation.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first bitAnd: second.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self AndR: secondLow R: firstLow.
+            self AndR: secondHigh R: firstHigh.
+            self ssPushNativeRegister: firstLow secondRegister: firstHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self AndR: second R: first.
+            self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1006" mnemonic="arithmeticRightShift32" kind="operation">
+        <name>Arithmetic Right Shift</name>
+        <description>Performs an arithmetic right shifting.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+            <int32 name="shiftAmount" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ArithmeticShiftRightR: shiftAmount R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value &gt;&gt; shiftAmount.
+        </semantic>
+    </instruction>
+    <instruction opcode="1007" mnemonic="arithmeticRightShift64" kind="operation">
+        <name>Arithmetic Right Shift</name>
+        <description>Performs an arithmetic right shifting.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+            <int64 name="shiftAmount" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value &gt;&gt; shiftAmount.
+        </semantic>
+    </instruction>
+    <instruction opcode="1008" mnemonic="beginCall" kind="operation">
+        <name>Begins a function call.</name>
+        <description>Begins a function call</description>
+        <arguments>
+            <extend-a name="alignment" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self beginHighLevelCall: alignment.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            "Store the shadow stack pointer"
+            self shadowCallStackPointerIn: localFP put: shadowCallStackPointer + 1.
+
+            "Allocate the callout state"
+            self allocateLowcodeCalloutState.
+        </semantic>
+    </instruction>
+    <instruction opcode="1009" mnemonic="callArgumentFloat32" kind="operation">
+        <name>Push Float32 call argument</name>
+        <description>Pushes a 32-bit integer to the call stack.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="argumentValue" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: DPFPReg0.
+	        self ssNativePop: 1.
+            self MoveRs: DPFPReg0 M32: BytesPerWord negated r: SPReg.
+            self SubCq: BytesPerWord R: SPReg.
+            currentCallCleanUpSize := currentCallCleanUpSize + BytesPerWord.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackFloat32: argumentValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1010" mnemonic="callArgumentFloat64" kind="operation">
+        <name>Push Float64 call argument</name>
+        <description>Pushes a 64-bit integer to the call stack.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="argumentValue" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: DPFPReg0.
+	        self ssNativePop: 1.
+            self MoveRd: DPFPReg0 M64: -8 r: SPReg.
+            self SubCq: 8 R: SPReg.
+            currentCallCleanUpSize := currentCallCleanUpSize + 8.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackFloat64: argumentValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1011" mnemonic="callArgumentInt32" kind="operation">
+        <name>Pushes Int32 call argument</name>
+        <description>Pushes a 32-bit integer to the call stack.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+            self PushR: TempReg.
+            currentCallCleanUpSize := currentCallCleanUpSize + BytesPerWord.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackInt32: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1012" mnemonic="callArgumentInt64" kind="operation">
+        <name>Push Int64 call argument</name>
+        <description>Pushes a 64-bit integer to the call stack.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+            BytesPerWord = 4 ifTrue: [
+	            self ssNativeTop nativeStackPopToReg: TempReg secondReg: ReceiverResultReg.
+	            self ssNativePop: 1.
+                self PushR: TempReg.
+                self PushR: ReceiverResultReg.
+
+                currentCallCleanUpSize := currentCallCleanUpSize + 8.
+            ] ifFalse: [
+	            self ssNativeTop nativeStackPopToReg: TempReg.
+	            self ssNativePop: 1.
+                self PushR: TempReg.
+
+                currentCallCleanUpSize := currentCallCleanUpSize + BytesPerWord.
+            ].
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackInt64: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1013" mnemonic="callArgumentPointer" kind="operation">
+        <name>Push Pointer call argument</name>
+        <description>Pushes a pointer to the call stack.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointerValue" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+            self PushR: TempReg.
+            currentCallCleanUpSize := currentCallCleanUpSize + BytesPerWord.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackPointer: pointerValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1014" mnemonic="callArgumentSpace" kind="operation">
+        <name>Push empty space call argument</name>
+        <description>Pushes an empty to the call stack.</description>
+        <arguments>
+            <extend-a name="spaceSize" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+            "Allocate space"
+            self SubCq: extA R: SPReg.
+            currentCallCleanUpSize := currentCallCleanUpSize + extA.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackSpace: spaceSize.
+        </semantic>
+    </instruction>
+    <instruction opcode="1015" mnemonic="callArgumentStructure" kind="operation">
+        <name>Push structure call argument</name>
+        <description>Pushes a pointer to the call stack.</description>
+        <arguments>
+            <extend-a name="structureSize" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="structurePointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+            "Fetch the pointer"
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            "Allocate space"
+            self SubCq: extA R: SPReg.
+            currentCallCleanUpSize := currentCallCleanUpSize + extA.
+
+            "Copy the structure"
+            backEnd genMemCopy: TempReg to: SPReg constantSize: extA.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackStructure: structurePointer size: structureSize.
+        </semantic>
+    </instruction>
+    <instruction opcode="1016" mnemonic="callInstruction" kind="operation">
+        <name>Low-Level call</name>
+        <description>This instruction performs a Low-Level call.</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self CallRT: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1017" mnemonic="callPhysical" kind="operation">
+        <name>Push Int32 from physical register</name>
+        <description>Pushes an Int32 from a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self CallR: registerID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1018" mnemonic="checkSessionIdentifier" kind="operation">
+        <name>Pushes true or false if the session ID matches</name>
+        <description>Computes a new pointer by offseting an old one.</description>
+        <arguments>
+            <extend-a name="expectedSession" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt32: (expectedSession = coInterpreter getThisSessionID ifTrue: [1] ifFalse: [0]).
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (expectedSession = self getThisSessionID) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1019" mnemonic="compareAndSwap32" kind="operation">
+        <name>Compare and Swap 32 Bits</name>
+        <description>
+            Compares a 32 bit value in memory with a reference value,
+            if they are equal it swaps the memory location with a new value.
+            It returns the old value in the memory location.
+            This operation is guaranteed to be atomic.
+        </description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="check" />
+            <int32 name="oldValue" />
+            <int32 name="newValue" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+    </instruction>
+    <instruction opcode="1020" mnemonic="div32" kind="operation">
+        <name>Integer Signed Division</name>
+        <description>Integer signed division without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self DivR: second R: first Quo: first Rem: second.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first // second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1021" mnemonic="div64" kind="operation">
+        <name>Integer Signed Division</name>
+        <description>Integer signed division without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first // second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1022" mnemonic="duplicateFloat32" kind="operation">
+        <name>Duplicate Float32</name>
+        <description>It duplicates the Float32 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="dup1" aliased="true" />
+            <float32 name="dup2" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveRs: value Rs: dup2.
+            self ssPushNativeRegisterSingleFloat: value;
+                ssPushNativeRegisterSingleFloat: dup2.
+        </semantic>
+        <semantic language="Pharo/VirtualCPU">
+            dup1 := value.
+            dup2 := value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            dup1 := value.
+            dup2 := value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1023" mnemonic="duplicateFloat64" kind="operation">
+        <name>Duplicate Float64</name>
+        <description>It duplicates the Float64 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="dup1" aliased="true" />
+            <float64 name="dup2" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveRd: value Rd: dup2.
+            self ssPushNativeRegisterDoubleFloat: value;
+                ssPushNativeRegisterDoubleFloat: dup2.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            dup1 := value.
+            dup2 := value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1024" mnemonic="duplicateInt32" kind="operation">
+        <name>Duplicate Int32</name>
+        <description>It duplicates the Int32 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="dup1" aliased="true" />
+            <int32 name="dup2" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveR: value R: dup2.
+            self ssPushNativeRegister: value;
+                ssPushNativeRegister: dup2.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            dup1 := value.
+            dup2 := value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1025" mnemonic="duplicateInt64" kind="operation">
+        <name>Duplicate Int64</name>
+        <description>It duplicates the Int64 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="dup1" aliased="true" />
+            <int64 name="dup2" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            dup1 := value.
+            dup2 := value.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self MoveR: value R: dup2.
+            self ssPushNativeRegister: value.
+            self ssPushNativeRegister: dup2.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self MoveR: valueLow R: dup2Low.
+            self MoveR: valueHigh R: dup2High.
+            self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+            self ssPushNativeRegister: dup2Low secondRegister: dup2High.
+        </semantic>
+    </instruction>
+    <instruction opcode="1026" mnemonic="duplicatePointer" kind="operation">
+        <name>Duplicate Pointer</name>
+        <description>It duplicates the pointer present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointerValue" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="dup1" aliased="true" />
+            <pointer name="dup2" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveR: pointerValue R: dup2.
+            self ssPushNativeRegister: pointerValue;
+                ssPushNativeRegister: dup2.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            dup1 := pointerValue.
+            dup2 := pointerValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1027" mnemonic="effectiveAddress32" kind="operation">
+        <name>Compute Effective Address 32-bit</name>
+        <description>It computes an effective address 32-bit factors.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="base" />
+            <int32 name="index" />
+            <int32 name="scale" />
+            <int32 name="offset" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MulR: scale R: index.
+            self AddR: index R: base.
+            self AddR: offset R: base.
+            self ssPushNativeRegister: base.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := base + (index*scale) + offset.
+        </semantic>
+    </instruction>
+    <instruction opcode="1028" mnemonic="effectiveAddress64" kind="operation">
+        <name>Compute Effective Address 64-bit</name>
+        <description>It computes an effective address using 64-bit factors.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="base" />
+            <int64 name="index" />
+            <int64 name="scale" />
+            <int64 name="offset" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := base + (index*scale) + offset.
+        </semantic>
+    </instruction>
+    <instruction opcode="1029" mnemonic="endCall" kind="operation">
+        <name>End a function call.</name>
+        <description>It ends a function call by cleaning the stack.</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self endHighLevelCallWithCleanup.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            "Restore the shadow stack pointer"
+            shadowCallStackPointer := (self shadowCallStackPointerIn: localFP) - 1.
+            self shadowCallStackPointerIn: localFP put: (self cCoerce: 1 to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1030" mnemonic="endCallNoCleanup" kind="operation">
+        <name>End a function call.</name>
+        <description>It ends a function call without cleaning the stack.</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self endHighLevelCallWithoutCleanup.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            "Restore the shadow stack pointer"
+            shadowCallStackPointer := (self shadowCallStackPointerIn: localFP) - 1.
+            self shadowCallStackPointerIn: localFP put: (self cCoerce: 1 to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1031" mnemonic="float32Add" kind="operation">
+        <name>Float32 addition</name>
+        <description>It Performs the addition of two single precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AddRs: second Rs: first.
+			self ssPushNativeRegisterSingleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first + second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1032" mnemonic="float32Div" kind="operation">
+        <name>Float32 division</name>
+        <description>It performs the division of two single precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self DivRs: second Rs: first.
+			self ssPushNativeRegisterSingleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first / second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1033" mnemonic="float32Equal" kind="operation">
+        <name>Float32 Equality</name>
+        <description>Float32 equality.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRs: second Rs: first.
+            falseJump := self JumpFPNotEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first = second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1034" mnemonic="float32Great" kind="operation">
+        <name>Float32 Great Than</name>
+        <description>Float32 great than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRs: second Rs: first.
+            falseJump := self JumpFPLessOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1035" mnemonic="float32GreatEqual" kind="operation">
+        <name>Float32 Great or Equal Than</name>
+        <description>Float32 great or equal than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRs: second Rs: first.
+            falseJump := self JumpFPLess: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1036" mnemonic="float32Less" kind="operation">
+        <name>Float32 Less Than</name>
+        <description>Float32 less than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRs: second Rs: first.
+            falseJump := self JumpFPGreaterOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1037" mnemonic="float32LessEqual" kind="operation">
+        <name>Float32 Less or Eual Than</name>
+        <description>Float32 less or equal than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRs: second Rs: first.
+            falseJump := self JumpFPGreater: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1038" mnemonic="float32Mul" kind="operation">
+        <name>Float32 multiplication</name>
+        <description>It performs the multiplication of two single precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MulRs: second Rs: first.
+			self ssPushNativeRegisterSingleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first * second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1039" mnemonic="float32Neg" kind="operation">
+        <name>Float32 negate</name>
+        <description>It computes the negation of a single precision floating point value.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self XorRs: result Rs: result.
+            self SubRs: value Rs: result.
+			self ssPushNativeRegisterSingleFloat: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value negated.
+        </semantic>
+    </instruction>
+    <instruction opcode="1040" mnemonic="float32NotEqual" kind="operation">
+        <name>Float32 Inequality</name>
+        <description>Float32 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRs: second Rs: first.
+            falseJump := self JumpFPEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first ~= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1041" mnemonic="float32Sqrt" kind="operation">
+        <name>Float32 square root</name>
+        <description>It computes the square root a single precision floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SqrtRs: value.
+			self ssPushNativeRegisterSingleFloat: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self sqrt: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1042" mnemonic="float32Sub" kind="operation">
+        <name>Float32 subtraction</name>
+        <description>It performs the subtraction of two single precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="first" />
+            <float32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SubRs: second Rs: first.
+			self ssPushNativeRegisterSingleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first - second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1043" mnemonic="float32ToFloat64" kind="operation">
+        <name>Float32 to Float64</name>
+        <description>It converts a single precision floating point number into
+                    a double precision floating point number
+        </description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="singleFloatValue" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="doubleResult" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertRs: singleFloatValue Rd: singleFloatValue.
+            self ssPushNativeRegisterDoubleFloat: singleFloatValue.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            doubleResult := self cCoerce: singleFloatValue to: 'double'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1044" mnemonic="float32ToInt32" kind="operation">
+        <name>Float32 to Int32</name>
+        <description>It converts single precision floating point number into 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertRs: value R: result.
+            self ssPushNativeRegister: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'sqInt'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1045" mnemonic="float32ToInt64" kind="operation">
+        <name>Float32 to Int64</name>
+        <description>It converts a single precision floating point number into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'sqLong'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1046" mnemonic="float32ToUInt32" kind="operation">
+        <name>Float32 to UInt32</name>
+        <description>It converts single precision floating point number into 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertRs: value R: result.
+            self ssPushNativeRegister: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint32_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1047" mnemonic="float32ToUInt64" kind="operation">
+        <name>Float32 to UInt64</name>
+        <description>It converts a single precision floating point number into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint64_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1048" mnemonic="float64Add" kind="operation">
+        <name>Float64 addition</name>
+        <description>It performs the addition of two double precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AddRd: second Rd: first.
+			self ssPushNativeRegisterDoubleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first + second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1049" mnemonic="float64Div" kind="operation">
+        <name>Float64 division</name>
+        <description>It performs the division of two double precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self DivRd: second Rd: first.
+			self ssPushNativeRegisterDoubleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first / second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1050" mnemonic="float64Equal" kind="operation">
+        <name>Float64 Equality</name>
+        <description>Float64 equality.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRd: second Rd: first.
+            falseJump := self JumpFPNotEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first = second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1051" mnemonic="float64Great" kind="operation">
+        <name>Float64 Great Than</name>
+        <description>Float64 great than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRd: second Rd: first.
+            falseJump := self JumpFPLessOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1052" mnemonic="float64GreatEqual" kind="operation">
+        <name>Float64 Great or Equal Than</name>
+        <description>Float64 great or equal than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRd: second Rd: first.
+            falseJump := self JumpFPLess: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1053" mnemonic="float64Less" kind="operation">
+        <name>Float64 Less Than</name>
+        <description>Float64 less than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRd: second Rd: first.
+            falseJump := self JumpFPGreaterOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1054" mnemonic="float64LessEqual" kind="operation">
+        <name>Float64 Less or Equal Than</name>
+        <description>Float32 less or equal than relationship.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRd: second Rd: first.
+            falseJump := self JumpFPGreater: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1055" mnemonic="float64Mul" kind="operation">
+        <name>Float64 multiplication</name>
+        <description>It performs the multiplication of two double precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MulRd: second Rd: first.
+			self ssPushNativeRegisterDoubleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first * second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1056" mnemonic="float64Neg" kind="operation">
+        <name>Float64 negate</name>
+        <description>It computes the negation of a double precision floating point value.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self XorRd: result Rd: result.
+            self SubRd: value Rd: result.
+			self ssPushNativeRegisterDoubleFloat: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value negated.
+        </semantic>
+    </instruction>
+    <instruction opcode="1057" mnemonic="float64NotEqual" kind="operation">
+        <name>Float64 Inequality</name>
+        <description>Float64 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpRd: second Rd: first.
+            falseJump := self JumpFPEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: value.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: value.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first ~= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1058" mnemonic="float64Sqrt" kind="operation">
+        <name>Float32 square root</name>
+        <description>It computes the square root a single precision floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SqrtRd: value.
+			self ssPushNativeRegisterDoubleFloat: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self sqrt: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1059" mnemonic="float64Sub" kind="operation">
+        <name>Float64 subtraction</name>
+        <description>It performs the subtraction of two double precision floating point numbers.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="first" />
+            <float64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SubRd: second Rd: first.
+			self ssPushNativeRegisterDoubleFloat: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first - second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1060" mnemonic="float64ToFloat32" kind="operation">
+        <name>Float64 to Float32</name>
+        <description>It converts a double precision floating point number into
+                    a single precision floating point number
+        </description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="floatValue" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="singleFloatResult" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertRd: floatValue Rs: floatValue.
+            self ssPushNativeRegisterSingleFloat: floatValue.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            singleFloatResult := self cCoerce: floatValue to: 'float'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1061" mnemonic="float64ToInt32" kind="operation">
+        <name>Float64 to Int32</name>
+        <description>It converts double precision floating point number into a 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="floatValue" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="int32Result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertRd: floatValue R: int32Result.
+            self ssPushNativeRegister: int32Result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            int32Result := self cCoerce: floatValue to: 'sqInt'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1062" mnemonic="float64ToInt64" kind="operation">
+        <name>Float64 to Int64</name>
+        <description>It converts a double precision floating point number into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="floatValue" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="int64Result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            int64Result := self cCoerce: floatValue to: 'sqLong'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1063" mnemonic="float64ToUInt32" kind="operation">
+        <name>Float64 to UInt32</name>
+        <description>It converts double precision floating point number into a 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="floatValue" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="int64Result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertRd: floatValue R: int64Result.
+            self ssPushNativeRegister: int64Result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            int64Result := self cCoerce: floatValue to: 'uint32_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1064" mnemonic="float64ToUInt64" kind="operation">
+        <name>Float64 to UInt64</name>
+        <description>It converts a double precision floating point number into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="floatValue" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="int64Result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            int64Result := self cCoerce: floatValue to: 'uint64_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1065" mnemonic="free" kind="operation">
+        <name>Frees Memory</name>
+        <description>
+            Frees previously allocated memory in the heap.
+        </description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            pointer ~= ReceiverResultReg ifTrue: [self MoveR: pointer R: ReceiverResultReg ].
+
+            self CallRT: ceFreeTrampoline.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self free: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1066" mnemonic="instantiateIndexable32Oop" kind="operation">
+        <name>Instantiate an oop class</name>
+        <description>It instantiates a class</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="classOop" />
+            <int32 name="indexableSize" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcInstantiateOop: classOop indexableSize: indexableSize.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory instantiateClass: classOop indexableSize: indexableSize.
+        </semantic>
+    </instruction>
+    <instruction opcode="1067" mnemonic="instantiateIndexableOop" kind="operation">
+        <name>Instantiate an indexable class</name>
+        <description>It instantiates a class</description>
+        <arguments>
+            <extend-a name="indexableSize" />
+        </arguments>
+        <stack-arguments>
+            <oop name="classOop" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcInstantiateOop: classOop constantIndexableSize: indexableSize.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory instantiateClass: classOop indexableSize: indexableSize.
+        </semantic>
+    </instruction>
+    <instruction opcode="1068" mnemonic="instantiateOop" kind="operation">
+        <name>Instantiate an oop class</name>
+        <description>It instantiates a class</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="classOop" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="object" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcInstantiateOop: classOop.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            object := objectMemory instantiateClass: classOop indexableSize: 0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1069" mnemonic="int32Equal" kind="operation">
+        <name>Int32 Equality</name>
+        <description>Int32 equality.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpNonZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first = second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1070" mnemonic="int32Great" kind="operation">
+        <name>Int32 Great Than</name>
+        <description>Int32 great than.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpLessOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1071" mnemonic="int32GreatEqual" kind="operation">
+        <name>Int32 Great or EqualThan</name>
+        <description>Int32 great or equal than.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpLess: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1072" mnemonic="int32Less" kind="operation">
+        <name>Int32 Less Than</name>
+        <description>Int32 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpGreaterOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1073" mnemonic="int32LessEqual" kind="operation">
+        <name>Int32 Less or Equal Than</name>
+        <description>Int32 less equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpGreater: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1074" mnemonic="int32NotEqual" kind="operation">
+        <name>Int32 Inequality</name>
+        <description>Float32 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first ~= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1075" mnemonic="int32ToFloat32" kind="operation">
+        <name>Int32 to Float32</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertR: value Rs: result.
+            self ssPushNativeRegisterSingleFloat: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'float'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1076" mnemonic="int32ToFloat64" kind="operation">
+        <name>Int32 to Float64</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertR: value Rd: result.
+            self ssPushNativeRegisterDoubleFloat: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'double'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1077" mnemonic="int32ToPointer" kind="operation">
+        <name>Int32 to Pointer</name>
+        <description>It converts a 32-bit integer into a pointer.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            "TODO: Perform a NOP here"
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uintptr_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1078" mnemonic="int64Equal" kind="operation">
+        <name>Int64 Equality</name>
+        <description>Int64 equality.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first = second ifTrue: [1] ifFalse: [0].
+        </semantic>
+        <semantic locals="falseJump falseJump2 falseLabel contJump" language="Smalltalk/Cog/32">
+            self CmpR: secondHigh R: firstHigh.
+            falseJump := self JumpNonZero: 0.
+            self CmpR: secondLow R: firstLow.
+            falseJump2 := self JumpNonZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: firstLow.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseLabel := self MoveCq: 0 R: firstLow.
+            falseJump jmpTarget: falseLabel.
+            falseJump2 jmpTarget: falseLabel.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: firstLow.
+        </semantic>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog/64">
+            self CmpR: second R: first.
+            falseJump := self JumpNonZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1079" mnemonic="int64Great" kind="operation">
+        <name>Int64 Great Than</name>
+        <description>Int64 great than.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1080" mnemonic="int64GreatEqual" kind="operation">
+        <name>Int64 Great or EqualThan</name>
+        <description>Int64 great or equal than.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &gt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1081" mnemonic="int64Less" kind="operation">
+        <name>Int64 Less Than</name>
+        <description>Int64 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt; second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1082" mnemonic="int64LessEqual" kind="operation">
+        <name>Int64 Less or Equal Than</name>
+        <description>Int64 less equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first &lt;= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1083" mnemonic="int64NotEqual" kind="operation">
+        <name>Int64 Inequality</name>
+        <description>Float64 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first ~= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+        <semantic locals="falseJump falseJump2 falseLabel contJump" language="Smalltalk/Cog/32">
+            self CmpR: secondHigh R: firstHigh.
+            falseJump := self JumpNonZero: 0.
+            self CmpR: secondLow R: firstLow.
+            falseJump2 := self JumpNonZero: 0.
+
+            "False result"
+            self MoveCq: 0 R: firstLow.
+            contJump := self Jump: 0.
+
+            "True result"
+            falseLabel := self MoveCq: 1 R: firstLow.
+            falseJump jmpTarget: falseLabel.
+            falseJump2 jmpTarget: falseLabel.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: firstLow.
+        </semantic>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog/64">
+            self CmpR: second R: first.
+            falseJump := self JumpNonZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1084" mnemonic="int64ToFloat32" kind="operation">
+        <name>Int64 to Float32</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'float'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1085" mnemonic="int64ToFloat64" kind="operation">
+        <name>Int64 to Float64</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'double'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1086" mnemonic="int64ToPointer" kind="operation">
+        <name>Int64 to Pointer</name>
+        <description>It converts a 64-bit integer into a pointer.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce:
+                        (self cCoerce: value to: 'intptr_t')
+                       to: 'char*'.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssPushNativeRegister: valueLow.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1087" mnemonic="leftShift32" kind="operation">
+        <name>Left Shift</name>
+        <description>Performs a left shifting.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+            <int32 name="shiftAmount" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self LogicalShiftLeftR: shiftAmount R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value &lt;&lt; shiftAmount.
+        </semantic>
+    </instruction>
+    <instruction opcode="1088" mnemonic="leftShift64" kind="operation">
+        <name>Left Shift</name>
+        <description>Performs a left shifting.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+            <int64 name="shiftAmount" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value &lt;&lt; shiftAmount.
+        </semantic>
+    </instruction>
+    <instruction opcode="1089" mnemonic="loadArgumentAddress" kind="operation">
+        <name>Load native argument address</name>
+        <description>It loads a native argument address in the stack</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <pointer name="pointer" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: pointer.
+            self ssPushNativeRegister: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := self framePointerOfNativeArgument: baseOffset in: localFP.
+        </semantic>
+    </instruction>
+    <instruction opcode="1090" mnemonic="loadArgumentFloat32" kind="operation">
+        <name>Load single precision float native argument</name>
+        <description>It loads a single precision float from the native argument frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float32 name="floatValue" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg Rs: floatValue.
+			self ssPushNativeRegisterSingleFloat: floatValue.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            floatValue := stackPages singleFloatAtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1091" mnemonic="loadArgumentFloat64" kind="operation">
+        <name>Load double precision float from native argument</name>
+        <description>It loads a double precision float from the native argument frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float64 name="doubleValue" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM64: 0 r: TempReg Rd: doubleValue.
+			self ssPushNativeRegisterDoubleFloat: doubleValue.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            doubleValue := stackPages floatAtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1092" mnemonic="loadArgumentInt16" kind="operation">
+        <name>Load I16 native argument</name>
+        <description>It Loads an U16 from the native argument frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM16: 0 r: TempReg R: value.
+            self SignExtend16R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int16AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1093" mnemonic="loadArgumentInt32" kind="operation">
+        <name>Load I32 native argument</name>
+        <description>It Loads an U32 from the native argument frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int32AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1094" mnemonic="loadArgumentInt64" kind="operation">
+        <name>Load I64 native argument</name>
+        <description>It Loads an I64 from the native argument frme memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int64AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "TODO: Check the endianness"
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: valueLow.
+            self MoveM32: 4 r: TempReg R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM64: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1095" mnemonic="loadArgumentInt8" kind="operation">
+        <name>Load I8 native argument</name>
+        <description>It Loads an U8 from the stack frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM8: 0 r: TempReg R: value.
+            self SignExtend8R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int8AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1096" mnemonic="loadArgumentPointer" kind="operation">
+        <name>Load pointer native argument</name>
+        <description>It loads a pointer from the stack frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <pointer name="pointerResult" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveMw: 0 r: TempReg R: pointerResult.
+			self ssPushNativeRegister: pointerResult.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointerResult := stackPages pointerAtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1097" mnemonic="loadArgumentUInt16" kind="operation">
+        <name>Load U16 native argument</name>
+        <description>It Loads an U16 from the stack frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM16: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint16AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1098" mnemonic="loadArgumentUInt32" kind="operation">
+        <name>Load U32 native argument</name>
+        <description>It Loads an U32 from the stack frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint32AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1099" mnemonic="loadArgumentUInt64" kind="operation">
+        <name>Load U8 native argument</name>
+        <description>It Loads an U8 from the stack frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint64AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "TODO: Check the endianness"
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: valueLow.
+            self MoveM32: 4 r: TempReg R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM64: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1100" mnemonic="loadArgumentUInt8" kind="operation">
+        <name>Load U8 native argument</name>
+        <description>It Loads an U8 from the stack frame memory.</description>
+        <arguments>
+            <native-argument name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeArgumentAddress: baseOffset to: TempReg.
+            self MoveM8: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint8AtPointer: (self framePointerOfNativeArgument: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1101" mnemonic="loadFloat32FromMemory" kind="operation">
+        <name>Load Float 32 from Memory</name>
+        <description>Loads a float 32 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM32: 0 r: pointer Rs: value.
+			self ssPushNativeRegisterSingleFloat: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self singleFloatAtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1102" mnemonic="loadFloat64FromMemory" kind="operation">
+        <name>Load Float 64 from Memory</name>
+        <description>Loads a float 64 from.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM64: 0 r: pointer Rd: value.
+			self ssPushNativeRegisterDoubleFloat: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self floatAtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1103" mnemonic="loadInt16FromMemory" kind="operation">
+        <name>Load U16 from Memory</name>
+        <description>Loads an U16 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM16: 0 r: pointer R: value.
+            self SignExtend16R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self int16AtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1104" mnemonic="loadInt32FromMemory" kind="operation">
+        <name>Load I32 from Memory</name>
+        <description>Loads an I32 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM32: 0 r: pointer R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self int32AtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1105" mnemonic="loadInt64FromMemory" kind="operation">
+        <name>Load I64 from Memory</name>
+        <description>Loads an I64 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self int64AtPointer: pointer.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "TODO: Check the endianness"
+            self MoveM32: 0 r: pointer R: valueLow.
+            self MoveM32: 4 r: pointer R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self MoveM64: 0 r: pointer R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1106" mnemonic="loadInt8FromMemory" kind="operation">
+        <name>Load I8 from Memory</name>
+        <description>Loads an I8 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM8: 0 r: pointer R: value.
+            self SignExtend8R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self int8AtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1107" mnemonic="loadLocalAddress" kind="operation">
+        <name>Load local address</name>
+        <description>It loads a local variable address in the stack</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <pointer name="pointer" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: pointer.
+            self ssPushNativeRegister: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := self framePointerOfNativeLocal: baseOffset in: localFP.
+        </semantic>
+    </instruction>
+    <instruction opcode="1108" mnemonic="loadLocalFloat32" kind="operation">
+        <name>Load single precision float from stack</name>
+        <description>It loads a single precision float from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float32 name="floatValue" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg Rs: floatValue.
+			self ssPushNativeRegisterSingleFloat: floatValue.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            floatValue := stackPages singleFloatAtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1109" mnemonic="loadLocalFloat64" kind="operation">
+        <name>Load double precision float from stack</name>
+        <description>It loads a double precision float from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float64 name="doubleValue" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM64: 0 r: TempReg Rd: doubleValue.
+			self ssPushNativeRegisterDoubleFloat: doubleValue.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            doubleValue := stackPages floatAtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1110" mnemonic="loadLocalInt16" kind="operation">
+        <name>Load I16 from stack</name>
+        <description>It Loads an U16 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM16: 0 r: TempReg R: value.
+            self SignExtend16R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int16AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1111" mnemonic="loadLocalInt32" kind="operation">
+        <name>Load I32 from stack</name>
+        <description>It Loads an U32 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int32AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1112" mnemonic="loadLocalInt64" kind="operation">
+        <name>Load I64 from stack</name>
+        <description>It Loads an I64 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int64AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "TODO: Check the endianness"
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: valueLow.
+            self MoveM32: 4 r: TempReg R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM64: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1113" mnemonic="loadLocalInt8" kind="operation">
+        <name>Load I8 from stack</name>
+        <description>It Loads an U8 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM8: 0 r: TempReg R: value.
+            self SignExtend8R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages int8AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1114" mnemonic="loadLocalPointer" kind="operation">
+        <name>Load pointer from stack</name>
+        <description>It loads a pointer from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <pointer name="pointerResult" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveMw: 0 r: TempReg R: pointerResult.
+			self ssPushNativeRegister: pointerResult.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointerResult := stackPages pointerAtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1115" mnemonic="loadLocalUInt16" kind="operation">
+        <name>Load U16 from stack</name>
+        <description>It Loads an U16 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM16: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint16AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1116" mnemonic="loadLocalUInt32" kind="operation">
+        <name>Load U32 from stack</name>
+        <description>It Loads an U32 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint32AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1117" mnemonic="loadLocalUInt64" kind="operation">
+        <name>Load U8 from stack</name>
+        <description>It Loads an U8 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint64AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "TODO: Check the endianness"
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM32: 0 r: TempReg R: valueLow.
+            self MoveM32: 4 r: TempReg R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM64: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1118" mnemonic="loadLocalUInt8" kind="operation">
+        <name>Load U8 from stack</name>
+        <description>It Loads an U8 from the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveM8: 0 r: TempReg R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := stackPages uint8AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP).
+        </semantic>
+    </instruction>
+    <instruction opcode="1119" mnemonic="loadObjectAt" kind="operation">
+        <name>Load an object field.</name>
+        <description>This instruction loads the value of an object.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+            <int32 name="fieldIndex" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="fieldValue" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcLoadObject: object at: fieldIndex.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            fieldValue := objectMemory fetchPointer: fieldIndex ofObject: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="1120" mnemonic="loadObjectField" kind="operation">
+        <name>Load an object field.</name>
+        <description>This instruction loads the value of an object.</description>
+        <arguments>
+            <extend-a name="fieldIndex" />
+        </arguments>
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <oop name="fieldValue" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcLoadObject: object field: fieldIndex.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            fieldValue := self fetchPointer: fieldIndex ofObject: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="1121" mnemonic="loadPointerFromMemory" kind="operation">
+        <name>Load Pointer from Memory</name>
+        <description>Loads a pointer from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointerResult" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveMw: 0 r: pointer R: pointerResult.
+			self ssPushNativeRegister: pointerResult.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointerResult := self pointerAtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1122" mnemonic="loadUInt16FromMemory" kind="operation">
+        <name>Load U16 from Memory</name>
+        <description>It loads an U16 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM16: 0 r: pointer R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self uint16AtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1123" mnemonic="loadUInt32FromMemory" kind="operation">
+        <name>Load U32 from Memory</name>
+        <description>Loads an U32 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM32: 0 r: pointer R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self uint32AtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1124" mnemonic="loadUInt64FromMemory" kind="operation">
+        <name>Load U64 from Memory</name>
+        <description>Loads an U64 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self uint64AtPointer: pointer.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "TODO: Check the endianness"
+            self MoveM32: 0 r: pointer R: valueLow.
+            self MoveM32: 4 r: pointer R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self MoveM64: 0 r: pointer R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1125" mnemonic="loadUInt8FromMemory" kind="operation">
+        <name>Load U8 from Memory</name>
+        <description>Loads an U8 from memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MoveM8: 0 r: pointer R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self uint8AtPointer: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1126" mnemonic="localFrameSize" kind="metadata">
+        <name>Local Frame Size</name>
+        <description>This instruction is used to describe the size of the local frame.</description>
+        <arguments>
+            <extend-a name="size" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self assert: needsFrame.
+            hasNativeFrame := true.
+
+            "Mark the stack frame"
+            self annotate: (self MoveCw: (objectMemory splObj: LowcodeContextMark) R: TempReg) objRef: (objectMemory splObj: LowcodeContextMark).
+            self MoveR: TempReg Mw: self frameOffsetOfNativeFrameMark r: FPReg.
+
+            "Fetch the stack"
+            self MoveAw: coInterpreter nativeStackPointerAddress R: TempReg.
+            self AddCq: 1 R: TempReg.
+            self MoveR: TempReg Mw: self frameOffsetOfPreviousNativeStackPointer r: FPReg.
+
+            "Store the frame pointer"
+            self SubCq: size R: TempReg.
+            self MoveR: TempReg Mw: self frameOffsetOfNativeFramePointer r: FPReg.
+
+            "Store the new stack pointer"
+            self MoveR: TempReg Mw: self frameOffsetOfNativeStackPointer r: FPReg.
+
+            "Allocate space for the locals"
+            self SubCq: 1 + coInterpreter defaultNativeStackFrameSize R: TempReg.
+            self MoveR: TempReg Aw: coInterpreter nativeStackPointerAddress.
+            
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            "Mark the frame"
+            self setFrameHasNativeFrame: localFP.
+
+            "Store the previous stack pointer"
+            self nativePreviousStackPointerIn: localFP put: nativeStackPointer + 1.
+
+            "Make the frame pointer"
+            nativeStackPointer := nativeStackPointer - size.
+            self nativeFramePointerIn: localFP put: nativeStackPointer + 1.
+
+            "Set the stack pointer"
+            nativeSP := nativeStackPointer + 1.
+            self nativeStackPointerIn: localFP put: nativeStackPointer + 1.
+
+            "Reserve space for the native stack"
+            nativeStackPointer := nativeStackPointer - self defaultNativeStackFrameSize.
+        </semantic>
+    </instruction>
+    <instruction opcode="1127" mnemonic="lockRegisters" kind="operation">
+        <name>Lock Registers</name>
+        <description>
+            Locks the CPU register. This tells the register allocator that the
+            following instructions are going to modify some explicit CPU registers.
+        </description>
+        <arguments />
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+        </semantic>
+    </instruction>
+    <instruction opcode="1128" mnemonic="lockVM" kind="operation">
+        <name>Lock VM</name>
+        <description>Locks the VM to the current thread.</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results />
+    </instruction>
+    <instruction opcode="1129" mnemonic="malloc32" kind="operation">
+        <name>Malloc</name>
+        <description>
+            Allocates memory from heap
+        </description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="size" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            size ~= ReceiverResultReg ifTrue: [self MoveR: size R: ReceiverResultReg ].
+
+            self CallRT: ceMallocTrampoline.
+
+            self MoveR: TempReg R: pointer.
+            self ssPushNativeRegister: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := self malloc: size.
+        </semantic>
+    </instruction>
+    <instruction opcode="1130" mnemonic="malloc64" kind="operation">
+        <name>Malloc</name>
+        <description>
+            Allocates memory from heap
+        </description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="size" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := self malloc: size.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssFlushAll.
+            sizeLow ~= ReceiverResultReg ifTrue: [self MoveR: sizeLow R: ReceiverResultReg ].
+
+            self CallRT: ceMallocTrampoline.
+
+            self MoveR: TempReg R: pointer.
+            self ssPushNativeRegister: pointer.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssFlushAll.
+            size ~= ReceiverResultReg ifTrue: [self MoveR: size R: ReceiverResultReg ].
+
+            self CallRT: ceMallocTrampoline.
+
+            self MoveR: TempReg R: pointer.
+            self ssPushNativeRegister: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1131" mnemonic="memcpy32" kind="operation">
+        <name>Copies a block of memory</name>
+        <description>Copies a block of memory</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="dest" />
+            <pointer name="source" />
+            <int32 name="size" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self mem: dest cp: source y: size.
+        </semantic>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            backEnd genMemCopy: source to: dest size: size.
+        </semantic>
+    </instruction>
+    <instruction opcode="1132" mnemonic="memcpy64" kind="operation">
+        <name>Copies a block of memory</name>
+        <description>Copies a block of memory</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="dest" />
+            <pointer name="source" />
+            <int64 name="size" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self mem: dest cp: source y: size.
+        </semantic>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            backEnd genMemCopy: source to: dest size: sizeLow.
+        </semantic>
+    </instruction>
+    <instruction opcode="1133" mnemonic="memcpyFixed" kind="operation">
+        <name>Copies a block of memory</name>
+        <description>Copies a block of memory</description>
+        <arguments>
+            <extend-a name="size" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="dest" />
+            <pointer name="source" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self mem: dest cp: source y: size.
+        </semantic>
+        <semantic language="Smalltalk/Cog">
+            size = BytesPerWord ifTrue: [
+                self MoveMw: 0 r: source R: TempReg.
+                self MoveR: TempReg Mw: 0 r: dest.
+            ] ifFalse: [
+                self ssFlushAll.
+                backEnd genMemCopy: source to: dest constantSize: size.
+            ].
+        </semantic>
+    </instruction>
+    <instruction opcode="1134" mnemonic="moveFloat32ToPhysical" kind="operation">
+        <name>Move Float32 To Physical Register</name>
+        <description>Moves a value into a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutState: lowcodeCalloutState float32Register: registerID value: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1135" mnemonic="moveFloat64ToPhysical" kind="operation">
+        <name>Move Float64 Register To Physical Register</name>
+        <description>Moves the content of a logical register into a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments>
+            <float64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutState: lowcodeCalloutState float64Register: registerID value: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1136" mnemonic="moveInt32ToPhysical" kind="operation">
+        <name>Move Int32  To Physical Register</name>
+        <description>Moves a value into a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutState: lowcodeCalloutState int32Register: registerID value: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1137" mnemonic="moveInt64ToPhysical" kind="operation">
+        <name>Move Int64 To Physical Register</name>
+        <description>Moves a value into a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutState: lowcodeCalloutState int64Register: registerID value: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1138" mnemonic="movePointerToPhysical" kind="operation">
+        <name>Move Pointer To Physical Register</name>
+        <description>Moves a value into a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="pointerValue" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutState: lowcodeCalloutState pointerRegister: registerID value: pointerValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1139" mnemonic="mul32" kind="operation">
+        <name>Integer Signed Multiplication</name>
+        <description>Integer multiplication without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MulR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first * second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1140" mnemonic="mul64" kind="operation">
+        <name>Integer Signed Multiplication</name>
+        <description>Integer multiplication without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first * second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1141" mnemonic="neg32" kind="operation">
+        <name>Integer Negation</name>
+        <description>Integer negation.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self NegateR: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value negated.
+        </semantic>
+    </instruction>
+    <instruction opcode="1142" mnemonic="neg64" kind="operation">
+        <name>Integer Negation</name>
+        <description>Integer negation.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value negated.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            "Two complement negation"
+            self NotR: valueLow.
+            self NotR: valueHigh.
+            self AddCq: 1 R: valueLow.
+            self AddcCq: 0 R: valueHigh.
+			self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self NegateR: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1143" mnemonic="not32" kind="operation">
+        <name>Bitwise Not</name>
+        <description>Performs a bitwise not.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self NotR: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitXor: -1.
+        </semantic>
+    </instruction>
+    <instruction opcode="1144" mnemonic="not64" kind="operation">
+        <name>Bitwise Not</name>
+        <description>Performs a bitwise not.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitXor: -1.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self NotR: valueLow.
+            self NotR: valueHigh.
+            self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self NotR: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1145" mnemonic="or32" kind="operation">
+        <name>Bitwise Or</name>
+        <description>Performs a bitwise or operation.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self OrR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first bitOr: second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1146" mnemonic="or64" kind="operation">
+        <name>Bitwise Or</name>
+        <description>Performs a bitwise or operation.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first bitOr: second.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self OrR: secondLow R: firstLow.
+            self OrR: secondHigh R: firstHigh.
+            self ssPushNativeRegister: firstLow secondRegister: firstHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self OrR: second R: first.
+            self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1147" mnemonic="performCallFloat32" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function with Float32 result</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+            self callSwitchToCStack.
+
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+
+            backEnd cFloatResultToRs: DPFPReg0.
+            self ssPushNativeRegisterSingleFloat: DPFPReg0.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutFloat32Result: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1148" mnemonic="performCallFloat64" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function with Float64 result</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float64 name="result" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+            self callSwitchToCStack.
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+
+
+            backEnd cFloatResultToRd: DPFPReg0.
+            self ssPushNativeRegisterDoubleFloat: DPFPReg0.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutFloat64Result: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1149" mnemonic="performCallIndirectFloat32" kind="operation">
+        <name>Perform indirect function call.</name>
+        <description>It performs an indirect function with Float32 result.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="function" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+
+
+            backEnd cFloatResultToRs: DPFPReg0.
+            self ssPushNativeRegisterSingleFloat: DPFPReg0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutFloat32Result: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1150" mnemonic="performCallIndirectFloat64" kind="operation">
+        <name>Perform indirect function call.</name>
+        <description>It erforms an indirect function with Float64 result.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="function" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+
+            backEnd cFloatResultToRd: DPFPReg0.
+            self ssPushNativeRegisterDoubleFloat: DPFPReg0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutFloat64Result: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1151" mnemonic="performCallIndirectInt32" kind="operation">
+        <name>Perform indirect function call.</name>
+        <description>It performs an indirect function with I32 result.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="function" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+
+
+            self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+            self ssPushNativeRegister: ReceiverResultReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutInt32Result: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1152" mnemonic="performCallIndirectInt64" kind="operation">
+        <name>Perform indirect function call.</name>
+        <description>It performs an indirect function with I64 result.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="function" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+
+            BytesPerWord = 4 ifTrue: [
+                self MoveR: backEnd cResultRegisterLow R: ReceiverResultReg.
+                self MoveR: backEnd cResultRegisterHigh R: Arg0Reg.
+                self ssPushNativeRegister: ReceiverResultReg secondRegister: Arg0Reg.
+            ] ifFalse: [
+                self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+                self ssPushNativeRegister: ReceiverResultReg.
+            ].
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutInt64Result: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1153" mnemonic="performCallIndirectPointer" kind="operation">
+        <name>Perform indirect function call.</name>
+        <description>It performs an indirect function with pointer result.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="function" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+
+            self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+            self ssPushNativeRegister: ReceiverResultReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutPointerResult: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1154" mnemonic="performCallIndirectStructure" kind="operation">
+        <name>Perform indirection function call.</name>
+        <description>It performs an indirect function with structure result.</description>
+        <arguments>
+            <extend-a name="structureSize" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="function" />
+            <pointer name="result" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="resultPointer" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+            "Push the result space"
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+            self PushR: TempReg.
+
+            "Fetch the function pointer"
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            "Call the function"
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+
+            "Fetch the result"
+            self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+            self ssPushNativeRegister: ReceiverResultReg.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            resultPointer := self lowcodeCallout: function structureResult: result.
+        </semantic>
+    </instruction>
+    <instruction opcode="1155" mnemonic="performCallIndirectVoid" kind="operation">
+        <name>Perform indirect function call.</name>
+        <description>It performs an indirect function without a result.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="function" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+
+            self callSwitchToCStack.
+            self CallRT: ceFFICalloutTrampoline.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutInt32Result: function.
+        </semantic>
+    </instruction>
+    <instruction opcode="1156" mnemonic="performCallInt32" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function with I32 result</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="result" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+
+            self callSwitchToCStack.
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+
+            self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+            self ssPushNativeRegister: ReceiverResultReg.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutInt32Result: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1157" mnemonic="performCallInt64" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function with I64 result</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="result" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+            self callSwitchToCStack.
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+
+            BytesPerWord = 4 ifTrue: [
+                self MoveR: backEnd cResultRegisterLow R: ReceiverResultReg.
+                self MoveR: backEnd cResultRegisterHigh R: Arg0Reg.
+                self ssPushNativeRegister: ReceiverResultReg secondRegister: Arg0Reg.
+            ] ifFalse: [
+                self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+                self ssPushNativeRegister: ReceiverResultReg.
+            ].
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutInt64Result: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1158" mnemonic="performCallPointer" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function with pointer result</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <pointer name="result" allocate="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+            self callSwitchToCStack.
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+
+            self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+            self ssPushNativeRegister: ReceiverResultReg.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self lowcodeCalloutPointerResult: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1159" mnemonic="performCallStructure" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function with structure result</description>
+        <arguments>
+            <extend-a name="function" />
+            <extend-b name="structureSize" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="result" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="resultPointer" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog/Raw">
+            "Push the result space"
+	        self ssNativeTop nativeStackPopToReg: TempReg.
+	        self ssNativePop: 1.
+            self PushR: TempReg.
+
+            "Call the function"
+            self callSwitchToCStack.
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+
+            "Fetch the result"
+            self MoveR: backEnd cResultRegister R: ReceiverResultReg.
+            self ssPushNativeRegister: ReceiverResultReg.
+            extA := 0.
+            extB := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self internalPushShadowCallStackPointer: result.
+            resultPointer := self lowcodeCalloutPointerResult: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1160" mnemonic="performCallVoid" kind="operation">
+        <name>Perform function call.</name>
+        <description>Performs a function without a result</description>
+        <arguments>
+            <extend-a name="function" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog/Raw">
+            self callSwitchToCStack.
+            self MoveCw: extA R: TempReg.
+            self CallRT: ceFFICalloutTrampoline.
+            extA := 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self lowcodeCalloutInt32Result: (self cCoerce: function to: #'char*').
+        </semantic>
+    </instruction>
+    <instruction opcode="1161" mnemonic="plaftormCode" kind="operation">
+        <name>Platform Code</name>
+        <description>
+            Returns the platform code
+        </description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <int32 name="code" />
+        </stack-results>
+    </instruction>
+    <instruction opcode="1162" mnemonic="pointerAddConstantOffset" kind="operation">
+        <name>Adds an offset to a pointer</name>
+        <description>Computes a new pointer by offseting an old one.</description>
+        <arguments>
+            <extend-b name="offset" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="base" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := base + offset.
+        </semantic>
+        <semantic language="Smalltalk/Cog">
+            self AddCq: offset R: base.
+            self ssPushNativeRegister: base.
+        </semantic>
+    </instruction>
+    <instruction opcode="1163" mnemonic="pointerAddOffset32" kind="operation">
+        <name>Adds an offset to a pointer</name>
+        <description>Computes a new pointer by offseting an old one.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="base" />
+            <int32 name="offset" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AddR: offset R: base.
+            self ssPushNativeRegister: base.
+        </semantic>
+        <semantic language="Pharo/VirtualCPU">
+            result := base + offset.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := base + offset.
+        </semantic>
+    </instruction>
+    <instruction opcode="1164" mnemonic="pointerAddOffset64" kind="operation">
+        <name>Adds an offset to a pointer</name>
+        <description>Computes a new pointer by offseting an old one.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="base" />
+            <int64 name="offset" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := base + offset.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self AddR: offset R: base.
+            self ssPushNativeRegister: base.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self AddR: offsetLow R: base.
+            self ssPushNativeRegister: base.
+        </semantic>
+    </instruction>
+    <instruction opcode="1165" mnemonic="pointerEqual" kind="operation">
+        <name>Pointer Equality</name>
+        <description>Pointer equality comparison.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="first" />
+            <pointer name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpNonZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first = second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1166" mnemonic="pointerNotEqual" kind="operation">
+        <name>Pointer Not Equality</name>
+        <description>Pointer not equality comparison.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="first" />
+            <pointer name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first ~= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1167" mnemonic="pointerToInt32" kind="operation">
+        <name>Pointer to Int32</name>
+        <description>It converts a pointer into a 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            "TODO: Perform a NOP here"
+            self ssPushNativeRegister: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: pointer to: 'uintptr_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1168" mnemonic="pointerToInt64" kind="operation">
+        <name>Pointer to Int64</name>
+        <description>It converts a pointer into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: pointer to: 'uintptr_t'.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self MoveR: pointer R: resultLow.
+            self MoveCq: 0 R: resultHigh.
+            self ssPushNativeRegister: resultLow secondRegister: resultHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssPushNativeRegister: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1169" mnemonic="popFloat32" kind="operation">
+        <name>Pop Float32</name>
+        <description>It removes the Float32 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Pharo/VirtualCPU" />
+        <semantic language="Smalltalk/Cog" />
+        <semantic language="C/Interpreter" />
+        <semantic language="Smalltalk/StackInterpreter" />
+        <semantic language="C++/LLVM" />
+    </instruction>
+    <instruction opcode="1170" mnemonic="popFloat64" kind="operation">
+        <name>Pop Float64</name>
+        <description>It removes the Float64 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Pharo/VirtualCPU" />
+        <semantic language="Smalltalk/Cog" />
+        <semantic language="C/Interpreter" />
+        <semantic language="Smalltalk/StackInterpreter" />
+        <semantic language="C++/LLVM" />
+    </instruction>
+    <instruction opcode="1171" mnemonic="popInt32" kind="operation">
+        <name>Pop Int32</name>
+        <description>It removes the Int32 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Pharo/VirtualCPU" />
+        <semantic language="Smalltalk/Cog" />
+        <semantic language="C/Interpreter" />
+        <semantic language="Smalltalk/StackInterpreter" />
+        <semantic language="C++/LLVM" />
+    </instruction>
+    <instruction opcode="1172" mnemonic="popInt64" kind="operation">
+        <name>Pop Int64</name>
+        <description>It removes the Int64 present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Pharo/VirtualCPU" />
+        <semantic language="Smalltalk/Cog" />
+        <semantic language="C/Interpreter" />
+        <semantic language="Smalltalk/StackInterpreter" />
+        <semantic language="C++/LLVM" />
+    </instruction>
+    <instruction opcode="1173" mnemonic="popMultipleNative" kind="multipop">
+        <name>Pop Pointer</name>
+        <description>It removes the Pointer present in the top of the stack</description>
+        <arguments>
+            <extend-a name="popSize" />
+        </arguments>
+        <stack-arguments />
+        <stack-results />
+
+        <semantic language="Smalltalk/Cog/Raw">
+            self ssPopNativeSize: extA.
+            extA := 0.
+        </semantic>
+
+        <semantic language="Smalltalk/StackInterpreter" >
+            self internalPopStackNativeSize: popSize.
+        </semantic>
+    </instruction>
+    <instruction opcode="1174" mnemonic="popPointer" kind="operation">
+        <name>Pop Pointer</name>
+        <description>It removes the Pointer present in the top of the stack</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointerValue" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Pharo/VirtualCPU" />
+        <semantic language="Smalltalk/Cog" />
+        <semantic language="C/Interpreter" />
+        <semantic language="Smalltalk/StackInterpreter" />
+        <semantic language="C++/LLVM" />
+    </instruction>
+    <instruction opcode="1175" mnemonic="pushConstantUInt32" kind="operation">
+        <name>Push a 32-bit integer constant</name>
+        <description>Pushes a 32-bit integer constant.</description>
+        <arguments>
+            <extend-a name="constant" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt32: constant.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := constant.
+        </semantic>
+    </instruction>
+    <instruction opcode="1176" mnemonic="pushConstantUInt64" kind="operation">
+        <name>Push a 64-bit integer constant</name>
+        <description>Pushes a 64-bit integer constant.</description>
+        <arguments>
+            <extend-a name="constant" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt64: constant.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := constant.
+        </semantic>
+    </instruction>
+    <instruction opcode="1177" mnemonic="pushNullPointer" kind="operation">
+        <name>Push Null Pointer</name>
+        <description>It pushes a null pointer</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <pointer name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantPointer: 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1178" mnemonic="pushOne32" kind="operation">
+        <name>Push one constant 32-bit integer</name>
+        <description>Pushes a 32 bit one constant</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt32: 1.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 1.
+        </semantic>
+    </instruction>
+    <instruction opcode="1179" mnemonic="pushOne64" kind="operation">
+        <name>Push one constant 64-bit integer</name>
+        <description>Pushes a 64 bit one constant</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt64: 1.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 1.
+        </semantic>
+    </instruction>
+    <instruction opcode="1180" mnemonic="pushOneFloat32" kind="operation">
+        <name>Push a single precision one constant</name>
+        <description>It pushes a single precision float of one</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantFloat32: 1.0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 1.0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1181" mnemonic="pushOneFloat64" kind="operation">
+        <name>Push a single precision one constant</name>
+        <description>It pushes a single precision float of one</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantFloat64: 1.0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 1.0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1182" mnemonic="pushPhysicalFloat32" kind="operation">
+        <name>Push Float32 from physical register</name>
+        <description>Pushes a Float32 from a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self lowcodeCalloutState: lowcodeCalloutState float32Register: registerID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1183" mnemonic="pushPhysicalFloat64" kind="operation">
+        <name>Push Float64 from physical register</name>
+        <description>Pushes an Float64 from a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <float64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self lowcodeCalloutState: lowcodeCalloutState float64Register: registerID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1184" mnemonic="pushPhysicalInt32" kind="operation">
+        <name>Push Int32 from physical register</name>
+        <description>Pushes an Int32 from a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self lowcodeCalloutState: lowcodeCalloutState int32Register: registerID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1185" mnemonic="pushPhysicalInt64" kind="operation">
+        <name>Push Int64 from physical register</name>
+        <description>Pushes an Int64 from a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self lowcodeCalloutState: lowcodeCalloutState int64Register: registerID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1186" mnemonic="pushPhysicalPointer" kind="operation">
+        <name>Push Pointer from physical register</name>
+        <description>Pushes a pointer from a physical CPU register.</description>
+        <arguments>
+            <extend-a name="registerID" />
+        </arguments>
+        <stack-arguments />
+        <stack-results>
+            <pointer name="pointerValue" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointerValue := self lowcodeCalloutState: lowcodeCalloutState pointerRegister: registerID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1187" mnemonic="pushSessionIdentifier" kind="operation">
+        <name>Pushes the unique session identifier</name>
+        <description>Computes a new pointer by offseting an old one.</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt32: coInterpreter getThisSessionID.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self getThisSessionID.
+        </semantic>
+    </instruction>
+    <instruction opcode="1188" mnemonic="pushZero32" kind="operation">
+        <name>Pushes zero constant</name>
+        <description>Pushes a 32 bit zero</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt32: 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1189" mnemonic="pushZero64" kind="operation">
+        <name>Pushes zero constant</name>
+        <description>Pushes a 64 bit zero</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantInt64: 0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1190" mnemonic="pushZeroFloat32" kind="operation">
+        <name>Pushes a zero single precision float constant</name>
+        <description>It pushes a single precision float zero</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantFloat32: 0.0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 0.0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1191" mnemonic="pushZeroFloat64" kind="operation">
+        <name>Pushes a zero single precision float constant</name>
+        <description>It pushes a single precision float zero</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssPushNativeConstantFloat64: 0.0.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := 0.0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1192" mnemonic="rem32" kind="operation">
+        <name>Integer Signed Remainder</name>
+        <description>Integer signed remainder without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self DivR: second R: first Quo: second Rem: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first \\ second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1193" mnemonic="rem64" kind="operation">
+        <name>Integer Signed Remainder</name>
+        <description>Integer signed remainder without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first \\ second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1194" mnemonic="rightShift32" kind="operation">
+        <name>Right Shift</name>
+        <description>Performs a right shifting.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+            <int32 name="shiftAmount" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self LogicalShiftRightR: shiftAmount R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value &gt;&gt; shiftAmount.
+        </semantic>
+    </instruction>
+    <instruction opcode="1195" mnemonic="rightShift64" kind="operation">
+        <name>Right Shift</name>
+        <description>Performs a right shifting.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+            <int64 name="shiftAmount" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value &gt;&gt; shiftAmount.
+        </semantic>
+    </instruction>
+    <instruction opcode="1196" mnemonic="signExtend32From16" kind="operation">
+        <name>Sign Extend 16-bit</name>
+        <description>Sign extends a 16 bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SignExtend16R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'signed short'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1197" mnemonic="signExtend32From8" kind="operation">
+        <name>Sign Extend 8-bit</name>
+        <description>Sign extends a 8-bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SignExtend8R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'signed char'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1198" mnemonic="signExtend64From16" kind="operation">
+        <name>Sign Extend 16-bit</name>
+        <description>Sign extends a 16 bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'int16_t'.
+        </semantic>
+        <semantic locals="isNegative cont" language="Smalltalk/Cog/32">
+            self SignExtend16R: valueLow R: valueLow.
+
+            "Check the sign to set the high word"
+            self CmpCq: 0 R: valueLow.
+
+            "Positive"
+            isNegative := self JumpLess: 0.
+            self MoveCq: 0 R: valueHigh.
+            cont := self Jump: 0.
+
+            "Negative"
+            isNegative jmpTarget: (self MoveCq: -1 R: valueHigh).
+            cont jmpTarget: self Label.
+
+            self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self SignExtend16R: value R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1199" mnemonic="signExtend64From32" kind="operation">
+        <name>Sign Extend 32-bit</name>
+        <description>Sign extends a 32 bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'int32_t'.
+        </semantic>
+        <semantic locals="isNegative cont" language="Smalltalk/Cog/32">
+            self MoveR: value R: resultLow.
+            "Check the sign to set the high word"
+            self CmpCq: 0 R: value.
+
+            "Positive"
+            isNegative := self JumpLess: 0.
+            self MoveCq: 0 R: resultHigh.
+            cont := self Jump: 0.
+
+            "Negative"
+            isNegative jmpTarget: (self MoveCq: -1 R: resultHigh).
+            cont jmpTarget: self Label.
+
+            self ssPushNativeRegister: resultLow secondRegister: resultHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self SignExtend32R: value R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1200" mnemonic="signExtend64From8" kind="operation">
+        <name>Sign Extend 8-bit</name>
+        <description>Sign extends a 8-bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'signed char'.
+        </semantic>
+        <semantic locals="isNegative cont" language="Smalltalk/Cog/32">
+            self SignExtend8R: valueLow R: valueLow.
+
+            "Check the sign to set the high word"
+            self CmpCq: 0 R: valueLow.
+
+            "Positive"
+            isNegative := self JumpLess: 0.
+            self MoveCq: 0 R: valueHigh.
+            cont := self Jump: 0.
+
+            "Negative"
+            isNegative jmpTarget: (self MoveCq: -1 R: valueHigh).
+            cont jmpTarget: self Label.
+
+            self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ZeroExtend16R: value R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1201" mnemonic="storeFloat32ToMemory" kind="operation">
+        <name>Store Float32 in memory</name>
+        <description>Stores a Float32 value to the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <float32 name="floatValue" />
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveRs: floatValue M32: 0 r: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self singleFloatAtPointer: pointer put: floatValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1202" mnemonic="storeFloat64ToMemory" kind="operation">
+        <name>Store Float64 in memory</name>
+        <description>Stores a Float64 value to the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <float64 name="doubleValue" />
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveRd: doubleValue M64: 0 r: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self floatAtPointer: pointer put: doubleValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1203" mnemonic="storeInt16ToMemory" kind="operation">
+        <name>Store UInt16 in memory</name>
+        <description>Stores an U16 value to the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveR: value R: TempReg.
+            self MoveR: TempReg M16: 0 r: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self int16AtPointer: pointer put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1204" mnemonic="storeInt32ToMemory" kind="operation">
+        <name>Store Int32 in memory</name>
+        <description>Stores an I32 value to the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveR: value M32: 0 r: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self int32AtPointer: pointer put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1205" mnemonic="storeInt64ToMemory" kind="operation">
+        <name>Store Int64 in memory</name>
+        <description>It stores an I64 value to the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            self int64AtPointer: pointer put: value.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self MoveR: valueLow M32: 0 r: pointer.
+            self MoveR: valueHigh M32: 4 r: pointer.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self MoveR: value M64: 0 r: pointer.
+        </semantic>
+    </instruction>
+    <instruction opcode="1206" mnemonic="storeInt8ToMemory" kind="operation">
+        <name>Store UInt8 in memory</name>
+        <description>Stores an U8 value to the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+            <pointer name="pointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveR: value R: TempReg.
+            self MoveR: TempReg M8: 0 r: pointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self int8AtPointer: pointer put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1207" mnemonic="storeLocalFloat32" kind="operation">
+        <name>Store single precision float in the stack frame</name>
+        <description>It stores a single precision float in the stack frame..</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <float32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveRs: value M32: 0 r: TempReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            stackPages singleFloatAtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP) put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1208" mnemonic="storeLocalFloat64" kind="operation">
+        <name>Store double precision float in the stack frame</name>
+        <description>It stores a double precision float in the stack frame.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <float64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveRd: value M64: 0 r: TempReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            stackPages floatAtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP) put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1209" mnemonic="storeLocalInt16" kind="operation">
+        <name>Store I16 to stack frame</name>
+        <description>It stores an I16 to the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveR: value R: TempReg.
+            self loadNativeLocalAddress: baseOffset to: value.
+            self MoveR: TempReg M16: 0 r: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            stackPages int16AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP) put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1210" mnemonic="storeLocalInt32" kind="operation">
+        <name>Store I32 to stack frame</name>
+        <description>It stores an I32 to the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveR: value M32: 0 r: TempReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            stackPages int32AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP) put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1211" mnemonic="storeLocalInt64" kind="operation">
+        <name>Store I64 to stack frame</name>
+        <description>It stores an I64 to the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog/32">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveR: valueLow M32: 0 r: TempReg.
+            self MoveR: valueHigh M32: 4 r: TempReg.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self MoveR: value M64: 0 r: TempReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter/Raw">
+            &lt;var: #valueInt64 type: #'sqLong'&gt;
+            |valueInt64|
+
+            BytesPerWord = 4 ifTrue: [
+                self lowcodeStoreLocalInt64Workaround: extA in: localFP sp: localSP.
+            ] ifFalse: [
+                valueInt64 := self internalPopStackInt64.
+                stackPages int64AtPointer: (self framePointerOfNativeLocal: extA in: localFP) put: valueInt64.
+            ].
+
+            extA := 0.
+        </semantic>
+    </instruction>
+    <instruction opcode="1212" mnemonic="storeLocalInt8" kind="operation">
+        <name>Store I8 to stack frame</name>
+        <description>It stores an I8 to the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveR: value R: TempReg.
+            self loadNativeLocalAddress: baseOffset to: value.
+            self MoveR: TempReg M8: 0 r: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            stackPages int8AtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP) put: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1213" mnemonic="storeLocalPointer" kind="operation">
+        <name>Store pointer in the stack frame</name>
+        <description>It stores a pointer in the stack frame memory.</description>
+        <arguments>
+            <local name="baseOffset" />
+        </arguments>
+        <stack-arguments>
+            <pointer name="pointerValue" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self loadNativeLocalAddress: baseOffset to: TempReg.
+            self MoveR: pointerValue Mw: 0 r: TempReg.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            stackPages pointerAtPointer: (self framePointerOfNativeLocal: baseOffset in: localFP) put: pointerValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1214" mnemonic="storePointerToMemory" kind="operation">
+        <name>Store a pointer in memory</name>
+        <description>Stores pointer int the memory.</description>
+        <arguments />
+        <stack-arguments>
+            <pointer name="pointerValue" />
+            <pointer name="memoryPointer" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            self MoveR: pointerValue Mw: 0 r: memoryPointer.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            self pointerAtPointer: memoryPointer put: pointerValue.
+        </semantic>
+    </instruction>
+    <instruction opcode="1215" mnemonic="sub32" kind="operation">
+        <name>Integer Subtraction</name>
+        <description>Integer subtraction without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self SubR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first - second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1216" mnemonic="sub64" kind="operation">
+        <name>Integer Subtraction</name>
+        <description>Integer subtraction without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first - second.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self SubR: secondLow R: firstLow.
+            self SubbR: secondHigh R: firstHigh.
+			self ssPushNativeRegister: firstLow secondRegister: firstHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self SubR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1217" mnemonic="truncate32To16" kind="operation">
+        <name>Truncate 32-bit to 16-bit integer</name>
+        <description>Truncates an integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AndCq: 16rFFFF R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitAnd: 16rFFFF.
+        </semantic>
+    </instruction>
+    <instruction opcode="1218" mnemonic="truncate32To8" kind="operation">
+        <name>Truncate 32-bit to 8-bit integer</name>
+        <description>Truncates an integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self AndCq: 16rFF R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitAnd: 16rFF.
+        </semantic>
+    </instruction>
+    <instruction opcode="1219" mnemonic="truncate64To16" kind="operation">
+        <name>Truncate 64-bit to 16-bit integer</name>
+        <description>Truncates an integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitAnd: 16rFFFF.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self AndCq: 16rFFFF R: valueLow.
+            self ssPushNativeRegister: valueLow.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self AndCq: 16rFFFF R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1220" mnemonic="truncate64To32" kind="operation">
+        <name>Truncate 64-bit to 32-bit integer</name>
+        <description>Truncates an integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitAnd: 16rFFFFFFFF.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssPushNativeRegister: valueLow.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self AndCq: 16rFFFFFFFF R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1221" mnemonic="truncate64To8" kind="operation">
+        <name>Truncate 64-bit to 8-bit integer</name>
+        <description>Truncates an integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := value bitAnd: 16rFF.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self AndCq: 16rFF R: valueLow.
+            self ssPushNativeRegister: valueLow.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self AndCq: 16rFF R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1222" mnemonic="udiv32" kind="operation">
+        <name>Integer Unsigned division</name>
+        <description>Integer unsigned division without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self DivR: second R: first Quo: first Rem: second.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := (self cCoerce: first to: 'unsigned int') //
+                        (self cCoerce: second to: 'unsigned int').
+        </semantic>
+    </instruction>
+    <instruction opcode="1223" mnemonic="udiv64" kind="operation">
+        <name>Integer Unsigned division</name>
+        <description>Integer unsigned division without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := (self cCoerce: first to: 'uint64_t') //
+                        (self cCoerce: second to: 'uint64_t').
+        </semantic>
+    </instruction>
+    <instruction opcode="1224" mnemonic="uint32Great" kind="operation">
+        <name>UInt32 Great Than</name>
+        <description>UInt32 great than.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpBelowOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'unsigned int') &gt;
+                        (self cCoerce: second to: 'unsigned int') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1225" mnemonic="uint32GreatEqual" kind="operation">
+        <name>UInt32 Great or Equal Than</name>
+        <description>UInt32 great or equal than.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpBelow: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'unsigned int') &gt;=
+                        (self cCoerce: second to: 'unsigned int') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1226" mnemonic="uint32Less" kind="operation">
+        <name>UInt32 Less Than</name>
+        <description>UInt32 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpAboveOrEqual: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'unsigned int') &lt;
+                        (self cCoerce: second to: 'unsigned int') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1227" mnemonic="uint32LessEqual" kind="operation">
+        <name>UInt32 Less or Equal Than</name>
+        <description>UInt32 less equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpAbove: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'unsigned int') &lt;=
+                        (self cCoerce: second to: 'unsigned int') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1228" mnemonic="uint32ToFloat32" kind="operation">
+        <name>UInt32 to Float32</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertR: value Rs: result.
+            self ssPushNativeRegisterSingleFloat: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: (self cCoerce: value to: 'unsigned int') to: 'float'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1229" mnemonic="uint32ToFloat64" kind="operation">
+        <name>UInt32 to Float64</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ConvertR: value Rd: result.
+            self ssPushNativeRegisterDoubleFloat: result.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: (self cCoerce: value to: 'unsigned int') to: 'double'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1230" mnemonic="uint64Great" kind="operation">
+        <name>UInt32 Great Than</name>
+        <description>UInt64 great than.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'uint64_t') &gt;
+                        (self cCoerce: second to: 'uint64_t') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1231" mnemonic="uint64GreatEqual" kind="operation">
+        <name>UInt64 Great or Equal Than</name>
+        <description>UInt64 great or equal than.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'uint64_t') &gt;=
+                        (self cCoerce: second to: 'uint64_t') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1232" mnemonic="uint64Less" kind="operation">
+        <name>UInt64 Less Than</name>
+        <description>UInt64 not equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'uint64_t') &lt;
+                        (self cCoerce: second to: 'uint64_t') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1233" mnemonic="uint64LessEqual" kind="operation">
+        <name>UInt64 Less or Equal Than</name>
+        <description>UInt64 less equal.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (self cCoerce: first to: 'uint64_t') &lt;=
+                        (self cCoerce: second to: 'uint64_t') ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="1234" mnemonic="uint64ToFloat32" kind="operation">
+        <name>UInt64 to Float32</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: (self cCoerce: value to: 'uint64_t') to: 'float'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1235" mnemonic="uint64ToFloat64" kind="operation">
+        <name>UInt64 to Float64</name>
+        <description>Converts an unsigned integer into a floating point number.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: (self cCoerce: value to: 'uint64_t') to: 'double'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1236" mnemonic="umul32" kind="operation">
+        <name>Integer Unsigned Multiplication</name>
+        <description>Integer addition without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self MulR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := (self cCoerce: first to: 'unsigned int') *
+                        (self cCoerce: second to: 'unsigned int').
+        </semantic>
+    </instruction>
+    <instruction opcode="1237" mnemonic="umul64" kind="operation">
+        <name>Integer Unsigned Multiplication</name>
+        <description>Integer addition without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := (self cCoerce: first to: 'uint64_t') *
+                        (self cCoerce: second to: 'uint64_t').
+        </semantic>
+    </instruction>
+    <instruction opcode="1238" mnemonic="unlockRegisters" kind="operation">
+        <name>Unlock Registers</name>
+        <description>
+            Unlocks the CPU register. This tells the register allocator that the
+            following instructions don't require specific CPU registers.
+        </description>
+        <arguments />
+        <stack-arguments />
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            "Do nothing for now"
+        </semantic>
+    </instruction>
+    <instruction opcode="1239" mnemonic="unlockVM" kind="operation">
+        <name>Unlock VM</name>
+        <description>Unlocks the VM from the current thread.</description>
+        <arguments />
+        <stack-arguments />
+        <stack-results />
+    </instruction>
+    <instruction opcode="1240" mnemonic="urem32" kind="operation">
+        <name>Integer Unsigned remainder</name>
+        <description>Integer unsigned remainder without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self DivR: second R: first Quo: second Rem: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := (self cCoerce: first to: 'unsigned int') \\
+                        (self cCoerce: second to: 'unsigned int').
+        </semantic>
+    </instruction>
+    <instruction opcode="1241" mnemonic="urem64" kind="operation">
+        <name>Integer Unsigned remainder</name>
+        <description>Integer unsigned remainder without overflow check.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := (self cCoerce: first to: 'unsigned int') \\
+                        (self cCoerce: second to: 'unsigned int').
+        </semantic>
+    </instruction>
+    <instruction opcode="1242" mnemonic="xor32" kind="operation">
+        <name>Bitwise Xor</name>
+        <description>Performs a bitwise xor operation.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="first" />
+            <int32 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self XorR: second R: first.
+			self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first bitXor: second.
+        </semantic>
+    </instruction>
+    <instruction opcode="1243" mnemonic="xor64" kind="operation">
+        <name>Bitwise Xor</name>
+        <description>Performs a bitwise xor operation.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="first" />
+            <int64 name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := first bitXor: second.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self XorR: secondLow R: firstLow.
+            self XorR: secondHigh R: firstHigh.
+            self ssPushNativeRegister: firstLow secondRegister: firstHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self XorR: second R: first.
+            self ssPushNativeRegister: first.
+        </semantic>
+    </instruction>
+    <instruction opcode="1244" mnemonic="zeroExtend32From16" kind="operation">
+        <name>Zero Extend 16-bit</name>
+        <description>Zero extends a 16 bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ZeroExtend16R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint16_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1245" mnemonic="zeroExtend32From8" kind="operation">
+        <name>Zero Extend 8-bit</name>
+        <description>Zero extends a 8-bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ZeroExtend8R: value R: value.
+			self ssPushNativeRegister: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint8_t'.
+        </semantic>
+    </instruction>
+    <instruction opcode="1246" mnemonic="zeroExtend64From16" kind="operation">
+        <name>Sign Extend 16-bit</name>
+        <description>Sign extends a 16 bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint16_t'.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ZeroExtend16R: valueLow R: valueLow.
+            self MoveCq: 0 R: valueHigh.
+            self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ZeroExtend16R: value R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1247" mnemonic="zeroExtend64From32" kind="operation">
+        <name>Sign Extend 32-bit</name>
+        <description>Sign extends a 32 bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int32 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint32_t'.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self MoveR: value R: resultLow.
+            self MoveCq: 0 R: resultHigh.
+            self ssPushNativeRegister: resultLow secondRegister: resultHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ZeroExtend32R: value R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="1248" mnemonic="zeroExtend64From8" kind="operation">
+        <name>Zero Extend 8-bit</name>
+        <description>Zero extends a 8-bit integer value.</description>
+        <arguments />
+        <stack-arguments>
+            <int64 name="value" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="result" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            result := self cCoerce: value to: 'uint8_t'.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ZeroExtend8R: valueLow R: valueLow.
+            self MoveCq: 0 R: valueHigh.
+            self ssPushNativeRegister: valueLow secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ZeroExtend8R: value R: value.
+            self ssPushNativeRegister: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="2000" mnemonic="byteSizeOf" kind="operation">
+        <name>Byte size of object</name>
+        <description>It tells the number of variable bytes of an object</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcByteSizeOf: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self byteSizeOf: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2001" mnemonic="firstFieldPointer" kind="operation">
+        <name>First Fixed Field</name>
+        <description>Loads the first fixed field address of an object into a register.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcFirstFieldPointer: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := objectMemory firstFixedField: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2002" mnemonic="firstIndexableFieldPointer" kind="operation">
+        <name>First Indexable Field</name>
+        <description>Loads the first indexable field address of an object into a register.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcFirstIndexableFieldPointer: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := objectMemory firstIndexableField: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2003" mnemonic="isBytes" kind="operation">
+        <name>Is bytes object</name>
+        <description>It tells if an object is bytes variable.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsBytes: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isBytes: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2004" mnemonic="isFloatObject" kind="operation">
+        <name>Is float object</name>
+        <description>It tells if an object is a float.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsFloatObject: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isFloatObject: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2005" mnemonic="isIndexable" kind="operation">
+        <name>Is indexable object</name>
+        <description>It tells if an object is an indexable.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsIndexable: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isIndexable: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2006" mnemonic="isIntegerObject" kind="operation">
+        <name>Is integer object</name>
+        <description>It tells if an object is an integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsIntegerObject: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isIntegerObject: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2007" mnemonic="isPointers" kind="operation">
+        <name>Is pointers object</name>
+        <description>It tells if an object contains pointers.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsPointers: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isPointers: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2008" mnemonic="isWords" kind="operation">
+        <name>Is Words object</name>
+        <description>It tells if an object is words variable.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsWords: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isWords: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2009" mnemonic="isWordsOrBytes" kind="operation">
+        <name>Is bytes object</name>
+        <description>It tells if an object is bytes variable.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcIsWordsOrBytes: object to: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := (objectMemory isWordsOrBytes: object) ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="2010" mnemonic="oopSmallIntegerToInt32" kind="operation">
+        <name>Oop to Int</name>
+        <description>It decodes an Oop representing a small integer into an integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genConvertSmallIntegerToIntegerInReg: object.
+            self ssPushNativeRegister: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := objectMemory integerValueOf: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2011" mnemonic="oopSmallIntegerToInt64" kind="operation">
+        <name>Oop to Int</name>
+        <description>It decodes an Oop representing a small integer boolean into a64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := objectMemory integerValueOf: object.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            objectRepresentation genConvertSmallIntegerToIntegerInReg: object.
+            self MoveCq: 0 R: valueHigh.
+            self ssPushNativeRegister: object secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            objectRepresentation genConvertSmallIntegerToIntegerInReg: object.
+            self ssPushNativeRegister: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2012" mnemonic="oopToBoolean32" kind="operation">
+        <name>Oop to Boolean</name>
+        <description>Decodes an Oop representing a boolean into an integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self booleanValueOf: object.
+        </semantic>
+        <semantic language="Smalltalk/Cog">
+            self annotate: (self SubCw: objectMemory falseObject R: object) objRef: objectMemory falseObject.
+            self ssPushNativeRegister: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2013" mnemonic="oopToBoolean64" kind="operation">
+        <name>Oop to Boolean</name>
+        <description>Decodes an Oop representing a boolean into an integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self booleanValueOf: object.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self MoveCq: 0 R: valueHigh.
+            self annotate: (self SubCw: objectMemory falseObject R: object) objRef: objectMemory falseObject.
+            self ssPushNativeRegister: object secondRegister: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self annotate: (self SubCw: objectMemory falseObject R: object) objRef: objectMemory falseObject.
+            self ssPushNativeRegister: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2014" mnemonic="oopToFloat32" kind="operation">
+        <name>Oop to Int</name>
+        <description>
+            It decodes an Oop representing floating point number into a single
+            precision IEEE-754 floating point number.
+        </description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <float32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcOop: object toFloat32: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := objectMemory floatValueOf: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2015" mnemonic="oopToFloat64" kind="operation">
+        <name>Oop to Int</name>
+        <description>
+            It decodes an Oop representing floating point number into a double
+            precision IEEE-754 floating point number.
+        </description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <float64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            self ssFlushAll.
+            objectRepresentation genLcOop: object toFloat64: value.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := objectMemory floatValueOf: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2016" mnemonic="oopToInt32" kind="operation">
+        <name>Oop to Int</name>
+        <description>It decodes an Oop an integer into signed 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+        	self ssFlushAll.
+            objectRepresentation genLcOopToInt32: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self signed32BitValueOf: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2017" mnemonic="oopToInt64" kind="operation">
+        <name>Oop to Int</name>
+        <description>It decodes an Oop representing a signed integer into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self signed64BitValueOf: object.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssFlushAll.
+            objectRepresentation genLcOop: object toInt64: valueLow highPart: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssFlushAll.
+            objectRepresentation genLcOopToInt64: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2018" mnemonic="oopToPointer" kind="operation">
+        <name>Oop to Pointer</name>
+        <description>Extracts a pointer encoded in an indexable such as NBExternalAddress.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" aliased="true" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcOopToPointer: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := self pointerAtPointer: (objectMemory firstIndexableField: object).
+        </semantic>
+    </instruction>
+    <instruction opcode="2019" mnemonic="oopToPointerReinterpret" kind="operation">
+        <name>Cast Oop to Pointer Reinterpret</name>
+        <description>Reinterpret casts an Oop into a pointer.
+        </description>
+        <warning>Reinterpret casts an Oop into a pointer.
+        </warning>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <pointer name="pointer" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+            "TODO: Generate a nop here"
+            self ssPushNativeRegister: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            pointer := self cCoerce: object to: 'char*'.
+        </semantic>
+    </instruction>
+    <instruction opcode="2020" mnemonic="oopToUInt32" kind="operation">
+        <name>Oop to Int</name>
+        <description>It decodes an Oop representing an integer into an unsigned 32-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/Cog">
+        	self ssFlushAll.
+            objectRepresentation genLcOopToUInt32: object.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self positive32BitValueOf: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2021" mnemonic="oopToUInt64" kind="operation">
+        <name>Oop to Int</name>
+        <description>It decodes an Oop representing an unsigned integer into a 64-bit integer.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results>
+            <int64 name="value" />
+        </stack-results>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := self positive64BitValueOf: object.
+        </semantic>
+        <semantic language="Smalltalk/Cog/32">
+            self ssFlushAll.
+            objectRepresentation genLcOop: object toUInt64: valueLow highPart: valueHigh.
+        </semantic>
+        <semantic language="Smalltalk/Cog/64">
+            self ssFlushAll.
+            objectRepresentation genLcOopToUInt64: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2022" mnemonic="pin" kind="operation">
+        <name>Pin Object</name>
+        <description>Pins an Oop pointed object</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            objectMemory pinObject: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="2023" mnemonic="unpin" kind="operation">
+        <name>Unpin Object</name>
+        <description>Unpins an Oop pointed object</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/StackInterpreter">
+            objectMemory unpinObject: object.
+        </semantic>
+    </instruction>
+    <instruction opcode="3000" mnemonic="oopEqual" kind="operation">
+        <name>Oop Equality</name>
+        <description>Oop identity comparison.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="first" />
+            <oop name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpNonZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first = second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="3001" mnemonic="oopNotEqual" kind="operation">
+        <name>Oop Not Equality</name>
+        <description>Oop not identity comparison.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="first" />
+            <oop name="second" />
+        </stack-arguments>
+        <stack-results>
+            <int32 name="value" aliased="true" />
+        </stack-results>
+        <semantic locals="falseJump contJump" language="Smalltalk/Cog">
+            self CmpR: second R: first.
+            falseJump := self JumpZero: 0.
+
+            "True result"
+            self MoveCq: 1 R: first.
+            contJump := self Jump: 0.
+
+            "False result"
+            falseJump jmpTarget: self Label.
+            self MoveCq: 0 R: first.
+
+            contJump jmpTarget: self Label.
+            self ssPushNativeRegister: first.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            value := first ~= second ifTrue: [1] ifFalse: [0].
+        </semantic>
+    </instruction>
+    <instruction opcode="3002" mnemonic="storeObjectField" kind="operation">
+        <name>Store an object field</name>
+        <description>This instruction stores an object into a field of an object.</description>
+        <arguments>
+            <extend-a name="fieldIndex" />
+        </arguments>
+        <stack-arguments>
+            <oop name="object" />
+            <oop name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcStore: value object: object field: fieldIndex.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            objectMemory storePointer: fieldIndex ofObject: object withValue: value.
+        </semantic>
+    </instruction>
+    <instruction opcode="3003" mnemonic="storeObjectFieldAt" kind="operation">
+        <name>Store an object field</name>
+        <description>This instruction stores an object into a field of an object.</description>
+        <arguments />
+        <stack-arguments>
+            <oop name="object" />
+            <int32 name="fieldIndex" />
+            <oop name="value" />
+        </stack-arguments>
+        <stack-results />
+        <semantic language="Smalltalk/Cog">
+            objectRepresentation genLcStore: value object: object at: fieldIndex.
+        </semantic>
+        <semantic language="Smalltalk/StackInterpreter">
+            objectMemory storePointer: fieldIndex ofObject: object withValue: value.
+        </semantic>
+    </instruction>
+</lowcode>


### PR DESCRIPTION
These are the changes in the support sources that are required by the LowcodeVM.

I am also putting a copy of the full XML based specification of the Lowcode instruction set that is used to generate the StackInterpreter and Cogit implementation of the instructions.

The Lowcode SmalltalkHub project ( http://smalltalkhub.com/#!/~ronsaldo/Lowcode ) contains the generator scripts.

To generate the implementations of the Lowcode instructions to the StackInterpreter and the Cogit, the following script can be used:

LowcodeCogitGenerator generateFromFileNamed: 'lowcode.xml' to: 'LowcodeCog.st'

To generate the IRLowcodeBuilder (extended OpalCompiler IRBuilder) generation methods, the following script can be used:

LowcodeOpalCompilerGenerator generateFromFileNamed: 'lowcode.xml'.

For generating the x86 assembly for testing, I am using a script like the following one:

compilationContext := CompilationContext new encoderClass: OpalEncoderForSistaV1.
ir := IRLowcodeBuilder buildIR: [ :builder |
	builder compilationContext: compilationContext.
	builder
		numArgs: 0;
		addTemps: #(__lowcodeFrameMark __lowcodePreviousNativeStackPointer__ __lowcodeNativeFramePointer__ __lowcodeNativeStackPointer__ __lowcodeCalloutState__);
		
		lowcodePushOneFloat32;
		lowcodeDuplicateFloat32;
		lowcodeFloat32Add;
		lowcodeFloat32ToOop;
		returnTop
].
method := ir compiledMethod.
method setSignFlag.
method setFrameBit: true.

StackToRegisterMappingCogit genAndDis: method options: #(
		SistaVM true
		LowcodeVM true
		MULTIPLEBYTECODESETS true
		bytecodeTableInitializer initializeBytecodeTableForSqueakV3PlusClosuresSistaV1Hybrid
		ObjectMemory Spur32BitCoMemoryManager
		FailImbalancedPrimitives false
		ISA IA32).

The first instruction of a method that uses Lowcode must be localFrameSize: . This instructions builds
a stack frame that is used for primitive local variables, the secondary native stack, and it is never inspected by the GC. A Lowcode native stack frame is always pinned.

For tracking the presence of a native stack frame, and the necesity of cleaning the native stack frame when returning from a method, the temporary is used as flag by putting a special object that is compared by identity. I used this approach because I did not find any available bit in the stack frame for putting this flag. It also has the advantage of giving room for implementing a mechanism for native stack context mapping, by replacing this mark object with an object that represents a stack frame that should not be cleaned up on method return, and to avoid the overhead of allocating a complete object on the start of a Lowcode method.

For doing callout from the StackInterpreter, the lowcodeCalloutState is used by the interpreter. The StackInterpreter cannot use the normal C stack immediately because it pushes a big pressure in the C compiler. The Cogit version just uses the C stack for the callouts.
