### PR TITLE
FilePlugin: Remove misleading check for end of line

### DIFF
--- a/FilePlugin/sqFilePluginBasicPrims.c
+++ b/FilePlugin/sqFilePluginBasicPrims.c
@@ -395,12 +395,8 @@ sqFileReadIntoAt(SQFile *f, size_t count, char* byteArrayIndex, size_t startInde
 		bytesRead = 0;
 		do {
 			clearerr(file);
-			if (fread(dst, 1, 1, file) == 1) {
+			if (fread(dst, 1, 1, file) == 1)
 				bytesRead += 1;
-				if (dst[bytesRead-1] == '\n'
-				 || dst[bytesRead-1] == '\r')
-					break;
-			}
 		}
 		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
 #if COGMTVM


### PR DESCRIPTION
When operating on stdin sqFileReadIntoAt will read one zero or one
byte from the FILE*. The loop will exit when bytesRead is not zero
and this will happen when a character was read. There is no reason
to exit the loop differently for \r or \n.
