### PR TITLE
Fixed race conditions in sqFilePluginBasicPrims.c's sqFileOpen(), ...

### DIFF
--- a/platforms/Cross/plugins/FilePlugin/FilePlugin.h
+++ b/platforms/Cross/plugins/FilePlugin/FilePlugin.h
@@ -15,6 +15,8 @@
 */
 /* File support definitions */
 
+#include <sys/types.h>
+
 #include "sqMemoryAccess.h"
 
 /* squeak file record; see sqFilePrims.c for details */
@@ -40,22 +42,23 @@ typedef struct {
 
 sqInt   sqFileAtEnd(SQFile *f);
 sqInt   sqFileClose(SQFile *f);
-sqInt   sqFileDeleteNameSize(char* sqFileNameIndex, sqInt sqFileNameSize);
+sqInt   sqFileDeleteNameSize(char *sqFileName, sqInt sqFileNameSize);
 squeakFileOffsetType sqFileGetPosition(SQFile *f);
 sqInt   sqFileInit(void);
 sqInt   sqFileShutdown(void);
-sqInt   sqFileOpen(SQFile *f, char* sqFileNameIndex, sqInt sqFileNameSize, sqInt writeFlag);
-size_t  sqFileReadIntoAt(SQFile *f, size_t count, char* byteArrayIndex, size_t startIndex);
-sqInt   sqFileRenameOldSizeNewSize(char* oldNameIndex, sqInt oldNameSize, char* newNameIndex, sqInt newNameSize);
+sqInt   sqFileOpen(SQFile *f, char *sqFileName, sqInt sqFileNameSize, sqInt writeFlag);
+sqInt   sqFileOpenNew(SQFile *f, char *sqFileName, sqInt sqFileNameSize);
+size_t  sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startIndex);
+sqInt   sqFileRenameOldSizeNewSize(char *sqOldName, sqInt sqOldNameSize, char *sqNewName, sqInt sqNewNameSize);
 sqInt   sqFileSetPosition(SQFile *f, squeakFileOffsetType position);
 squeakFileOffsetType sqFileSize(SQFile *f);
 sqInt   sqFileValid(SQFile *f);
-size_t  sqFileWriteFromAt(SQFile *f, size_t count, char* byteArrayIndex, size_t startIndex);
+size_t  sqFileWriteFromAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startIndex);
 sqInt   sqFileFlush(SQFile *f);
 sqInt   sqFileSync(SQFile *f);
-sqInt   sqFileTruncate(SQFile *f,squeakFileOffsetType offset);
+sqInt   sqFileTruncate(SQFile *f, squeakFileOffsetType offset);
 sqInt   sqFileThisSession(void);
-sqInt   sqFileStdioHandlesInto(SQFile files[3]);
+sqInt   sqFileStdioHandlesInto(SQFile files[]);
 
 /* directories */
 
@@ -67,7 +70,7 @@ sqInt dir_Lookup(char *pathString, sqInt pathStringLength, sqInt index,
 		/* outputs: */
 		char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
 		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile, sqInt *posixPermissions, sqInt *isSymlink);
-sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength, char* nameString, sqInt nameStringLength,
+sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength, char *nameString, sqInt nameStringLength,
 		/* outputs: */
 		char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
 		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile, sqInt *posixPermissions, sqInt *isSymlink);
@@ -76,7 +79,7 @@ sqInt dir_Lookup(char *pathString, sqInt pathStringLength, sqInt index,
 		/* outputs: */
 		char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
 		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile);
-sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength, char* nameString, sqInt nameStringLength,
+sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength, char *nameString, sqInt nameStringLength,
 		/* outputs: */
 		char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
 		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile);

--- a/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
+++ b/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
@@ -27,14 +27,22 @@
 * and thus bypasses this file
 */
 
+
 #include <errno.h>
+
 #include "sq.h"
 
 #ifndef NO_STD_FILE_SUPPORT
 
-#include "FilePlugin.h"
-#include <limits.h> /* for PATH_MAX */
+#include <sys/stat.h>
+#include <sys/types.h>
 
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+
+#include "sqMemoryAccess.h"
+#include "FilePlugin.h" /* must be included after sq.h */
 
 /***
 	The state of a file is kept in the following structure,
@@ -74,9 +82,9 @@
 #define WRITE_OP	2
 
 #ifndef SEEK_SET
-#define SEEK_SET	0
-#define SEEK_CUR	1
-#define SEEK_END	2
+# define SEEK_SET	0
+# define SEEK_CUR	1
+# define SEEK_END	2
 #endif
 
 /*** Variables ***/
@@ -154,7 +162,7 @@ sqFileClose(SQFile *f) {
 		return interpreterProxy->success(false);
 
 	result = fclose(getFile(f));
-	setFile(f, 0);
+	setFile(f, NULL);
 	f->sessionID = 0;
 	f->writable = false;
 	setSize(f, 0);
@@ -162,7 +170,7 @@ sqFileClose(SQFile *f) {
 
 	/*
 	 * fclose() can fail for the same reasons fflush() or write() can so
-	 * errors must be checked
+	 * errors must be checked, but it must NEVER be retried
 	 */
 	if (result != 0)
 		return interpreterProxy->success(false);
@@ -171,7 +179,7 @@ sqFileClose(SQFile *f) {
 }
 
 sqInt
-sqFileDeleteNameSize(char* sqFileName, sqInt sqFileNameSize) {
+sqFileDeleteNameSize(char *sqFileName, sqInt sqFileNameSize) {
 	char cFileName[PATH_MAX];
 	int err;
 
@@ -198,7 +206,7 @@ sqFileGetPosition(SQFile *f) {
 		return interpreterProxy->success(false);
 	pentry(sqFileGetPosition);
 	if (f->isStdioStream
-	 && !f->writable)
+		&& !f->writable)
 		return pexit(f->lastChar == EOF ? 0 : 1);
 	position = ftell(getFile(f));
 	if (position == -1)
@@ -219,8 +227,61 @@ sqFileInit(void) {
 sqInt
 sqFileShutdown(void) { return 1; }
 
+/* These functions use the open() sys call directly, retrying on EINTR, and
+   return a file descriptor on success and a negative integer on failure.
+   They're needed because fopen() doesn't give enough control over file
+   creation and truncation, for example to only create a file if it doesn't
+   already exist or to open a file for just writing but not truncation.
+*/
+static int openFileWithFlags(const char *path, int flags)
+{
+	int fd;
+
+	do {
+		fd = open(path, flags);
+	} while (fd < 0 && errno == EINTR);
+
+	return fd;
+}
+static int openFileWithFlagsInMode(const char *path, int flags, mode_t mode)
+{
+	int fd;
+
+	do {
+		fd = open(path, flags, mode);
+	} while (fd < 0 && errno == EINTR);
+
+	return fd;
+}
+
+static FILE *openFileDescriptor(int fd, const char *mode)
+{
+	/* This must be implemented separately from openFileWithFlags()
+	   and openFileWithFlagsInMode() so error checking can be done
+	   by the caller for both open() and fdopen() failure conditions.
+	 */
+	FILE *file;
+
+	do {
+		file = fdopen(fd, mode);
+	} while (file == NULL && errno == EINTR);
+
+	return file;
+}
+
+static void setNewFileMacTypeAndCreator(char *sqFileName, sqInt sqFileNameSize)
+{
+	char type[4], creator[4];
+
+	dir_GetMacFileTypeAndCreator(sqFileName, sqFileNameSize, type, creator);
+	if (strncmp(type, "BINA", 4) == 0
+		|| strncmp(type, "????", 4) == 0
+		|| strncmp(type, "", 1) == 0)
+		dir_SetMacFileTypeAndCreator(sqFileName, sqFileNameSize, "TEXT", "R*ch");
+}
+
 sqInt
-sqFileOpen(SQFile *f, char* sqFileName, sqInt sqFileNameSize, sqInt writeFlag) {
+sqFileOpen(SQFile *f, char *sqFileName, sqInt sqFileNameSize, sqInt writeFlag) {
 	/* Opens the given file using the supplied sqFile structure
 	   to record its state. Fails with no side effects if f is
 	   already open. Files are always opened in binary mode;
@@ -228,6 +289,8 @@ sqFileOpen(SQFile *f, char* sqFileName, sqInt sqFileNameSize, sqInt writeFlag) {
 	*/
 
 	char cFileName[PATH_MAX];
+	int fd;
+	const char *mode;
 
 	/* don't open an already open file */
 	if (sqFileValid(f))
@@ -241,56 +304,156 @@ sqFileOpen(SQFile *f, char* sqFileName, sqInt sqFileNameSize, sqInt writeFlag) {
 		return interpreterProxy->success(false);
 
 	if (writeFlag) {
-		/* First try to open an existing file read/write: */
-		setFile(f, fopen(cFileName, "r+b"));
-		if (getFile(f) == NULL) {
-			/* Previous call fails if file does not exist. In that case,
-			   try opening it in write mode to create a new, empty file.
-			*/
-			setFile(f, fopen(cFileName, "w+b"));
-			/* and if w+b fails, try ab to open a write-only file in append mode,
-			   not wb which opens a write-only file but overwrites its contents.
-			 */
-			if (getFile(f) == NULL)
-				setFile(f, fopen(cFileName, "ab"));
-			if (getFile(f) != NULL) {
-			    /* New file created, set Mac file characteristics */
-			    char type[4],creator[4];
-				dir_GetMacFileTypeAndCreator(sqFileName, sqFileNameSize, type, creator);
-				if (strncmp(type,"BINA",4) == 0 || strncmp(type,"????",4) == 0 || *(int *)type == 0 ) 
-				    dir_SetMacFileTypeAndCreator(sqFileName, sqFileNameSize,"TEXT","R*ch");	
-			} else {
-				/* If the file could not be opened read/write and if a new file
-				   could not be created, then it may be that the file exists but
-				   does not permit read access. Try opening as a write only file,
-				   opened for append to preserve existing file contents.
-				*/
-				setFile(f, fopen(cFileName, "ab"));
-				if (getFile(f) == NULL) {
-					return interpreterProxy->success(false);
+		int retried = 0;
+		do {
+			mode = "r+b";
+			fd = openFileWithFlags(cFileName, O_RDWR);
+			/* could have failed if we lack read permission or it didn't exist */
+			if (fd < 0) {
+				if (errno == EACCES) {
+					/* this does no truncation, unlike the
+					   equivalent with fopen()
+					 */
+					mode = "wb";
+					fd = openFileWithFlags(cFileName, O_WRONLY);
+				} else if (errno == ENOENT) {
+					mode = "r+b";
+					fd = openFileWithFlagsInMode(
+						cFileName,
+						O_CREAT|O_EXCL|O_RDWR,
+						/* the mode fopen() uses when creating files;
+						   will likely be rw-r--r-- after being modified
+						   by the process's umask
+						 */
+						S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
+
+					/* could have failed if we lack read permission
+					   or it already exists
+					 */
+					if (fd < 0 && errno == EACCES) {
+						mode = "wb";
+						fd = openFileWithFlagsInMode(
+							cFileName,
+							O_CREAT|O_EXCL|O_WRONLY,
+							/* write-only version of the above mode;
+							   will likely be -w------- after being
+							   modified by the process's umask
+							 */
+							S_IWUSR|S_IWGRP|S_IWOTH);
+					}
+
+					if (fd >= 0)
+						setNewFileMacTypeAndCreator(sqFileName, sqFileNameSize);
 				}
 			}
-		}
-		f->writable = true;
+		/* We retry this only once if it failed because we attempted to create
+		   a new file that already existed (EEXIST when O_EXCL is used).
+		   This should only occur if the file was created after we tried to
+		   read an existing file but before we could create it.
+		 */
+		} while (fd < 0 && errno == EEXIST && ++retried <= 1);
 	} else {
-		setFile(f, fopen(cFileName, "rb"));
-		f->writable = false;
+		mode = "rb";
+		fd = openFileWithFlags(cFileName, O_RDONLY);
 	}
 
-	if (getFile(f) == NULL) {
-		f->sessionID = 0;
-		setSize(f, 0);
-		return interpreterProxy->success(false);
-	} else {
-		FILE *file= getFile(f);
-		f->sessionID = thisSession;
-		/* compute and cache file size */
-		fseek(file, 0, SEEK_END);
-		setSize(f, ftell(file));
-		fseek(file, 0, SEEK_SET);
+	if (fd >= 0) {
+		FILE *file = openFileDescriptor(fd, mode);
+		if (file != NULL) {
+			f->sessionID = thisSession;
+			setFile(f, file);
+
+			/* compute and cache file size */
+			fseek(file, 0, SEEK_END);
+			setSize(f, ftell(file));
+			fseek(file, 0, SEEK_SET);
+
+			f->writable = writeFlag ? true : false;
+			f->lastOp = UNCOMMITTED;
+			return 1;
+		}
+
+		/* close() the bad fd to avoid leaking file descriptors;
+		   NEVER reattempt close() if it fails, even on EINTR
+		 */
+		close(fd);
 	}
-	f->lastOp = UNCOMMITTED;
-	return 1;
+
+	f->sessionID = 0;
+	setSize(f, 0);
+	f->writable = false;
+	return interpreterProxy->success(false);
+}
+
+sqInt
+sqFileOpenNew(SQFile *f, char *sqFileName, sqInt sqFileNameSize) {
+	/* Opens the given file for writing and if possible reading
+	   if it does not already exist using the supplied sqFile
+	   structure to record its state.
+	   Fails with no side effects if f is already open. Files are
+	   always opened in binary mode; Squeak must take care of any
+	   line-end character mapping.
+	*/
+
+	char cFileName[PATH_MAX];
+	int fd;
+	const char *mode;
+
+	/* don't open an already open file */
+	if (sqFileValid(f))
+		return interpreterProxy->success(false);
+
+	/* copy the file name into a null-terminated C string */
+	if (sqFileNameSize >= sizeof(cFileName))
+		return interpreterProxy->success(false);
+	/* can fail when alias resolution is enabled */
+	if (interpreterProxy->ioFilenamefromStringofLengthresolveAliases(cFileName, sqFileName, sqFileNameSize, true) != 0)
+		return interpreterProxy->success(false);
+
+	mode = "r+b";
+	fd = openFileWithFlagsInMode(
+		cFileName,
+		O_CREAT|O_EXCL|O_RDWR,
+		/* the mode fopen() uses when creating files; will likely
+		   be rw-r--r-- after being modified by the process's umask
+		 */
+		S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
+	/* could have failed if we lack read permission or it already exists */
+	if (fd < 0 && errno == EACCES) {
+		mode = "wb";
+		fd = openFileWithFlagsInMode(
+			cFileName,
+			O_CREAT|O_EXCL|O_WRONLY,
+			/* write-only version of the above mode; will likely
+			   be -w------- after being modified by the process's umask
+			 */
+			S_IWUSR|S_IWGRP|S_IWOTH);
+	}
+
+	if (fd >= 0) {
+		FILE *file;
+
+		setNewFileMacTypeAndCreator(sqFileName, sqFileNameSize);
+		file = openFileDescriptor(fd, mode);
+		if (file != NULL) {
+			f->sessionID = thisSession;
+			setFile(f, file);
+			setSize(f, 0);
+			f->writable = true;
+			f->lastOp = UNCOMMITTED;
+			return 1;
+		}
+
+		/* close() the bad fd to avoid leaking file descriptors;
+		   NEVER reattempt close() if it fails, even on EINTR
+		 */
+		close(fd);
+	}
+
+	f->sessionID = 0;
+	setSize(f, 0);
+	f->writable = false;
+	return interpreterProxy->success(false);
 }
 
 /*
@@ -314,11 +477,7 @@ sqFileStdioHandlesInto(SQFile files[])
 	files[0].fileSize = 0;
 	files[0].writable = false;
 	files[0].lastOp = READ_OP;
-#if 0
-	files[0].isStdioStream = true;
-#else
 	files[0].isStdioStream = isatty(fileno(stdin));
-#endif
 	files[0].lastChar = EOF;
 
 	files[1].sessionID = thisSession;
@@ -341,7 +500,7 @@ sqFileStdioHandlesInto(SQFile files[])
 }
 
 size_t
-sqFileReadIntoAt(SQFile *f, size_t count, char* byteArrayIndex, size_t startIndex) {
+sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startIndex) {
 	/* Read count bytes from the given file into byteArray starting at
 	   startIndex. byteArray is the address of the first byte of a
 	   Squeak bytes object (e.g. String or ByteArray). startIndex
@@ -427,16 +586,16 @@ sqFileReadIntoAt(SQFile *f, size_t count, char* byteArrayIndex, size_t startInde
 }
 
 sqInt
-sqFileRenameOldSizeNewSize(char* oldNameIndex, sqInt oldNameSize, char* newNameIndex, sqInt newNameSize) {
+sqFileRenameOldSizeNewSize(char *sqOldName, sqInt sqOldNameSize, char *sqNewName, sqInt sqNewNameSize) {
 	char cOldName[PATH_MAX], cNewName[PATH_MAX];
 	int err;
 
-	if ((oldNameSize >= sizeof(cOldName)) || (newNameSize >= sizeof(cNewName)))
+	if ((sqOldNameSize >= sizeof(cOldName)) || (sqNewNameSize >= sizeof(cNewName)))
 		return interpreterProxy->success(false);
 
 	/* copy the file names into null-terminated C strings */
-	interpreterProxy->ioFilenamefromStringofLengthresolveAliases(cOldName, oldNameIndex, oldNameSize, false);
-	interpreterProxy->ioFilenamefromStringofLengthresolveAliases(cNewName, newNameIndex, newNameSize, false);
+	interpreterProxy->ioFilenamefromStringofLengthresolveAliases(cOldName, sqOldName, sqOldNameSize, false);
+	interpreterProxy->ioFilenamefromStringofLengthresolveAliases(cNewName, sqNewName, sqNewNameSize, false);
 
 	err = rename(cOldName, cNewName);
 	if (err)
@@ -516,7 +675,7 @@ sqFileSync(SQFile *f) {
 }
 
 sqInt
-sqFileTruncate(SQFile *f,squeakFileOffsetType offset) {
+sqFileTruncate(SQFile *f, squeakFileOffsetType offset) {
 	if (!sqFileValid(f))
 		return interpreterProxy->success(false);
  	if (sqFTruncate(getFile(f), offset))
@@ -534,7 +693,7 @@ sqFileValid(SQFile *f) {
 }
 
 size_t
-sqFileWriteFromAt(SQFile *f, size_t count, char* byteArrayIndex, size_t startIndex) {
+sqFileWriteFromAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startIndex) {
 	/* Write count bytes to the given writable file starting at startIndex
 	   in the given byteArray. (See comment in sqFileReadIntoAt for interpretation
 	   of byteArray and startIndex).

--- a/platforms/unix/plugins/FilePlugin/sqUnixFile.c
+++ b/platforms/unix/plugins/FilePlugin/sqUnixFile.c
@@ -28,37 +28,21 @@
 /* Author: Ian.Piumarta@INRIA.Fr
  */
 
-#include "sq.h"
-#include "FilePlugin.h"
-#include "sqUnixCharConv.h"
-
-#ifdef HAVE_DIRENT_H
-# include <dirent.h>
-# define NAMLEN(dirent) strlen((dirent)->d_name)
-#else
-# define dirent direct
-# define NAMLEN(dirent) (dirent)->d_namlen
-# ifdef HAVE_SYS_NDIR_H
-#  include <sys/ndir.h>
-# endif
-# ifdef HAVE_SYS_DIR_H
-#  include <sys/dir.h>
-# endif
-# ifdef HAVE_NDIR_H
-#  include <ndir.h>
-# endif
-#endif
-
-#ifdef HAVE_UNISTD_H
-# include <sys/types.h>
-# include <unistd.h>
-#endif
-
-#include <time.h>
-#include <errno.h>
-#include <string.h>
-#include <sys/param.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "sq.h"
+#include "sqStrSafe.h"
+#include "sqUnixCharConv.h"
+#include "FilePlugin.h" /* must be included after sq.h */
 
 /***
 	The interface to the directory primitive is path based.
@@ -77,277 +61,289 @@
 #define DELIMITER '/'
 
 /*** Variables ***/
-char lastPath[MAXPATHLEN+1];
-int  lastPathValid = false;
-int  lastIndex= -1;
-DIR *openDir= 0;
-
+static char lastPath[PATH_MAX];
+static int lastPathValid = false;
+static int lastIndex = -1;
+static DIR *openDir = NULL;
 
 /*** Functions ***/
 
 extern time_t convertToSqueakTime(time_t unixTime);
 
-
 sqInt dir_Create(char *pathString, sqInt pathStringLength)
 {
-  /* Create a new directory with the given path. By default, this
-     directory is created relative to the cwd. */
-  char name[MAXPATHLEN+1];
-  int i;
-  if (pathStringLength >= MAXPATHLEN)
-    return false;
-  if (!sq2uxPath(pathString, pathStringLength, name, MAXPATHLEN, 1))
-    return false;
-  return mkdir(name, 0777) == 0;	/* rwxrwxrwx & ~umask */
-}
+	/* Create a new directory with the given path. By default, this
+	   directory is created relative to the cwd.
+	*/
+	char unixPath[PATH_MAX];
 
+	if (pathStringLength >= sizeof(unixPath))
+		return false;
+	if (sq2uxPath(pathString, pathStringLength, unixPath, sizeof(unixPath) - 1, 1) == 0)
+		return false;
+
+	return mkdir(unixPath, 0777) == 0;	/* rwxrwxrwx & ~umask */
+}
 
 sqInt dir_Delete(char *pathString, sqInt pathStringLength)
 {
-  /* Delete the existing directory with the given path. */
-  char name[MAXPATHLEN+1];
-  int i;
-  if (pathStringLength >= MAXPATHLEN)
-    return false;
-  if (!sq2uxPath(pathString, pathStringLength, name, MAXPATHLEN, 1))
-    return false;
-  if (lastPathValid && !strcmp(lastPath, name))
-    {
-      closedir(openDir);
-      lastPathValid= false;
-      lastIndex= -1;
-      lastPath[0]= '\0';
-    }
-  return rmdir(name) == 0;
-}
+	/* Delete the existing directory with the given path. */
+	char unixPath[PATH_MAX];
 
+	if (pathStringLength >= sizeof(unixPath))
+		return false;
+	if (sq2uxPath(pathString, pathStringLength, unixPath, sizeof(unixPath) - 1, 1) == 0)
+		return false;
+
+	if (lastPathValid && strcmp(lastPath, unixPath) == 0) {
+		closedir(openDir);
+		lastPathValid = false;
+		lastIndex = -1;
+		strSafeCpy(lastPath, "", sizeof(lastPath));
+	}
+	return rmdir(unixPath) == 0;
+}
 
 sqInt dir_Delimitor(void)
 {
-  return DELIMITER;
+	return DELIMITER;
 }
-
 
 static int maybeOpenDir(char *unixPath)
 {
-  /* if the last opendir was to the same directory, re-use the directory
-     pointer from last time.  Otherwise close the previous directory,
-     open the new one, and save its name.  Return true if the operation
-     was successful, false if not. */
-  if (!lastPathValid || strcmp(lastPath, unixPath))
-    {
-      /* invalidate the old, open the new */
-      if (lastPathValid)
-	closedir(openDir);
-      lastPathValid= false;
-      strcpy(lastPath, unixPath);
-      if ((openDir= opendir(unixPath)) == 0)
-	return false;
-      lastPathValid= true;
-      lastIndex= 0;	/* first entry is index 1 */
-    }
-  return true;
-}
-
-#if PharoVM
-sqInt dir_Lookup(char *pathString, sqInt pathStringLength, sqInt index,
-/* outputs: */  char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
-		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile, sqInt * posixPermissions, sqInt *isSymlink)
-#else 
-sqInt dir_Lookup(char *pathString, sqInt pathStringLength, sqInt index,
-/* outputs: */  char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
-		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile)
-#endif
-{
-  /* Lookup the index-th entry of the directory with the given path, starting
-     at the root of the file system. Set the name, name length, creation date,
-     creation time, directory flag, and file size (if the entry is a file).
-     Return:	0 	if a entry is found at the given index
-     		1	if the directory has fewer than index entries
-		2	if the given path has bad syntax or does not reach a directory
-  */
-
-  int i;
-  int nameLen= 0;
-  struct dirent *dirEntry= 0;
-  char unixPath[MAXPATHLEN+1];
-  struct stat statBuf;
-
-  /* default return values */
-  *name             = 0;
-  *nameLength       = 0;
-  *creationDate     = 0;
-  *modificationDate = 0;
-  *isDirectory      = false;
-  *sizeIfFile       = 0;
-#if PharoVM
-  *posixPermissions = 0;
-  *isSymlink        = false;
-#endif
-
-  if ((pathStringLength == 0))
-    strcpy(unixPath, ".");
-  else if (!sq2uxPath(pathString, pathStringLength, unixPath, MAXPATHLEN, 1))
-    return BAD_PATH;
-
-  /* get file or directory info */
-  if (!maybeOpenDir(unixPath))
-    return BAD_PATH;
-
-  if (++lastIndex == index)
-    index= 1;		/* fake that the dir is rewound and we want the first entry */
-  else
-    {
-      rewinddir(openDir);	/* really rewind it, and read to the index */
-      lastIndex= index;
-    }
-
-  for (i= 0; i < index; i++)
-    {
-    nextEntry:
-      do
-	{ 
-	  errno= 0; 
-	  dirEntry= readdir(openDir);
+	/* If the last opendir was to the same directory, re-use the directory
+	   pointer from last time.  Otherwise close the previous directory,
+	   open the new one, and save its name.  Return true if the operation
+	   was successful, false if not.
+	*/
+	if (!lastPathValid || strcmp(lastPath, unixPath) != 0) {
+		/* invalidate the old, open the new */
+		if (lastPathValid)
+			closedir(openDir);
+		lastPathValid = false;
+		if (strSafeCpy(lastPath, unixPath, sizeof(lastPath)) >= sizeof(lastPath))
+			return false;
+		openDir = opendir(unixPath);
+		if (openDir == NULL)
+			return false;
+		lastPathValid = true;
+		lastIndex = 0;	/* first entry is index 1 */
 	}
-      while ((dirEntry == 0) && (errno == EINTR));
-
-      if (!dirEntry)
-	return NO_MORE_ENTRIES;
-      
-      nameLen= NAMLEN(dirEntry);
-
-      /* ignore '.' and '..' (these are not *guaranteed* to be first) */
-      if (nameLen < 3 && dirEntry->d_name[0] == '.')
-	if (nameLen == 1 || dirEntry->d_name[1] == '.')
-	  goto nextEntry;
-    }
-
-  *nameLength= ux2sqPath(dirEntry->d_name, nameLen, name, MAXPATHLEN, 0);
-
-  {
-    char terminatedName[MAXPATHLEN];
-    strncpy(terminatedName, dirEntry->d_name, nameLen);
-    terminatedName[nameLen]= '\0';
-    strcat(unixPath, "/");
-    strcat(unixPath, terminatedName);
-    if (stat(unixPath, &statBuf) && lstat(unixPath, &statBuf))
-      {
-	/* We can't stat the entry, but failing here would invalidate
-	   the whole directory --bertf */
-	return ENTRY_FOUND;
-      }
-  }
-
-  /* last change time */
-  *creationDate= convertToSqueakTime(statBuf.st_ctime);
-  /* modification time */
-  *modificationDate= convertToSqueakTime(statBuf.st_mtime);
-
-  if (S_ISDIR(statBuf.st_mode))
-    *isDirectory= true;
-  else
-    *sizeIfFile= statBuf.st_size;
-
-#if PharoVM
-  *isSymlink = S_ISLNK(statBuf.st_mode);
-  *posixPermissions = statBuf.st_mode & 0777;
-#endif
-
-  return ENTRY_FOUND;
+	return true;
 }
 
-
 #if PharoVM
-sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength, char* nameString, sqInt nameStringLength,
-/* outputs: */  char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
-		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile, sqInt *posixPermissions, sqInt *isSymlink)
+sqInt dir_Lookup(char *pathString, sqInt pathStringLength, sqInt index,
+/* outputs: */ char *name, sqInt * nameLength,
+		 sqInt * creationDate, sqInt * modificationDate,
+		 sqInt * isDirectory, squeakFileOffsetType * sizeIfFile,
+		 sqInt * posixPermissions, sqInt * isSymlink)
 #else
-sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength, char* nameString, sqInt nameStringLength,
-/* outputs: */  char *name, sqInt *nameLength, sqInt *creationDate, sqInt *modificationDate,
-		sqInt *isDirectory, squeakFileOffsetType *sizeIfFile)
+sqInt dir_Lookup(char *pathString, sqInt pathStringLength, sqInt index,
+/* outputs: */ char *name, sqInt * nameLength,
+		 sqInt * creationDate, sqInt * modificationDate,
+		 sqInt * isDirectory, squeakFileOffsetType * sizeIfFile)
 #endif
 {
-  /* Lookup the given name in the given directory,
-     Set the name, name length, creation date,
-     creation time, directory flag, and file size (if the entry is a file).
-     Return:	0 	if a entry is found at the given index
-     		1	if there is no such entry in the directory
-		2	if the given path has bad syntax or does not reach a directory
-  */
-  
-  char unixPath[MAXPATHLEN+1];
-  struct stat statBuf;
+	/* Lookup the index-th entry of the directory with the given path, starting
+	   at the root of the file system. Set the name, name length, creation date,
+	   creation time, directory flag, and file size (if the entry is a file).
+	   Return:    0       if a entry is found at the given index
+	   1  if the directory has fewer than index entries
+	   2  if the given path has bad syntax or does not reach a directory
+	 */
 
-  /* default return values */
-  *name             = 0;
-  *nameLength       = 0;
-  *creationDate     = 0;
-  *modificationDate = 0;
-  *isDirectory      = false;
-  *sizeIfFile       = 0;
+	char unixPath[PATH_MAX];
+	struct dirent *dirEntry = NULL;
+	struct stat statBuf;
+	int i;
+
+	/* default return values */
+	strSafeCpy(name, "", NAME_MAX);
+	*nameLength = 0;
+	*creationDate = 0;
+	*modificationDate = 0;
+	*isDirectory = false;
+	*sizeIfFile = 0;
 #if PharoVM
-  *posixPermissions = 0;
-  *isSymlink        = false;
+	*posixPermissions = 0;
+	*isSymlink = false;
 #endif
 
-  if ((pathStringLength == 0))
-    strcpy(unixPath, ".");
-  else if (!sq2uxPath(pathString, pathStringLength, unixPath, MAXPATHLEN, 1))
-    return BAD_PATH;
+	if (pathStringLength == 0) {
+		strSafeCpy(unixPath, ".", sizeof(unixPath));
+	} else {
+		if (pathStringLength >= sizeof(unixPath))
+			return BAD_PATH;
+		if (sq2uxPath(pathString, pathStringLength, unixPath, sizeof(unixPath) - 1, 1) == 0)
+			return BAD_PATH;
+	}
 
-  char terminatedName[MAXPATHLEN+1];
-  strncpy(terminatedName, nameString, nameStringLength);
-  terminatedName[nameStringLength]= '\0';
-  strcat(unixPath, "/");
-  strcat(unixPath, terminatedName);
-  if (stat(unixPath, &statBuf) && lstat(unixPath, &statBuf)) {
-	return NO_MORE_ENTRIES;
-  }
+	/* get file or directory info */
+	if (!maybeOpenDir(unixPath))
+		return BAD_PATH;
 
-  /* To match the results of dir_Lookup, copy back the file name */
-  *nameLength = ux2sqPath(nameString, nameStringLength, name, 256, 0);
+	if (++lastIndex == index) {
+		index = 1;	/* fake that the dir is rewound and we want the first entry */
+	} else {
+		rewinddir(openDir);	/* really rewind it, and read to the index */
+		lastIndex = index;
+	}
 
-  /* last change time */
-  *creationDate= convertToSqueakTime(statBuf.st_ctime);
-  /* modification time */
-  *modificationDate= convertToSqueakTime(statBuf.st_mtime);
+	i = 0;
+	while (i < index) {
+		do {
+			/* readdir() returns NULL on error or if it reaches
+			   the end of the dir and doesn't reset errno in the
+			   second case, so we must reset it before checking
+			   the return value and errno
+			 */
+			errno = 0;
+			dirEntry = readdir(openDir);
+		} while (dirEntry == NULL && errno == EINTR);
 
-  if (S_ISDIR(statBuf.st_mode))
-    *isDirectory= true;
-  else
-    *sizeIfFile= statBuf.st_size;
-  
+		if (dirEntry == NULL)
+			return NO_MORE_ENTRIES;
+
+		/* ignore '.' and '..' (these are not *guaranteed* to be first) */
+		if (strcmp(dirEntry->d_name, ".") != 0
+			&& strcmp(dirEntry->d_name, "..") != 0)
+			++i;
+	}
+
+	if (strSafeCat(unixPath, "/", sizeof(unixPath)) >= sizeof(unixPath))
+		return BAD_PATH;
+	if (strSafeCat(unixPath, dirEntry->d_name, sizeof(unixPath)) >= sizeof(unixPath))
+		return BAD_PATH;
+
+	*nameLength = ux2sqPath(dirEntry->d_name, strlen(dirEntry->d_name), name, NAME_MAX - 1, 0);
+
+	if (stat(unixPath, &statBuf) != 0
+		&& lstat(unixPath, &statBuf) != 0) {
+		/* We can't stat the entry, but failing here would invalidate
+		   the whole directory --bertf */
+		return ENTRY_FOUND;
+	}
+
+	/* last change time */
+	*creationDate = convertToSqueakTime(statBuf.st_ctime);
+	/* modification time */
+	*modificationDate = convertToSqueakTime(statBuf.st_mtime);
+
+	if (S_ISDIR(statBuf.st_mode))
+		*isDirectory = true;
+	else
+		*sizeIfFile = statBuf.st_size;
+
 #if PharoVM
-  *isSymlink = S_ISLNK(statBuf.st_mode);
-  *posixPermissions = statBuf.st_mode & 0777;
+	*isSymlink = S_ISLNK(statBuf.st_mode);
+	*posixPermissions = statBuf.st_mode & 0777;
 #endif
 
-  return ENTRY_FOUND;
+	return ENTRY_FOUND;
+}
+
+#if PharoVM
+sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength,
+		      char *nameString, sqInt nameStringLength,
+/* outputs: */ char *name, sqInt * nameLength,
+		      sqInt * creationDate, sqInt * modificationDate,
+		      sqInt * isDirectory, squeakFileOffsetType * sizeIfFile,
+		      sqInt * posixPermissions, sqInt * isSymlink)
+#else
+sqInt dir_EntryLookup(char *pathString, sqInt pathStringLength,
+		      char *nameString, sqInt nameStringLength,
+/* outputs: */ char *name, sqInt * nameLength,
+		      sqInt * creationDate, sqInt * modificationDate,
+		      sqInt * isDirectory, squeakFileOffsetType * sizeIfFile)
+#endif
+{
+	/* Lookup the given name in the given directory,
+	   Set the name, name length, creation date,
+	   creation time, directory flag, and file size (if the entry is a file).
+	   Return:    0       if a entry is found at the given index
+	   1  if there is no such entry in the directory
+	   2  if the given path has bad syntax or does not reach a directory
+	 */
+
+	char unixPath[PATH_MAX];
+	char terminatedName[NAME_MAX];
+	struct stat statBuf;
+
+	/* default return values */
+	strSafeCpy(name, "", NAME_MAX);
+	*nameLength = 0;
+	*creationDate = 0;
+	*modificationDate = 0;
+	*isDirectory = false;
+	*sizeIfFile = 0;
+#if PharoVM
+	*posixPermissions = 0;
+	*isSymlink = false;
+#endif
+
+	if (pathStringLength == 0) {
+		strSafeCpy(unixPath, ".", sizeof(unixPath));
+	} else {
+		if (pathStringLength >= sizeof(unixPath))
+			return BAD_PATH;
+		if (sq2uxPath(pathString, pathStringLength, unixPath, sizeof(unixPath) - 1, 1) == 0)
+			return BAD_PATH;
+	}
+
+	if (strSafeCpyLen(terminatedName, nameString, nameStringLength, sizeof(terminatedName))
+		>= sizeof(terminatedName))
+		return BAD_PATH;
+	if (strSafeCat(unixPath, "/", sizeof(unixPath)) >= sizeof(unixPath))
+		return BAD_PATH;
+	if (strSafeCat(unixPath, terminatedName, sizeof(unixPath)) >= sizeof(unixPath))
+		return BAD_PATH;
+
+	if (stat(unixPath, &statBuf) != 0
+		&& lstat(unixPath, &statBuf) != 0)
+		return NO_MORE_ENTRIES;
+
+	/* To match the results of dir_Lookup(), copy back the file name */
+	*nameLength = ux2sqPath(nameString, nameStringLength, name, NAME_MAX - 1, 0);
+	/* last change time */
+	*creationDate = convertToSqueakTime(statBuf.st_ctime);
+	/* modification time */
+	*modificationDate = convertToSqueakTime(statBuf.st_mtime);
+
+	if (S_ISDIR(statBuf.st_mode))
+		*isDirectory = true;
+	else
+		*sizeIfFile = statBuf.st_size;
+
+#if PharoVM
+	*isSymlink = S_ISLNK(statBuf.st_mode);
+	*posixPermissions = statBuf.st_mode & 0777;
+#endif
+
+	return ENTRY_FOUND;
 }
 
 /* unix files are untyped, and the creator is correct by default */
 
-
-sqInt dir_SetMacFileTypeAndCreator(char *filename, sqInt filenameSize, char *fType, char *fCreator)
+sqInt dir_SetMacFileTypeAndCreator(char *filename, sqInt filenameSize,
+				   char *fType, char *fCreator)
 {
-  return true;
+	return true;
 }
 
-sqInt dir_GetMacFileTypeAndCreator(char *filename, sqInt filenameSize, char *fType, char *fCreator)
+sqInt dir_GetMacFileTypeAndCreator(char *filename, sqInt filenameSize,
+				   char *fType, char *fCreator)
 {
-  return true;
+	return true;
 }
-
 
 /*
  * The following is useful in a debugging context when the VM's output has been
  * directed to a log file.  It binds stdout to /dev/tty, arranging that output
  * of debugging print routines such as printOop appear on stdout.
  */
-void
-sqStdoutToDevTTY()
+void sqStdoutToDevTTY()
 {
-	if (!freopen("/dev/tty","w",stdout))
+	if (!freopen("/dev/tty", "w", stdout))
 		perror("sqStdoutToDevTTY freopen(\"/dev/tty\",\"w\",stdout):");
 }

--- a/platforms/unix/vm/Makefile.in
+++ b/platforms/unix/vm/Makefile.in
@@ -44,13 +44,13 @@ TARGET		= vm$a
 COBJS		= $(INTERP)$o cogit$o sqNamedPrims$o sqVirtualMachine$o sqHeapMap$o\
 			sqExternalSemaphores$o sqTicker$o aio$o debug$o osExports$o \
 			sqUnixExternalPrims$o sqUnixMemory$o sqUnixSpurMemory$o \
-			sqUnixCharConv$o sqUnixMain$o \
+			sqUnixCharConv$o sqStrSafe$o sqUnixMain$o \
 			sqUnixVMProfile$o sqUnixHeartbeat$o sqUnixThreads$o
 
 IOBJS		= $(INTERP)$o sqNamedPrims$o sqVirtualMachine$o sqHeapMap$o\
 			sqExternalSemaphores$o sqTicker$o aio$o debug$o osExports$o \
 			sqUnixExternalPrims$o sqUnixMemory$o sqUnixSpurMemory$o \
-			sqUnixCharConv$o sqUnixMain$o \
+			sqUnixCharConv$o sqStrSafe$o sqUnixMain$o \
 			sqUnixVMProfile$o sqUnixHeartbeat$o sqUnixThreads$o
 
 OBJS		= [COBJS_OR_IOBJS] # see mkmf

--- a/platforms/unix/vm/sqStrSafe.c
+++ b/platforms/unix/vm/sqStrSafe.c
@@ -1,0 +1,107 @@
+/*
+ * Safe(r) string functions adapted from BSD's strlcpy() and strlcat() functions.
+ */
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t
+strSafeCpy(char *dst, const char *src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}
+
+/*
+ * Appends src to string dst of size dsize (unlike strncat, dsize is the
+ * full size of dst, not space left).  At most dsize-1 characters
+ * will be copied.  Always NUL terminates (unless dsize <= strlen(dst)).
+ * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
+ * If retval >= siz, truncation occurred.
+ */
+size_t
+strSafeCat(char *dst, const char *src, size_t dsize)
+{
+	const char *odst = dst;
+	const char *osrc = src;
+	size_t n = dsize;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end. */
+	while (n-- != 0 && *dst != '\0')
+		dst++;
+	dlen = dst - odst;
+	n = dsize - dlen;
+
+	if (n-- == 0)
+		return(dlen + strlen(src));
+	while (*src != '\0') {
+		if (n != 0) {
+			*dst++ = *src;
+			n--;
+		}
+		src++;
+	}
+	*dst = '\0';
+
+	return(dlen + (src - osrc));	/* count does not include NUL */
+}
+
+/*
+ * Copy non-NUL terminated string src of length slen to buffer dst of size
+ * dsize.  At most dsize-1 chars will be copied.
+ * Always NUL terminates (unless dsize == 0).
+ * Returns slen; if retval >= dsize, truncation occurred.
+ */
+size_t
+strSafeCpyLen(char *dst, const char *src, size_t slen, size_t dsize)
+{
+	if (dsize > 0) {
+		size_t dlen = (slen >= dsize) ? dsize - 1 : slen;
+
+		memcpy(dst, src, dlen);
+		dst[dlen] = '\0';
+	}
+
+	return slen;	/* count does not include NUL */
+}

--- a/platforms/unix/vm/sqStrSafe.h
+++ b/platforms/unix/vm/sqStrSafe.h
@@ -1,0 +1,19 @@
+/*
+ * Safe(r) string functions adapted from BSD's strlcpy() and strlcat() functions.
+ */
+
+#ifndef SQ_STR_SAFE_H
+#define SQ_STR_SAFE_H
+
+#include <sys/types.h>
+
+extern size_t
+strSafeCpy(char *dst, const char *src, size_t dsize);
+
+extern size_t
+strSafeCat(char *dst, const char *src, size_t dsize);
+
+extern size_t
+strSafeCpyLen(char *dst, const char *src, size_t slen, size_t dsize);
+
+#endif

--- a/platforms/unix/vm/sqUnixCharConv.c
+++ b/platforms/unix/vm/sqUnixCharConv.c
@@ -354,6 +354,7 @@ int convertChars(char *from, int fromLen, void *fromCode, char *to, int toLen, v
 #endif
 
 
+
 static inline void sq2uxLines(char *string, int n)
 {
   while (n--)
@@ -373,27 +374,66 @@ static inline void ux2sqLines(char *string, int n)
 }
 
 
-#define Convert(sq,ux, type, F, T, N, L)					\
-  int sq##2##ux##type(char *from, int fromLen, char *to, int toLen, int term)	\
-  {										\
-    int n= convertChars(from, fromLen, F, to, toLen, T, N, term);		\
-    if (L) sq##2##ux##Lines(to, n);						\
-    return n;									\
-  }
 
-Convert(sq,ux, Text, sqTextEncoding, uxTextEncoding, 0, 1);
-Convert(ux,sq, Text, uxTextEncoding, sqTextEncoding, 0, 1);
+int sq2uxText(char *from, int fromLen, char *to, int toLen, int term)
+{
+	int n = convertChars(from, fromLen, sqTextEncoding, to, toLen,
+				 uxTextEncoding, 0, term);
+	sq2uxLines(to, n);
+	return n;
+};
+
+int ux2sqText(char *from, int fromLen, char *to, int toLen, int term)
+{
+	int n = convertChars(from, fromLen, uxTextEncoding, to, toLen,
+				 sqTextEncoding, 0, term);
+	ux2sqLines(to, n);
+	return n;
+};
+
 #if defined(__MACH__)
-Convert(sq,ux, Path, sqTextEncoding, uxPathEncoding, 1, 0);	// normalised paths for HFS+
+int sq2uxPath(char *from, int fromLen, char *to, int toLen, int term)
+{
+	return convertChars(from, fromLen, sqTextEncoding, to, toLen,
+				 uxPathEncoding, 1, term); // normalised paths for HFS+
+};
 #else
-Convert(sq,ux, Path, sqTextEncoding, uxPathEncoding, 0, 0);	// composed paths for others
+int sq2uxPath(char *from, int fromLen, char *to, int toLen, int term)
+{
+	return convertChars(from, fromLen, sqTextEncoding, to, toLen,
+				 uxPathEncoding, 0, term); // composed paths for others
+};
 #endif
-Convert(ux,sq, Path, uxPathEncoding, sqTextEncoding, 0, 0);
-Convert(sq,ux, UTF8, sqTextEncoding, uxUTF8Encoding, 0, 1);
-Convert(ux,sq, UTF8, uxUTF8Encoding, sqTextEncoding, 0, 1);
-Convert(ux,sq, XWin, uxXWinEncoding, sqTextEncoding, 0, 1);
 
-#undef Convert
+int ux2sqPath(char *from, int fromLen, char *to, int toLen, int term)
+{
+	return convertChars(from, fromLen, uxPathEncoding, to, toLen,
+				 sqTextEncoding, 0, term);
+};
+
+int sq2uxUTF8(char *from, int fromLen, char *to, int toLen, int term)
+{
+	int n = convertChars(from, fromLen, sqTextEncoding, to, toLen,
+				 uxUTF8Encoding, 0, term);
+	sq2uxLines(to, n);
+	return n;
+};
+
+int ux2sqUTF8(char *from, int fromLen, char *to, int toLen, int term)
+{
+	int n = convertChars(from, fromLen, uxUTF8Encoding, to, toLen,
+				 sqTextEncoding, 0, term);
+	ux2sqLines(to, n);
+	return n;
+};
+
+int ux2sqXWin(char *from, int fromLen, char *to, int toLen, int term)
+{
+	int n = convertChars(from, fromLen, uxXWinEncoding, to, toLen,
+				 sqTextEncoding, 0, term);
+	ux2sqLines(to, n);
+	return n;
+};
 
 
 

--- a/platforms/win32/plugins/FilePlugin/sqWin32FilePrims.c
+++ b/platforms/win32/plugins/FilePlugin/sqWin32FilePrims.c
@@ -212,13 +212,48 @@ sqInt sqFileOpen(SQFile *f, char* fileNameIndex, sqInt fileNameSize, sqInt write
   return 1;
 }
 
+sqInt sqFileOpenNew(SQFile *f, char* fileNameIndex, sqInt fileNameSize) {
+  HANDLE h;
+  WCHAR *win32Path = NULL;
+
+  /* convert the file name into a null-terminated C string */
+  ALLOC_WIN32_PATH(win32Path, fileNameIndex, fileNameSize);
+
+  /* test for case duplicates using hasCaseSensitiveDuplicate(), even though
+     CreateFileW() with CREATE_NEW should fail if any exist, so if
+     hasCaseSensitiveDuplicate() treats some paths as duplicates that
+     CreateFileW() doesn't, sqFileOpenNew() will fail like sqFileOpen() would
+   */
+  if(hasCaseSensitiveDuplicate(win32Path)) {
+    f->sessionID = 0;
+    FAIL();
+  }
+  h = CreateFileW(win32Path,
+		  (GENERIC_READ | GENERIC_WRITE),
+		  FILE_SHARE_READ,
+		  NULL, /* No security descriptor */
+		  CREATE_NEW, /* Only create and open if it doesn't exist */
+		  FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
+		  NULL /* No template */);
+  if(h == INVALID_HANDLE_VALUE) {
+    f->sessionID = 0;
+    FAIL();
+  } else {
+    f->sessionID = thisSession;
+    f->file = (HANDLE)h;
+    f->writable = true;
+    AddHandleToTable(win32Files, h);
+  }
+  return 1;
+}
+
 /*
  * Fill-in files with handles for stdin, stdout and seterr as available and
  * answer a bit-mask of the availability, 1 corresponding to stdin, 2 to stdout
  * and 4 to stderr, with 0 on error or unavailablity.
  */
 sqInt
-sqFileStdioHandlesInto(SQFile files[3])
+sqFileStdioHandlesInto(SQFile files[])
 {
 	DWORD mode;
 


### PR DESCRIPTION
> This commit fixes race conditions in sqFilePluginBasicPrims.c's sqFileOpen() and buffer overflows in sqUnixFile.c and adds sqFileOpenNew() to support a new primitive to open only new files for IO atomically using open() with O_CREAT|O_EXCL and the equivalent on Windows, failing if they already exist. This will hopefully eventually replace any in-image code that tests for a file's existence before opening it for writing and creation/truncation, a classic race condition.
> 
> I don't have a Github account so I attached the commit as a "git format-patch" patch that you can apply with "git am". Details of the issues fixed follow.
> 
> sqFileOpen() issues:
> 
> Look at the current implementation. It tries fopen() with "r+b", reading/writing of an existing file, then if that fails, with "w+b", reading/writing of a new or truncated file. If the file is created and modified elsewhere between the first and second fopen(), you get unintentional truncation with potential data loss. There's also a minor race condition involving the setting of Mac file characteristics. The fix is replacing use of fopen() with the more general sys call open() and fdopen() after and proper error checking throughout.
> 
> sqUnixFile.c issues:
> 
> Evaluate this in a Pharo5/6 image with a recent SpurVM:
>         name := String newFrom: ((1 to: 10000) collect: [ :e | $a ]).
>         (name, '/', name) asFileReference writeStream.
> it should crash with a stack trace with dir_EntryLookup() on top. I fixed it by cleaning up sqUnixFile.c, making it use safer string functions adapted from BSD's strlcpy()/strlcat(), added checks throughout for truncation, removed obsolete includes, and made unexternally referenced global vars static. The iOS branch uses strlcpy()/strlcat() directly, but we sadly can't assume all non-BSDs like Linux have them, so I inserted renamed versions, which is common: http://marc.info/?l=openbsd-tech&m=138733933417096&w=2
> 
> The diff is smaller than it looks, because I ran sqUnixFile.c through Lindent to make it easier for me to edit and replaced the function-generating macros in sqUnixCharConv.c with their output ("gcc -E" with minor awk post-processing).

_Submitted by monty via the vm-dev mailing list._
