### PR TITLE
Bug when calling mprotect and VirtualAlloc with the SpurMemoryManager

### DIFF
--- a/platforms/unix/vm/sqUnixSpurMemory.c
+++ b/platforms/unix/vm/sqUnixSpurMemory.c
@@ -1,19 +1,19 @@
 /* sqUnixSpurMemory.c -- dynamic memory management for Spur on unix & Mac OS X.
- * 
+ *
  * Author: eliot.miranda@gmail.com
- * 
+ *
  *   This file is part of Unix Squeak.
- * 
+ *
  *   Permission is hereby granted, free of charge, to any person obtaining a
  *   copy of this software and associated documentation files (the "Software"),
  *   to deal in the Software without restriction, including without limitation
  *   the rights to use, copy, modify, merge, publish, distribute, sublicense,
  *   and/or sell copies of the Software, and to permit persons to whom the
  *   Software is furnished to do so, subject to the following conditions:
- * 
+ *
  *   The above copyright notice and this permission notice shall be included in
  *   all copies or substantial portions of the Software.
- * 
+ *
  *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -164,9 +164,10 @@ sqDeallocateMemorySegmentAtOfSize(void *addr, sqInt sz)
 void
 sqMakeMemoryExecutableFromTo(unsigned long startAddr, unsigned long endAddr)
 {
+	unsigned long size = endAddr - startAddr;
 	unsigned long firstPage = roundDownToPage(startAddr);
 	if (mprotect((void *)firstPage,
-				 endAddr - firstPage + 1,
+				 size,
 				 PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
 		perror("mprotect(x,y,PROT_READ | PROT_WRITE | PROT_EXEC)");
 }
@@ -174,17 +175,16 @@ sqMakeMemoryExecutableFromTo(unsigned long startAddr, unsigned long endAddr)
 void
 sqMakeMemoryNotExecutableFromTo(unsigned long startAddr, unsigned long endAddr)
 {
-#	if 0
+	unsigned long size = endAddr - startAddr;
 	unsigned long firstPage = roundDownToPage(startAddr);
 	/* Arguably this is pointless since allocated memory always includes write
 	 * permission by default.  Annoyingly the mprotect call fails on both linux
 	 * and mac os x.  So make the whole thing a nop.
 	 */
 	if (mprotect((void *)firstPage,
-				 endAddr - firstPage + 1,
+				 size,
 				 PROT_READ | PROT_WRITE) < 0)
 		perror("mprotect(x,y,PROT_READ | PROT_WRITE)");
-#	endif
 }
 # endif /* COGVM */
 

--- a/platforms/unix/vm/sqUnixSpurMemory.c
+++ b/platforms/unix/vm/sqUnixSpurMemory.c
@@ -164,8 +164,8 @@ sqDeallocateMemorySegmentAtOfSize(void *addr, sqInt sz)
 void
 sqMakeMemoryExecutableFromTo(unsigned long startAddr, unsigned long endAddr)
 {
-	unsigned long size = endAddr - startAddr;
 	unsigned long firstPage = roundDownToPage(startAddr);
+	unsigned long size = endAddr - firstPage;
 	if (mprotect((void *)firstPage,
 				 size,
 				 PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
@@ -175,8 +175,8 @@ sqMakeMemoryExecutableFromTo(unsigned long startAddr, unsigned long endAddr)
 void
 sqMakeMemoryNotExecutableFromTo(unsigned long startAddr, unsigned long endAddr)
 {
-	unsigned long size = endAddr - startAddr;
 	unsigned long firstPage = roundDownToPage(startAddr);
+	unsigned long size = endAddr - firstPage;
 	/* Arguably this is pointless since allocated memory always includes write
 	 * permission by default.  Annoyingly the mprotect call fails on both linux
 	 * and mac os x.  So make the whole thing a nop.

--- a/platforms/win32/vm/sqWin32SpurAlloc.c
+++ b/platforms/win32/vm/sqWin32SpurAlloc.c
@@ -199,9 +199,11 @@ void
 sqMakeMemoryExecutableFromTo(usqIntptr_t startAddr, usqIntptr_t endAddr)
 {
 	DWORD previous;
+    SIZE_T size;
 
+    size = endAddr - startAddr;
 	if (!VirtualProtect((void *)startAddr,
-						endAddr - startAddr + 1,
+						size,
 						PAGE_EXECUTE_READWRITE,
 						&previous))
 		perror("VirtualProtect(x,y,PAGE_EXECUTE_READWRITE)");
@@ -211,9 +213,11 @@ void
 sqMakeMemoryNotExecutableFromTo(usqIntptr_t startAddr, usqIntptr_t endAddr)
 {
 	DWORD previous;
+    SIZE_T size;
 
+    size = endAddr - startAddr;
 	if (!VirtualProtect((void *)startAddr,
-						endAddr - startAddr + 1,
+						size,
 						PAGE_READWRITE,
 						&previous))
 		perror("VirtualProtect(x,y,PAGE_EXECUTE_READWRITE)");


### PR DESCRIPTION
The endAddr parameter to sqMakeMemoryNotExecutableFromTo is exclusive. This means, that the size computation (endAddr - startAddr + 1) does not need the extra + 1.

When computing the size for mprotect and VirtualProtect with just endAddr - startAddr, the call does not fail anymore in Windows, Linux and OS X.

Please validate this with how are these functions used from the Slang side.