### PR TITLE
Download PharoXXX.sources if its not found in the usual location.

### DIFF
--- a/build.linux32ARMv6/editpharoinstall.sh
+++ b/build.linux32ARMv6/editpharoinstall.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # Edit the installed directory tree to rename squeak to pharo and install source
-INSTALLDIR="$1"
+OSVMROOTDIR=$(cd ../../..; pwd)
 
+INSTALLDIR="$1"
 shift
 cd $INSTALLDIR
 
@@ -11,8 +12,10 @@ if [ "$1" = -source ]; then
 else
 	SourceFile="PharoV50"
 fi
-SOURCE=../../sources/$SourceFile.sources
-test -f $SOURCE || SOURCE=../../../sources/$SourceFile.sources
+mkdir -p "$OSVMROOTDIR/sources"
+SOURCE=$OSVMROOTDIR/sources/$SourceFile.sources
+test -f $SOURCE || wget -O $SOURCE http://files.pharo.org/sources/$SourceFile
+
 if [ -f squeak ]; then
 	mv squeak pharo
 	sed -i 's/squeak/pharo/g' pharo

--- a/build.linux32x86/editpharoinstall.sh
+++ b/build.linux32x86/editpharoinstall.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # Edit the installed directory tree to rename squeak to pharo and install source
-INSTALLDIR="$1"
+OSVMROOTDIR=$(cd ../../..; pwd)
 
+INSTALLDIR="$1"
 shift
 cd $INSTALLDIR
 
@@ -11,8 +12,10 @@ if [ "$1" = -source ]; then
 else
 	SourceFile="PharoV50"
 fi
-SOURCE=../../sources/$SourceFile.sources
-test -f $SOURCE || SOURCE=../../../sources/$SourceFile.sources
+mkdir -p "$OSVMROOTDIR/sources"
+SOURCE=$OSVMROOTDIR/sources/$SourceFile.sources
+test -f $SOURCE || wget -O $SOURCE http://files.pharo.org/sources/$SourceFile
+
 if [ -f squeak ]; then
 	mv squeak pharo
 	sed -i 's/squeak/pharo/g' pharo

--- a/build.linux64x64/editpharoinstall.sh
+++ b/build.linux64x64/editpharoinstall.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # Edit the installed directory tree to rename squeak to pharo and install source
-INSTALLDIR="$1"
+OSVMROOTDIR=$(cd ../../..; pwd)
 
+INSTALLDIR="$1"
 shift
 cd $INSTALLDIR
 
@@ -11,8 +12,10 @@ if [ "$1" = -source ]; then
 else
 	SourceFile="PharoV50"
 fi
-SOURCE=../../sources/$SourceFile.sources
-test -f $SOURCE || SOURCE=../../../sources/$SourceFile.sources
+mkdir -p "$OSVMROOTDIR/sources"
+SOURCE=$OSVMROOTDIR/sources/$SourceFile.sources
+test -f $SOURCE || wget -O $SOURCE http://files.pharo.org/sources/$SourceFile
+
 if [ -f squeak ]; then
 	mv squeak pharo
 	sed -i 's/squeak/pharo/g' pharo


### PR DESCRIPTION
If someone makes a fresh clone of the repository then the PharoXXX.sources file wont exist and a fresh-out-of-the-box Pharo build won't succeed.  So download it from its well known location. 
