### PR TITLE
replaces sprintf with snprintf

### DIFF
--- a/platforms/Cross/vm/dispdbg.h
+++ b/platforms/Cross/vm/dispdbg.h
@@ -149,7 +149,7 @@ void closeBytecodeTraceFile() { if (bct) { fclose(bct); bct = 0; } }
 # endif
 # define bytecodeDispatchDebugHook() do { char line[64], expected[64]; \
 	/* print byteCount pc byteCode(hex) stackPtr */ \
-	sprintf(expected, "%ld: %d %d(%x) %d %s\n", \
+	snprintf(expected, sizeof(expected), "%ld: %d %d(%x) %d %s\n", \
 			++GIV(byteCount), localIP-GIV(method)-3, currentBytecode, currentBytecode, \
 			(localFP-localSP)/sizeof(sqInt)-5, bytecodeNameTable[currentBytecode]); \
 	printf(expected); \

--- a/platforms/Cross/vm/sqSCCSVersion.h
+++ b/platforms/Cross/vm/sqSCCSVersion.h
@@ -128,7 +128,7 @@ sourceVersionString(char separator)
 				+ strlen(pluginsRevisionAsString())
 				+ strlen(pluginsRepositoryURL());
 		sourceVersion = malloc(len);
-		sprintf(sourceVersion, fmt,
+		snprintf(sourceVersion, len, fmt,
 				revisionAsString(), repositoryURL(), revisionDateAsString(),
 				separator,
 				pluginsRevisionAsString(), pluginsRepositoryURL());

--- a/platforms/unix/vm/sqUnixCharConv.c
+++ b/platforms/unix/vm/sqUnixCharConv.c
@@ -251,7 +251,7 @@ static void iconvFail(char *toCode, char *fromCode)
   if (!warned++)
     {
       char buf[256];
-      sprintf(buf, "iconv_open(%s, %s)", toCode, fromCode);
+      snprintf(buf, sizeof(buf), "iconv_open(%s, %s)", toCode, fromCode);
       perror(buf);
     }
 }

--- a/platforms/unix/vm/sqUnixExternalPrims.c
+++ b/platforms/unix/vm/sqUnixExternalPrims.c
@@ -161,7 +161,8 @@ tryLoadModule(char *in, char *name)
       continue;
     }
   }
-  sprintf(out, "/" MODULE_PREFIX "%s" MODULE_SUFFIX, name);
+  snprintf(out, sizeof(path) - (out - path),
+    "/" MODULE_PREFIX "%s" MODULE_SUFFIX, name);
   handle= dlopen(path, RTLD_NOW | RTLD_GLOBAL);
   DPRINTF((stderr, __FILE__ " %d tryLoading dlopen(%s) = %p\n", __LINE__, path, handle));
   if (!handle) {
@@ -202,11 +203,7 @@ void *ioLoadModule(char *pluginName)
 
   /* try dlopen()ing LIBRARY_PREFIX<name>LIBRARY_SUFFIX searching only the default locations modulo LD_LIBRARY_PATH et al */
 
-# if defined(HAVE_SNPRINTF)
   snprintf(path, sizeof(path), "%s%s%s", LIBRARY_PREFIX, pluginName, LIBRARY_SUFFIX);
-# else
-  sprintf(path, "%s%s%s", LIBRARY_PREFIX, pluginName, LIBRARY_SUFFIX);
-# endif
 
   handle= dlopen(path, RTLD_NOW | RTLD_GLOBAL);
   DPRINTF((stderr, __FILE__ " %d ioLoadModule dlopen(%s) = %p%s\n", __LINE__, path, handle, handle ? "" : dlerror()));
@@ -236,7 +233,7 @@ tryLoading(char *dirName, char *moduleName)
 		char        libName[NAME_MAX + 32];	/* headroom for prefix/suffix */
 		struct stat buf;
 		int         n;
-		n = sprintf(libName,"%s%s%s%s",dirName,*prefix,moduleName,*suffix);
+		n = snprintf(libName, sizeof(libName), "%s%s%s%s",dirName,*prefix,moduleName,*suffix);
 		assert(n >= 0 && n < NAME_MAX + 32);
 		if (!stat(libName, &buf)) {
 			if (S_ISDIR(buf.st_mode))
@@ -277,7 +274,7 @@ static void *tryLoadingPath(char *varName, char *pluginName)
 	   path= strtok(0, ":"))
 	{
 	  char buf[MAXPATHLEN];
-	  sprintf(buf, "%s/", path);
+	  snprintf(buf, sizeof(buf), "%s/", path);
 	  DPRINTF((stderr, "  path dir = %s\n", buf));
 	  if ((handle= tryLoading(buf, pluginName)) != 0)
 	    break;
@@ -384,7 +381,7 @@ ioLoadModule(char *pluginName)
     for (framework= frameworks;  *framework;  ++framework)
       {
 	char path[NAME_MAX];
-	sprintf(path, "%s/%s.framework/", *framework, pluginName);
+	snprintf(path, sizeof(path), "%s/%s.framework/", *framework, pluginName);
 	if ((handle= tryLoading(path, pluginName)))
 	  return handle;
       }
@@ -394,11 +391,7 @@ ioLoadModule(char *pluginName)
   /* finally (for VM hackers) try the pre-install build location */
   {
     char pluginDir[MAXPATHLEN];
-#  ifdef HAVE_SNPRINTF
     snprintf(pluginDir, sizeof(pluginDir), "%s%s/.libs/", vmPath, pluginName);
-#  else
-    sprintf(pluginDir, "%s%s/.libs/", vmPath, pluginName);
-#  endif
     if ((handle= tryLoading(pluginDir, pluginName)))
       return handle;
   }
@@ -425,11 +418,7 @@ ioFindExternalFunctionIn(char *lookupName, void *moduleHandle)
   char buf[256];
   void *fn;
 
-#ifdef HAVE_SNPRINTF
   snprintf(buf, sizeof(buf), "%s", lookupName);
-#else
-  sprintf(buf, "%s", lookupName);
-#endif
 
   if (!*lookupName) /* avoid errors in dlsym from eitherPlugin: code. */
     return 0;
@@ -452,11 +441,7 @@ ioFindExternalFunctionIn(char *lookupName, void *moduleHandle)
   if (fn && accessorDepthPtr) {
 	signed char *accessorDepthVarPtr;
 
-# ifdef HAVE_SNPRINTF
 	snprintf(buf+strlen(buf), sizeof(buf) - strlen(buf), "AccessorDepth");
-# else
-	sprintf(buf+strlen(buf), "AccessorDepth");
-# endif
 	accessorDepthVarPtr = dlsym(moduleHandle, buf);
 	/* The Slang machinery assumes accessor depth defaults to -1, which
 	 * means "no accessor depth".  It saves space not outputting -1 depths.

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -586,7 +586,8 @@ static void emergencyDump(int quit)
   for (i= 0; ++i;)
     {
       struct stat sb;
-      sprintf(imageName, "%s-emergency-dump-%d.image", baseName, i);
+      snprintf(imageName, sizeof(imageName), "%s-emergency-dump-%d.image",
+        baseName, i);
       if (stat(imageName, &sb))
 	break;
     }
@@ -1117,14 +1118,14 @@ struct SqModule *queryLoadModule(char *type, char *name, int query)
   char modName[MAXPATHLEN], itfName[32];
   struct SqModule *module= 0;
   void *itf= 0;
-  sprintf(modName, "vm-%s-%s", type, name);
+  snprintf(modName, sizeof(modName), "vm-%s-%s", type, name);
 #ifdef DEBUG_MODULES
   printf("looking for module %s\n", modName);
 #endif
   modulesDo (module)
     if (!strcmp(module->name, modName))
       return module;
-  sprintf(itfName, "%s_%s", type, name);
+  snprintf(itfName, sizeof(itfName), "%s_%s", type, name);
   itf= ioFindExternalFunctionIn(itfName, ioLoadModule(0));
   if (!itf)
     {


### PR DESCRIPTION
sprintf is usually misused; snprintf is safer in that regard.
