### PR TITLE
OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ can be found in Cog, or in various Monticello packages in various repositories.
 Each vm source directory contains several files, a subset of the following:
 ```
 	cogit.c				- the JIT; a Cogit cooperates with a CoInterpreter.
-                          This simply includes a proessor-specific JIT file
+                          This simply includes a processor-specific JIT file
 	cogitIA32.c et al   - relevant processor-specific JIT, selected by cogit.c
 	cogit.h				- the Cogit's API, as used by the CoInterpreter
 	cogmethod.h			- the structure of a CogMethod, the output of the Cogit
@@ -160,33 +160,39 @@ the necessary steps to compile a VM.
 Within each build.OS_WordSize_Processor directory are a set of build directories
 for specific configurations of Cog, and for support code and makefiles.  For
 example, there exist
+```
 	build.macos32x86/squeak.cog.spur   - A Cog JIT VM with Squeak branding,
                                          using the Spur memory manager.
 	build.macos32x86/squeak.stack.spur - A Stack interpreter VM with Squeak
                                          branding, and the Spur memory manager.
 	build.macos32x86/squeak.cog.v3     - A Cog JIT VM with Squeak branding,
-                                         iusing the old Squeak memory manager.
+                                         using the old Squeak memory manager.
 	build.macos32x86/pharo.cog.spur    - A Cog JIT VM with Pharo branding and
                                          plugins (not yet implemented) using the
                                          Spur memory manager.
+```
     etc.
 
 There exist
+```
     build.macos32x86/bochsx86 - Support libraries for the BochsIA32Plugin which
                                 is used to develop Cog itself.
     build.macos32x86/bochsx64 - Support libraries for the BochsX64Plugin which
                                 is used to develop Cog itself.
     build.macos32x86/gdbarm32 - Support libraries for the GdbARMPlugin which
                                 is used to develop Cog itself.
+```
 and the intention is to add such directories to contain e.g. support code for
 the Pharo Cairo and Freetype plugins, and anything else needed.  By placing
 support directories in each build directory they can be shared between various
 branded VM builds, avoiding duplication.
 
 There exist
+```
 	build.macos32x86/common - Gnu Makefiles for building the various branded VMs
 	build.macos64x64/common - Gnu Makefiles for building the various branded VMs
 	build.win32x86/common   - Gnu Makefiles for building the various branded VMs
+```
 And the intention is to add build.linuxNN????/common as soon as possible to
 use Gnu Makefiles to build all VMs on all platfrms.
 

--- a/build.linux64x64/squeak.cog.spur/build/mvm
+++ b/build.linux64x64/squeak.cog.spur/build/mvm
@@ -7,6 +7,17 @@ case `gcc -v 2>&1 | grep version | sed 's/gcc version *//'` in
 *)		OPT="-g -O2 -DNDEBUG -DDEBUGVM=0";;
 esac
 
+CFLAGS="$OPT -msse2 -D_GNU_SOURCE -DCOGMTVM=0"
+LIBS="-lpthread -luuid"
+LDFLAGS="-Wl,-z,now"
+case $(uname -s) in
+  OpenBSD)
+           CFLAGS="$CFLAGS -I/usr/local/include"
+           LIBS="$LIBS -lexecinfo"
+           LDFLAGS="$LDFLAGS -L/usr/local/lib"
+           ;;
+esac
+
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
@@ -24,9 +35,9 @@ test -f config.h || ../../../platforms/unix/config/configure --without-npsqueak 
 		--with-src=spur64src \
 	CC="gcc -m64" \
 	CXX="g++ -m64" \
-	CFLAGS="$OPT -msse2 -D_GNU_SOURCE -DCOGMTVM=0" \
-	LIBS="-lpthread -luuid" \
-	LDFLAGS=-Wl,-z,now
+	CFLAGS="$CFLAGS" \
+	LIBS="$LIBS" \
+	LDFLAGS="$LDFLAGS"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`

--- a/build.linux64x64/squeak.cog.spur/build/mvm
+++ b/build.linux64x64/squeak.cog.spur/build/mvm
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Spur VM with VM profiler and threaded heartbeat
 INSTALLDIR=cogspur64linuxht
 # Some gcc versions create a broken VM using -O2

--- a/image/buildspurtrunk64image.sh
+++ b/image/buildspurtrunk64image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 . ./envvars.sh
 
 test -f SpurVMMaker.image || ./buildspurtrunkvmmakerimage.sh

--- a/image/buildspurtrunkvmmakerimage.sh
+++ b/image/buildspurtrunkvmmakerimage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 . ./envvars.sh
 
 ./updatespurimage.sh

--- a/image/getsqueak50.sh
+++ b/image/getsqueak50.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 . ./envvars.sh
 
 IMAGEHASH=e6be0ea204a8409dc0976a792502ab65

--- a/image/updatespurimage.sh
+++ b/image/updatespurimage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Update the latest Spur image.
 . ./envvars.sh
 

--- a/image/updatevmmakerimage.sh
+++ b/image/updatevmmakerimage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Update the latest Spur image.
 . ./envvars.sh
 

--- a/platforms/Cross/plugins/SqueakFFIPrims/sqFFIPlugin.c
+++ b/platforms/Cross/plugins/SqueakFFIPrims/sqFFIPlugin.c
@@ -8,7 +8,7 @@
 *****************************************************************************/
 
 #include <stdio.h>
-#if !WIN32 && !__FreeBSD__
+#if !WIN32 && !__FreeBSD__ && !__OpenBSD__
 # include <alloca.h>
 #endif
 #include <string.h>

--- a/platforms/unix/config/bin.squeak.sh.in
+++ b/platforms/unix/config/bin.squeak.sh.in
@@ -17,6 +17,11 @@ case "$BIN" in
 /*) PLUGINS="$BIN";;
 *) PLUGINS="`pwd`/$BIN"
 esac
+
+if [ $(uname -s) = "OpenBSD" ]; then
+  LD_LIBRARY_PATH="$PLUGINS:${LD_LIBRARY_PATH}" exec $GDB "$BIN/squeak" "$@"
+fi
+
 # On some linuxes there multiple versions of the C library.  If the image uses
 # libc (e.g. through the FFI) then it must use the same version that the VM uses
 # and so it should take precedence over /lib libc.  This is done by setting

--- a/platforms/unix/config/squeak.sh.in
+++ b/platforms/unix/config/squeak.sh.in
@@ -17,6 +17,11 @@ case "$BIN" in
 /*) PLUGINS="$BIN";;
 *) PLUGINS="`pwd`/$BIN"
 esac
+
+if [ $(uname -s) = "OpenBSD" ]; then
+  LD_LIBRARY_PATH="$PLUGINS:${LD_LIBRARY_PATH}" exec $GDB "$BIN/squeak" "$@"
+fi
+
 # On some linuxes there multiple versions of the C library.  If the image uses
 # libc (e.g. through the FFI) then it must use the same version that the VM uses
 # and so it should take precedence over /lib libc.  This is done by setting

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -59,6 +59,9 @@
 # include <execinfo.h>
 # define BACKTRACE_DEPTH 64
 #endif
+#if __OpenBSD__
+# include <sys/signal.h>
+#endif
 #if __FreeBSD__
 # include <sys/ucontext.h>
 #endif
@@ -870,6 +873,9 @@ reportStackState(char *msg, char *date, int printAll, ucontext_t *uap)
 # elif __FreeBSD__ && __i386__
 			void *fp = (void *)(uap ? uap->uc_mcontext.mc_ebp: 0);
 			void *sp = (void *)(uap ? uap->uc_mcontext.mc_esp: 0);
+# elif __OpenBSD__
+			void *fp = (void *)(uap ? uap->sc_rbp: 0);
+			void *sp = (void *)(uap ? uap->sc_rsp: 0);
 # elif __sun__ && __i386__
       void *fp = (void *)(uap ? uap->uc_mcontext.gregs[REG_FP]: 0);
       void *sp = (void *)(uap ? uap->uc_mcontext.gregs[REG_SP]: 0);

--- a/platforms/unix/vm/sqUnixVMProfile.c
+++ b/platforms/unix/vm/sqUnixVMProfile.c
@@ -50,7 +50,11 @@ ioClearProfile(void)
 #	define __USE_GNU /* to get register defines in sys/ucontext.h */
 # endif
 #endif
+#ifdef __OpenBSD__
+#include <sys/signal.h>
+#else
 #include <sys/ucontext.h>
+#endif
 #if  __linux__ && UNDEF__USE_GNU
 # undef __USE_GNU
 #endif
@@ -185,6 +189,8 @@ pcbufferSIGPROFhandler(int sig, siginfo_t *info, ucontext_t *uap)
 # define _PC_IN_UCONTEXT uc_mcontext.arm_pc
 #elif __FreeBSD__ && __i386__
 # define _PC_IN_UCONTEXT uc_mcontext.mc_eip
+#elif __OpenBSD__
+# define _PC_IN_UCONTEXT sc_rip
 #else
 # error need to implement extracting pc from a ucontext_t on this system
 #endif

--- a/scripts/updateSCCSVersions
+++ b/scripts/updateSCCSVersions
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # checkin script for Git that serves to cause
 # platforms/Cross/vm/sqSCCSVersion.h to be checked-in so that its version
 # info reflects that of the current check-in.

--- a/src/plugins/UnixOSProcessPlugin/UnixOSProcessPlugin.c
+++ b/src/plugins/UnixOSProcessPlugin/UnixOSProcessPlugin.c
@@ -24,6 +24,10 @@ static char __buildInfo[] = "UnixOSProcessPlugin VMConstruction-Plugins-OSProces
 #include <pthread.h>
 #include <errno.h>
 
+#ifdef __OpenBSD__
+#include <sys/signalvar.h>
+#endif
+
 /* Default EXPORT macro that does nothing (see comment in sq.h): */
 #define EXPORT(returnType) returnType
 

--- a/src/plugins/VMProfileLinuxSupportPlugin/VMProfileLinuxSupportPlugin.c
+++ b/src/plugins/VMProfileLinuxSupportPlugin/VMProfileLinuxSupportPlugin.c
@@ -13,6 +13,12 @@ static char __buildInfo[] = "VMProfileLinuxSupportPlugin VMMaker.oscog-eem.1851 
 #include <string.h>
 #include <time.h>
 #include <limits.h>
+#ifdef __OpenBSD__
+#include <dlfcn.h>
+#define RTLD_MODE RTLD_LAZY
+#else
+#define RTLD_MODE (RTLD_LAZY | RTLD_NODELETE)
+#endif
 #ifndef _GNU_SOURCE
 # define _GNU_SOURCE
 #endif
@@ -171,7 +177,7 @@ primitiveDLSymInLibrary(void)
 	symName = malloc(sz + 1);
 	strncpy(symName, firstIndexableField(nameObj), sz);
 	symName[sz] = 0;
-	lib = dlopen(libName, RTLD_LAZY | RTLD_NODELETE);
+	lib = dlopen(libName, RTLD_MODE);
 	if (!(lib)) {
 		free(libName);
 		free(symName);


### PR DESCRIPTION
makes build.linux64x64/squeak.cog.spur/build compile on OpenBSD 6.0

removes dependency on bash, since a) it is not necessary and b) it would require an additional package installation on OpenBSD
