### PR TITLE
pharovm: add double-dash for command line options (macOS)

### DIFF
--- a/build.linux32ARMv6/pharo.cog.spur/prepare-rpi.sh
+++ b/build.linux32ARMv6/pharo.cog.spur/prepare-rpi.sh
@@ -56,7 +56,8 @@ if [ ! -e "$ARMCHROOT/etc/debian_chroot" ]; then
 		build-essential libcairo2-dev libpango1.0-dev libssl-dev uuid-dev uuid-runtime libasound2-dev \
 		debhelper devscripts libssl-dev libfreetype6-dev libx11-dev libxext-dev \
 		libx11-dev libsm-dev libice-dev libgl1-mesa-dev libgl1-mesa-glx git
-
+    #needed for third-party libraries
+    schroot -c rpi -u root -- apt-get --allow-unauthenticated install -y cmake curl
 fi
 schroot -c rpi -- uname -m
 

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
@@ -62,6 +62,14 @@
 # endif
 #endif
 
+#ifdef PharoVM
+# define VMOPTION(arg) "--"arg
+# define VMOPTIONOBJ(arg) @"--"arg
+#else
+# define VMOPTION(arg) "-"arg
+# define VMOPTIONOBJ(arg) @"-"arg
+#endif
+
 usqInt gMaxHeapSize = 512*1024*1024;
 
 #if defined(__GNUC__) && ( defined(i386) || defined(__i386) || defined(__i386__)  \
@@ -158,60 +166,60 @@ static char *getVersionInfo(int verbose);
 	/* Options with no arguments */
 
 	NS_DURING;
-		if ([argData compare:  @"-psn_" options: NSLiteralSearch range: NSMakeRange(0,5)] == NSOrderedSame) {
+		if ([argData compare:  VMOPTIONOBJ("psn_") options: NSLiteralSearch range: NSMakeRange(0,5)] == NSOrderedSame) {
 			return 1;
 		}
 	NS_HANDLER;
 	NS_ENDHANDLER;
 
-	if ([argData isEqualToString: @"-help"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("help")]) {
 		[self usage];
 		exit(0);
 		return 1;
 	}
-	if ([argData isEqualToString: @"-version"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("version")]) {
 		printf("%s\n", getVersionInfo(0));
 		exit(0);
 		return 1;
 	}
-	if ([argData isEqualToString: @"-blockonerror"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("blockonerror")]) {
 		extern int blockOnError;
 		blockOnError = true;
 		return 1;
 	}
-	if ([argData isEqualToString: @"-blockonwarn"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("blockonwarn")]) {
 		extern int blockOnError;
 		extern sqInt erroronwarn;
 		erroronwarn = blockOnError = true;
 		return 1;
 	}
-	if ([argData isEqualToString: @"-exitonwarn"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("exitonwarn")]) {
 		extern sqInt erroronwarn;
 		erroronwarn = true;
 		return 1;
 	}
-	if ([argData isEqualToString: @"-headless"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("headless")]) {
 		extern BOOL gSqueakHeadless;
 		gSqueakHeadless = YES;
 		return 1;
 	}
-	if ([argData isEqualToString: @"-headfull"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("headfull")]) {
 		extern BOOL gSqueakHeadless;
 		gSqueakHeadless = NO;
 		return 1;
 	}
-    if ([argData isEqualToString: @"-nohandlers"]) {
+    if ([argData isEqualToString: VMOPTIONOBJ("nohandlers")]) {
 		extern BOOL gNoSignalHandlers;
         gNoSignalHandlers = YES;
         return 1;
     }
-	if ([argData isEqualToString: @"-timephases"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("timephases")]) {
 		extern void printPhaseTime(int);
 		printPhaseTime(1);
 		return 1;
 	}
 #if COGVM
-	if ([argData compare:  @"-trace" options: NSLiteralSearch range: NSMakeRange(0,6)] == NSOrderedSame) {
+	if ([argData compare:  VMOPTIONOBJ("trace") options: NSLiteralSearch range: NSMakeRange(0,6)] == NSOrderedSame) {
 		extern int traceFlags;
 
 		if ([argData length] == 6) {
@@ -226,30 +234,30 @@ static char *getVersionInfo(int verbose);
 		traceFlags = atoi([argData UTF8String] + 7);
 		return 1;
 	}
-	if ([argData isEqualToString: @"-tracestores"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("tracestores")]) {
 		extern sqInt traceStores;
 		traceStores = 1;
 		return 1;
 	}
 #endif
 #if STACKVM
-	if ([argData isEqualToString: @"-checkpluginwrites"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("checkpluginwrites")]) {
 		extern sqInt checkAllocFiller;
 		checkAllocFiller = 1;
 		return 1;
 	}
-	if ([argData isEqualToString: @"-noheartbeat"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("noheartbeat")]) {
 		extern sqInt suppressHeartbeatFlag;
 		suppressHeartbeatFlag = 1;
 		return 1;
 	}
-	if ([argData isEqualToString: @"-warnpid"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("warnpid")]) {
 		extern sqInt warnpid;
 		warnpid = getpid();
 		return 1;
 	}
-	if ([argData isEqualToString: @"-reportheadroom"]
-	 || [argData isEqualToString: @"-rh"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("reportheadroom")]
+	 || [argData isEqualToString: VMOPTIONOBJ("rh")]) {
 		extern sqInt reportStackHeadroom;
 		reportStackHeadroom = 1;
 		return 1;
@@ -260,7 +268,7 @@ static char *getVersionInfo(int verbose);
 	if (!peek)
 		return 0;
 
-	if ([argData isEqualToString: @"-memory"]) {
+	if ([argData isEqualToString: VMOPTIONOBJ("memory")]) {
 		gMaxHeapSize = (usqInt) [self strtobkm: peek];
 		return 2;
 	}
@@ -270,74 +278,74 @@ static char *getVersionInfo(int verbose);
     }
 
 #if STACKVM || NewspeakVM
-	if ([argData isEqualToString: @"-breaksel"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("breaksel")]) {
 		extern void setBreakSelector(char *);
 		setBreakSelector(peek);
 		return 2;
 	}
 #endif
 #if STACKVM
-	if ([argData isEqualToString: @"-breakmnu"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("breakmnu")]) {
 		extern void setBreakMNUSelector(char *);
 		setBreakMNUSelector(peek);
 		return 2;
 	}
-	if ([argData isEqualToString: @"-eden"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("eden")]) {
 		extern sqInt desiredEdenBytes;
 		desiredEdenBytes = [self strtobkm: peek]; 
 		return 2;
 	}
-	if ([argData isEqualToString: @"-leakcheck"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("leakcheck")]) {
 		extern sqInt checkForLeaks;
 		checkForLeaks = atoi(peek);		 
 		return 2;
 	}
-	if ([argData isEqualToString: @"-stackpages"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("stackpages")]) {
 		extern sqInt desiredNumStackPages;
 		desiredNumStackPages = atoi(peek);		 
 		return 2;
 	}
-	if ([argData isEqualToString: @"-numextsems"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("numextsems")]) {
 		ioSetMaxExtSemTableSize(atoi(peek));
 		return 2;
 	}
-	if ([argData isEqualToString: @"-pollpip"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("pollpip")]) {
 		extern sqInt pollpip;
 		pollpip = atoi(peek);		 
 		return 2;
 	}
 #endif /* STACKVM */
 #if COGVM
-	if ([argData isEqualToString: @"-codesize"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("codesize")]) {
 		extern sqInt desiredCogCodeSize;
 		desiredCogCodeSize = [self strtobkm: peek];		 
 		return 2;
 	}
-	if ([argData isEqualToString: @"-dpcso"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("dpcso")]) {
 		extern unsigned long debugPrimCallStackOffset;
 		debugPrimCallStackOffset = (unsigned long)[self strtobkm: peek];		 
 		return 2;
 	}
-	if ([argData isEqualToString: @"-cogmaxlits"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("cogmaxlits")]) {
 		extern sqInt maxLiteralCountForCompile;
 		maxLiteralCountForCompile = [self strtobkm: peek];		 
 		return 2;
 	}
-	if ([argData isEqualToString: @"-cogminjumps"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("cogminjumps")]) {
 		extern sqInt minBackwardJumpCountForCompile;
 		minBackwardJumpCountForCompile = [self strtobkm: peek];		 
 		return 2;
 	}
 #endif /* COGVM */
 #if SPURVM
-	if ([argData isEqualToString: @"-maxoldspace"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("maxoldspace")]) {
 		extern unsigned long maxOldSpaceSize;
 		maxOldSpaceSize = (unsigned long)[self strtobkm: peek];		 
 		return 2;
 	}
 #endif
 #if 0 /* Not sure if encoding is an issue with the Cocoa VM. eem 2015-11-30 */
-	if ([argData isEqualToString: @"-pathenc"]) { 
+	if ([argData isEqualToString: VMOPTIONOBJ("pathenc")]) {
 		setEncodingType(peek);
 		return 2;
 	}
@@ -442,60 +450,60 @@ static char *getVersionInfo(int verbose);
 
 - (void) printUsage {
 	printf("\nCommon <option>s:\n");
-	printf("  -help                 print this help message, then exit\n");
-	printf("  -memory <size>[mk]    use fixed heap size (added to image size)\n");
-    printf("  -nohandlers           disable sigsegv & sigusr1 handlers\n");
-	printf("  -timephases           print start load and run times\n");
+	printf("  "VMOPTION("help")"                 print this help message, then exit\n");
+	printf("  "VMOPTION("memory")" <size>[mk]    use fixed heap size (added to image size)\n");
+    printf("  "VMOPTION("nohandlers")"           disable sigsegv & sigusr1 handlers\n");
+	printf("  "VMOPTION("timephases")"           print start load and run times\n");
 #if STACKVM || NewspeakVM
-	printf("  -breaksel selector    set breakpoint on send of selector\n");
+	printf("  "VMOPTION("breaksel")" selector    set breakpoint on send of selector\n");
 #endif
 #if STACKVM
-	printf("  -breakmnu selector    set breakpoint on MNU of selector\n");
-	printf("  -eden <size>[mk]      set eden memory to bytes\n");
-	printf("  -leakcheck num        check for leaks in the heap\n");
-	printf("  -stackpages num       use n stack pages\n");
-	printf("  -numextsems num       make the external semaphore table num in size\n");
-	printf("  -noheartbeat          disable the heartbeat for VM debugging. disables input\n");
-	printf("  -pollpip              output . on each poll for input\n");
-	printf("  -checkpluginwrites    check for writes past end of object in plugins\n");
+	printf("  "VMOPTION("breakmnu")" selector    set breakpoint on MNU of selector\n");
+	printf("  "VMOPTION("eden")" <size>[mk]      set eden memory to bytes\n");
+	printf("  "VMOPTION("leakcheck")" num        check for leaks in the heap\n");
+	printf("  "VMOPTION("stackpages")" num       use n stack pages\n");
+	printf("  "VMOPTION("numextsems")" num       make the external semaphore table num in size\n");
+	printf("  "VMOPTION("noheartbeat")"          disable the heartbeat for VM debugging. disables input\n");
+	printf("  "VMOPTION("pollpip")"              output . on each poll for input\n");
+	printf("  "VMOPTION("checkpluginwrites")"    check for writes past end of object in plugins\n");
 #endif
 #if STACKVM || NewspeakVM
 # if COGVM
-	printf("  -trace[=num]          enable tracing (optionally to a specific value)\n");
+	printf("  "VMOPTION("trace")"[=num]          enable tracing (optionally to a specific value)\n");
 # else
-	printf("  -sendtrace            enable send tracing\n");
+	printf("  "VMOPTION("sendtrace")"            enable send tracing\n");
 # endif
-	printf("  -warnpid              print pid in warnings\n");
+	printf("  "VMOPTION("warnpid")"              print pid in warnings\n");
 #endif
 #if COGVM
-	printf("  -codesize <size>[mk]  set machine code memory to bytes\n");
-	printf("  -tracestores          enable store tracing (assert check stores)\n");
-	printf("  -cogmaxlits <n>       set max number of literals for methods to be compiled to machine code\n");
-	printf("  -cogminjumps <n>      set min number of backward jumps for interpreted methods to be considered for compilation to machine code\n");
-	printf("  -reportheadroom       report unused stack headroom on exit\n");
+	printf("  "VMOPTION("codesize")" <size>[mk]  set machine code memory to bytes\n");
+	printf("  "VMOPTION("tracestores")"          enable store tracing (assert check stores)\n");
+	printf("  "VMOPTION("cogmaxlits")" <n>       set max number of literals for methods to be compiled to machine code\n");
+	printf("  "VMOPTION("cogminjumps")" <n>      set min number of backward jumps for interpreted methods to be considered for compilation to machine code\n");
+	printf("  "VMOPTION("reportheadroom")"       report unused stack headroom on exit\n");
 #endif
 #if SPURVM
-	printf("  -maxoldspace <size>[mk]      set max size of old space memory to bytes\n");
+	printf("  "VMOPTION("maxoldspace")" <size>[mk]      set max size of old space memory to bytes\n");
 #endif
 #if 0 /* Not sure if encoding is an issue with the Cocoa VM. eem 2015-11-30 */
-	printf("  -pathenc <enc>        set encoding for pathnames (default: %s)\n",
+	printf("  "VMOPTION("pathenc")" <enc>        set encoding for pathnames (default: %s)\n",
 		getEncodingType([self currentVMEncoding]));
 #endif
-	printf("  -headless             run in headless (no window) mode (default: false)\n");
-	printf("  -headfull             run in headful (window) mode (default: true)\n");
-	printf("  -version              print version information, then exit\n");
+	printf("  "VMOPTION("headless")"             run in headless (no window) mode (default: false)\n");
+	printf("  "VMOPTION("headfull")"             run in headful (window) mode (default: true)\n");
+	printf("  "VMOPTION("version")"              print version information, then exit\n");
 
-	printf("  -blockonerror         on error or segv block, not exit.  useful for attaching gdb\n");
-	printf("  -blockonwarn          on warning block, don't warn.  useful for attaching gdb\n");
-	printf("  -exitonwarn           treat warnings as errors, exiting on warn\n");
+	printf("  "VMOPTION("blockonerror")"         on error or segv block, not exit.  useful for attaching gdb\n");
+	printf("  "VMOPTION("blockonwarn")"          on warning block, don't warn.  useful for attaching gdb\n");
+	printf("  "VMOPTION("exitonwarn")"           treat warnings as errors, exiting on warn\n");
 }
 
 - (void) printUsageNotes
 {
 #if SPURVM
-	printf("  If `-memory' or '-maxoldspace' are not specified then the heap will grow dynamically.\n");
+	printf("  If '"VMOPTION("memory")"' or '-maxoldspace' are not specified then the heap will grow dynamically.\n");
 #else
-	printf("  If `-memory' is not specified then the heap will grow dynamically.\n");
+	printf("  If '"VMOPTION("memory")"' is not specified then the heap will grow dynamically.\n");
 #endif
 	printf("  <argument>s are ignored, but are processed by the Squeak image.\n");
 	printf("  The first <argument> normally names a Squeak `script' to execute.\n");


### PR DESCRIPTION
in pharo we use double dash (I will submit linux and windows versions in a couple of days)