### PR TITLE
configure.ac: Modernize scripts to allow autoreconf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ matrix:
 install:
 - ./.travis_install.sh
 script:
+- cd platforms/unix/config/ && make configure
+- cd ../../../
 - $CHROOT ./.travis_build.sh
 - ./.travis_test.sh
 after_success:

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -69,7 +69,10 @@ sudo apt-get install -yq --no-install-suggests --no-install-recommends --force-y
      build-essential \
      python-dev \
      libffi-dev \
-     zlib1g-dev
+     zlib1g-dev \
+     libtool \
+     automake \
+     autoconf
 
 sudo chown $USER /etc/schroot/schroot.conf
 echo "

--- a/platforms/unix/config/Makefile
+++ b/platforms/unix/config/Makefile
@@ -1,7 +1,6 @@
 configure : .force
 	./mkacinc > acplugins.m4
-	aclocal
-	autoconf
+	autoreconf --install --force
 	rm acplugins.m4
 
 .force :

--- a/platforms/unix/config/Makefile.in
+++ b/platforms/unix/config/Makefile.in
@@ -40,6 +40,11 @@ squeak		= squeak
 squeaksh	= squeak.sh
 binsqueaksh	= bin.squeak.sh
 
+# We are not really using automake but we need to link vm/vm.a multiple
+# times or we have undefined references. This was taken from:
+# http://lists.gnu.org/archive/html/automake/2006-05/msg00091.html
+LIBTOOL = @LIBTOOL@ --preserve-dup-deps
+
 all : $(squeak) plugins squeak.1 $(npsqueak)
 
 # VM

--- a/platforms/unix/config/acinclude.m4
+++ b/platforms/unix/config/acinclude.m4
@@ -103,12 +103,12 @@ AC_DEFUN([AC_CHECK_INT64_T],[
     AC_MSG_ERROR([could not find a 64-bit integer type])
   fi
   SQUEAK_INT64_T="$ac_cv_int64_t"
-  AC_DEFINE_UNQUOTED(squeakInt64, $ac_cv_int64_t)])
+  AC_DEFINE_UNQUOTED(squeakInt64, $ac_cv_int64_t, [64bit signed integer])])
   
 
 AC_DEFUN([AC_NEED_SUNOS_H],
 [case "$host" in
-  *-sunos*)	AC_DEFINE(NEED_SUNOS_H, 1)
+  *-sunos*)	AC_DEFINE(NEED_SUNOS_H, 1, [building on SunOS])
 esac])
 
 
@@ -130,11 +130,11 @@ if test "$GCC" = yes; then
     ac_optflags="-O3 -funroll-loops -mcpu=750 -mno-fused-madd"
     ;;
   esac
-  AC_DEFINE(VM_BUILD_STRING, ["Unix built on "__DATE__ " "__TIME__" Compiler: "__VERSION__])
+  AC_DEFINE(VM_BUILD_STRING, ["Unix built on "__DATE__ " "__TIME__" Compiler: "__VERSION__], [build string])
 else
   ac_optflags="-O"
   ac_vm_build_date="`date`"
-  AC_DEFINE(VM_BUILD_STRING, ["Unix built on ${ac_vm_build_date}"])
+  AC_DEFINE(VM_BUILD_STRING, ["Unix built on ${ac_vm_build_date}"], [build string])
 fi
 if test "$ac_optflags" = "no"; then
   AC_MSG_RESULT([(none)])
@@ -172,38 +172,38 @@ AC_DEFUN([AC_CHECK_ATEXIT],
   AC_TRY_COMPILE([#include <stdlib.h>],[on_exit(0);], ac_cv_atexit="on_exit",
   ac_cv_atexit="no")))
 if test "$ac_cv_atexit" != "no"; then
-  AC_DEFINE_UNQUOTED(AT_EXIT, $ac_cv_atexit)
+  AC_DEFINE_UNQUOTED([AT_EXIT], [$ac_cv_atexit], [Is atexit present])
 fi])
 
 AC_DEFUN([AC_CHECK_SOCKLEN_T],
 [AC_CACHE_CHECK([for socklen_t in sys/socket.h], ac_cv_socklen_t,
   AC_TRY_COMPILE([#include <sys/socket.h>],[sizeof(socklen_t);],
     ac_cv_socklen_t="yes", ac_cv_socklen_t="no"))
-test "$ac_cv_socklen_t" != "yes" && AC_DEFINE(socklen_t, int)])
+test "$ac_cv_socklen_t" != "yes" && AC_DEFINE(socklen_t, int, [socklen size])])
 
 AC_DEFUN([AC_CHECK_TZSET],
 [AC_CACHE_CHECK([for tzset], ac_cv_tzset,
   AC_TRY_COMPILE([#include <time.h>],[tzet();],
     ac_cv_tzset="yes", ac_cv_tzset="no"))
-test "$ac_cv_tzset" != "no" && AC_DEFINE(HAVE_TZSET)])
+test "$ac_cv_tzset" != "no" && AC_DEFINE(HAVE_TZSET, [], [tzset available])])
 
 AC_DEFUN([AC_CHECK_GMTOFF],
 [AC_CACHE_CHECK([for gmtoff in struct tm], ac_cv_tm_gmtoff,
   AC_TRY_COMPILE([#include <time.h>],[struct tm tm; tm.tm_gmtoff;],
     ac_cv_tm_gmtoff="yes", ac_cv_tm_gmtoff="no"))
-test "$ac_cv_tm_gmtoff" != "no" && AC_DEFINE(HAVE_TM_GMTOFF)])
+test "$ac_cv_tm_gmtoff" != "no" && AC_DEFINE(HAVE_TM_GMTOFF, [], [tm_gmtoff present])])
 
 AC_DEFUN([AC_CHECK_TIMEZONE],
 [AC_CACHE_CHECK([for timezone and daylight variables], ac_cv_timezone,
   AC_TRY_COMPILE([extern long timezone; extern int daylight;],[timezone;daylight;],
     ac_cv_timezone="yes", ac_cv_timezone="no"))
-test "$ac_cv_timezone" != "no" && AC_DEFINE(HAVE_TIMEZONE)])
+test "$ac_cv_timezone" != "no" && AC_DEFINE(HAVE_TIMEZONE, [], [timezone present])])
 
 AC_DEFUN([AC_CHECK_GETHOSTNAME],
 [AC_CACHE_CHECK([for gethostname in unistd.h], ac_cv_gethostname_p,
   AC_TRY_COMPILE([#include <unistd.h>],[return (int)gethostname;],
     ac_cv_gethostname_p="yes", ac_cv_gethostname_p="no"))
-test "$ac_cv_gethostname_p" = "no" && AC_DEFINE(NEED_GETHOSTNAME_P)])
+test "$ac_cv_gethostname_p" = "no" && AC_DEFINE(NEED_GETHOSTNAME_P, [], [gethostname_p])])
 
 
 if test -x /bin/test; then
@@ -229,7 +229,7 @@ AC_DEFUN([AC_C_DOUBLE_ALIGNMENT],
   AC_TRY_RUN([f(int i){*(double *)i=*(double *)(i+4);}
               int main(){char b[[12]];f(b);return 0;}],
     ac_cv_double_align="yes", ac_cv_double_align="no"))
-test "$ac_cv_double_align" = "no" && AC_DEFINE(DOUBLE_WORD_ALIGNMENT)])
+test "$ac_cv_double_align" = "no" && AC_DEFINE(DOUBLE_WORD_ALIGNMENT, [], [Unaligned double access])])
 
 # this assumes that libtool has already been configured and built --
 # if not then err on the side of conservatism.
@@ -240,7 +240,7 @@ if test -x ./libtool &&
 then ac_cv_module_prefix="(none)";
 else ac_cv_module_prefix="lib"
 fi)
-AC_DEFINE_UNQUOTED(VM_MODULE_PREFIX,"$mkfrags_lib_prefix")
+AC_DEFINE_UNQUOTED(VM_MODULE_PREFIX,"$mkfrags_lib_prefix", [VM module prefix])
 test "$ac_cv_module_prefix" = lib && mkfrags_lib_prefix=lib])
 
 AC_DEFUN([AC_64BIT_ARCH],

--- a/platforms/unix/config/configure.ac
+++ b/platforms/unix/config/configure.ac
@@ -117,7 +117,7 @@ AC_SUBST(blddir)
 
 SQ_VERSION=${SQ_MAJOR}.${SQ_MINOR}-${SQ_UPDATE}
 
-AC_DEFINE_UNQUOTED(SQ_VERSION, "${SQ_VERSION}")
+AC_DEFINE_UNQUOTED(SQ_VERSION, "${SQ_VERSION}", [Squeak version])
 
 AC_SUBST(SQ_MAJOR)
 AC_SUBST(SQ_MINOR)
@@ -126,7 +126,7 @@ AC_SUBST(SQ_VERSION)
 
 #VM_VERSION=${VM_MAJOR}.${VM_MINOR}-${VM_RELEASE}
 
-#AC_DEFINE_UNQUOTED(VM_VERSION, "${VM_VERSION}")
+#AC_DEFINE_UNQUOTED(VM_VERSION, "${VM_VERSION}", [VM version])
 
 #AC_SUBST(VM_MAJOR)
 #AC_SUBST(VM_MINOR)
@@ -144,7 +144,7 @@ AC_SUBST(imgdir)
 AC_SUBST(expanded_relative_imgdir)
 AC_SUBST(plgdir)
 
-AC_DEFINE(OS_TYPE, "unix")
+AC_DEFINE(OS_TYPE, "unix", [OS type])
 
 AC_CANONICAL_HOST
 
@@ -156,9 +156,9 @@ AC_SUBST(host_cpu)
 AC_SUBST(host_vendor)
 AC_SUBST(host_os)
 
-AC_DEFINE_UNQUOTED(VM_HOST, "$host")
-AC_DEFINE_UNQUOTED(VM_HOST_OS, "$host_os")
-AC_DEFINE_UNQUOTED(VM_HOST_CPU, "$host_cpu")
+AC_DEFINE_UNQUOTED(VM_HOST, "$host", [host])
+AC_DEFINE_UNQUOTED(VM_HOST_OS, "$host_os", [host os])
+AC_DEFINE_UNQUOTED(VM_HOST_CPU, "$host_cpu", [host cpu])
 
 AC_CANONICAL_TARGET
 
@@ -170,9 +170,9 @@ AC_SUBST(target_cpu)
 AC_SUBST(target_vendor)
 AC_SUBST(target_os)
 
-AC_DEFINE_UNQUOTED(VM_TARGET, "$target")
-AC_DEFINE_UNQUOTED(VM_TARGET_OS, "$target_os")
-AC_DEFINE_UNQUOTED(VM_TARGET_CPU, "$target_cpu")
+AC_DEFINE_UNQUOTED(VM_TARGET, "$target", [target])
+AC_DEFINE_UNQUOTED(VM_TARGET_OS, "$target_os", [target os])
+AC_DEFINE_UNQUOTED(VM_TARGET_CPU, "$target_cpu", [target cpu])
 
 echo
 echo "Configuring Squeak ${VM_VERSION} (${SQ_VERSION}) for ${host}"
@@ -238,7 +238,7 @@ AC_HEADER_TIME
 AC_HEADER_DIRENT
 
 if test -f "${vmmdir}/vm/interp.h"; then
-  AC_DEFINE(HAVE_INTERP_H, 1)
+  AC_DEFINE(HAVE_INTERP_H, 1, [Interpreter header file present])
 fi
 AC_SUBST(HAVE_INTERP_H)
 
@@ -258,7 +258,7 @@ AC_ARG_WITH(rfb,
   [have_rfb="$withval"],
   [have_rfb="no"])
 
-test $have_rfb = "yes" && AC_DEFINE(USE_RFB,[1])
+test $have_rfb = "yes" && AC_DEFINE(USE_RFB,[1], [Use RFB])
 
 # Checks for libraries.
 
@@ -283,11 +283,11 @@ AC_CHECK_LIB(pthread, pthread_create)
 #])
 
 AC_CHECK_FUNC(_dyld_present, [
-  AC_DEFINE(HAVE_DYLD,[1])
+  AC_DEFINE(HAVE_DYLD,[1], [dyld linker present])
 ],[
   AC_HAVE_HEADERS(dlfcn.h)
   AC_CHECK_FUNC(dlopen, [
-    AC_DEFINE(HAVE_LIBDL,[1])
+    AC_DEFINE(HAVE_LIBDL,[1], [dl linker present])
   ],[
     AC_CHECK_LIB(dl, dlopen, [
       LIBS="-ldl $LIBS"
@@ -319,7 +319,7 @@ AC_C_DOUBLE_ALIGNMENT
 
 case $host_os in
   darwin*)
-    AC_DEFINE(DARWIN,[1])
+    AC_DEFINE([DARWIN],[1], [Defined when building on Darwin])
 #    CFLAGS="-no-cpp-precomp $CFLAGS"
     with_npsqueak=no
     VM_APP_ICONS="${imgdir}/SqueakVM.icns"
@@ -361,7 +361,7 @@ else
 fi
 
 AC_SUBST(SQ_LIBDIR)
-AC_DEFINE_UNQUOTED(SQ_LIBDIR,["${SQ_LIBDIR}"])
+AC_DEFINE_UNQUOTED(SQ_LIBDIR,["${SQ_LIBDIR}"], [Squeak libdir])
 
 # Configure files
 

--- a/platforms/unix/plugins/MIDIPlugin/acinclude.m4
+++ b/platforms/unix/plugins/MIDIPlugin/acinclude.m4
@@ -3,7 +3,7 @@ AC_TRY_COMPILE([
   #include <alsa/asoundlib.h>
 ],[;],[
   AC_MSG_RESULT(yes)
-  AC_DEFINE(USE_MIDI_ALSA, 1)
+  AC_DEFINE(USE_MIDI_ALSA, 1, [Use MIDI ALSA])
 ],[
   AC_MSG_RESULT(no)
   AC_PLUGIN_DISABLE

--- a/platforms/unix/plugins/MIDIPlugin/sqUnixMIDI.c
+++ b/platforms/unix/plugins/MIDIPlugin/sqUnixMIDI.c
@@ -36,8 +36,8 @@
 #include "config.h"
 #include "debug.h"
 
-/* this simply doesn't work */
-#if defined(USE_MIDI_ALSA)
+/* It would work now but the linking has not ctahced up */
+#if 0 /* defined(USE_MIDI_ALSA) */
 # include "sqUnixMIDIALSA.inc"
 #else
 

--- a/platforms/unix/plugins/PseudoTTYPlugin/acinclude.m4
+++ b/platforms/unix/plugins/PseudoTTYPlugin/acinclude.m4
@@ -1,7 +1,7 @@
 AC_HAVE_HEADERS(util.h libutil.h pty.h stropts.h)
 
 AC_SEARCH_LIBS(openpty, util,
-  AC_DEFINE(HAVE_OPENPTY, 1),[
+  AC_DEFINE(HAVE_OPENPTY, 1, [Have openpty]),[
   if test -r /dev/ptmx; then
-    AC_CHECK_FUNC(grantpt, AC_DEFINE(HAVE_UNIX98_PTYS, 1))
+    AC_CHECK_FUNC(grantpt, AC_DEFINE(HAVE_UNIX98_PTYS, 1, [Have grantpt]))
   fi])

--- a/platforms/unix/plugins/UnixOSProcessPlugin/acinclude.m4
+++ b/platforms/unix/plugins/UnixOSProcessPlugin/acinclude.m4
@@ -1,1 +1,1 @@
-AC_CHECK_FUNC(unsetenv, AC_DEFINE(HAVE_UNSETENV, 1))
+AC_CHECK_FUNC(unsetenv, AC_DEFINE(HAVE_UNSETENV, 1, [Have unsetenv]))

--- a/platforms/unix/vm-display-Quartz/acinclude.m4
+++ b/platforms/unix/vm-display-Quartz/acinclude.m4
@@ -11,15 +11,15 @@ case $host_os in
 esac
 
 if test "$have_quartz" = "yes"; then
-  AC_DEFINE(USE_QUARTZ, [1])
+  AC_DEFINE(USE_QUARTZ, [1], [Use Quartz])
   if test "$have_gl" = ""; then have_gl="no"; fi
   if test "$have_gl" = "yes"; then
 	AC_CHECK_HEADERS(OpenGL/gl.h, [
       have_gl=yes
-      AC_DEFINE(USE_QUARTZ_CGL, [1])
+      AC_DEFINE(USE_QUARTZ_CGL, [1], [Use Quartz CGL])
 	])
   else
-    AC_DEFINE(USE_QUARTZ_CGL, 0)
+    AC_DEFINE(USE_QUARTZ_CGL, 0, [Use Quartz CGL])
   fi
 else
   AC_PLUGIN_DISABLE

--- a/platforms/unix/vm-display-X11/acinclude.m4
+++ b/platforms/unix/vm-display-X11/acinclude.m4
@@ -46,19 +46,19 @@ if test "$have_x" = "yes"; then
     X_INCLUDES="-I${x_includes}"
   fi
   AC_CHECK_LIB(X11, XOpenDisplay, [
-    AC_DEFINE(USE_X11, [1])
-    AC_DEFINE_UNQUOTED(VM_X11DIR, "${x_libraries}")
+    AC_DEFINE(USE_X11, [1], [Use X11])
+    AC_DEFINE_UNQUOTED(VM_X11DIR, "${x_libraries}", [X11 libraries])
     LIBS="${LIBS} -lX11"
     AC_CHECK_LIB(Xext, XShmAttach)
     if test "$have_gl" = ""; then have_gl="no"; fi
 	if test "$have_gl" = "yes"; then
 		AC_CHECK_HEADERS(GL/gl.h, [
 		  have_gl=yes
-		  AC_DEFINE(USE_X11_GLX, [1])
+		  AC_DEFINE(USE_X11_GLX, [1], [Use X11 GLX])
 		  AC_CHECK_LIB(GL,glIsEnabled)
 		])
 	else
-		AC_DEFINE(USE_X11_GLX, 0)
+		AC_DEFINE(USE_X11_GLX, 0, [Use X11 GLX])
 	fi
   ],[
     AC_PLUGIN_DISABLE

--- a/platforms/unix/vm-sound-Sun/acinclude.m4
+++ b/platforms/unix/vm-sound-Sun/acinclude.m4
@@ -3,11 +3,11 @@
 AC_MSG_CHECKING([for SunOS/Solaris audio])
 AC_TRY_COMPILE([#include <sys/audioio.h>],[AUDIO_SUNVTS;],[
   AC_MSG_RESULT(yes)
-  AC_DEFINE_UNQUOTED(HAVE_SYS_AUDIOIO_H,1)
+  AC_DEFINE_UNQUOTED(HAVE_SYS_AUDIOIO_H,1, [SunOS/Solaris audio])
 ],[
   AC_TRY_COMPILE([#include <sun/audioio.h>],[AUDIO_SUNVTS;],[
     AC_MSG_RESULT(yes)
-    AC_DEFINE_UNQUOTED(HAVE_SUN_AUDIOIO_H,1)
+    AC_DEFINE_UNQUOTED(HAVE_SUN_AUDIOIO_H,1, [Sun audioio])
   ],[
     AC_MSG_RESULT(no)
     AC_PLUGIN_DISABLE

--- a/platforms/unix/vm/acinclude.m4
+++ b/platforms/unix/vm/acinclude.m4
@@ -42,6 +42,6 @@ else
 fi
 
 AC_CHECK_FUNC(nanosleep, [
-  AC_DEFINE(HAVE_NANOSLEEP, 1)
+  AC_DEFINE(HAVE_NANOSLEEP, 1, [Is nanosleep available])
   AC_SUBST(HAVE_NANOSLEEP)
 ])


### PR DESCRIPTION
Allow to autoreconf with autoconf released in 2012. It might
be best to remove generated files to prevent bitrot again or
at least run it as part of the CI process.

Just tried to autoreconf but didn't run the script yet. Let's
see how it goes in CI.