### PR TITLE
add posix permissions to FilePlugin for Windows (PharoVM)

### DIFF
--- a/build.linux32ARMv6/pharo.cog.spur/plugins.ext
+++ b/build.linux32ARMv6/pharo.cog.spur/plugins.ext
@@ -8,5 +8,6 @@ RePlugin \
 InternetConfigPlugin \
 SurfacePlugin \
 EventsHandlerPlugin \
+SqueakSSL \
 #SDL2DisplayPlugin \
 

--- a/build.linux32x86/pharo.cog.spur/plugins.ext
+++ b/build.linux32x86/pharo.cog.spur/plugins.ext
@@ -8,5 +8,6 @@ RePlugin \
 InternetConfigPlugin \
 SurfacePlugin \
 EventsHandlerPlugin \
+SqueakSSL \
 # SDL2DisplayPlugin \
 

--- a/build.linux64x64/pharo.cog.spur/plugins.ext
+++ b/build.linux64x64/pharo.cog.spur/plugins.ext
@@ -8,5 +8,6 @@ RePlugin \
 InternetConfigPlugin \
 SurfacePlugin \
 EventsHandlerPlugin \
+SqueakSSL \
 #SDL2DisplayPlugin \
 

--- a/platforms/iOS/vm/Common/Classes/sqSqueakFileDirectoryInterface.m
+++ b/platforms/iOS/vm/Common/Classes/sqSqueakFileDirectoryInterface.m
@@ -61,12 +61,14 @@ such third-party acknowledgments.
 #define BAD_PATH        2
 
 - (sqInt)linkIsDirectory:(NSString *)filePath fileManager:(NSFileManager *)fileManager {
-    NSString *resolvedPath = [self resolvedAliasFiles: filePath];
+    NSString *resolvedPath;
 	NSDictionary *fileAttributes;
     NSError *error;
     
+    resolvedPath = [self resolvedAliasFiles: filePath];
 	fileAttributes = [fileManager attributesOfItemAtPath:resolvedPath error: &error];
-    return [[fileAttributes objectForKey: NSFileType] isEqualToString: NSFileTypeDirectory] ? 1 : 0;
+    
+    return [fileAttributes[NSFileType] isEqualToString: NSFileTypeDirectory] ? 1 : 0;
 }
 
 - (sqInt)attributesForPath:(NSString *)filePath 
@@ -368,11 +370,10 @@ such third-party acknowledgments.
 	
 	NSNumber *typeCode = [NSNumber numberWithUnsignedLong: CFSwapInt32HostToBig(*((uint32_t *) fType))];
 	NSNumber *creatorCode = [NSNumber numberWithUnsignedLong: CFSwapInt32HostToBig(*((uint32_t *) fCreator))];
-
-	
-    BOOL ok=[fileMgr  setAttributes:  @{ NSFileHFSTypeCode : typeCode, NSFileHFSCreatorCode: creatorCode} ofItemAtPath: filePath
-													 error: NULL];
-	return ok;
+    return [fileMgr
+             setAttributes: @{ NSFileHFSTypeCode: typeCode, NSFileHFSCreatorCode: creatorCode }
+             ofItemAtPath: filePath
+             error: NULL];
 }
 
 - (NSString *) resolvedAliasFiles: (NSString *) filePath {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXFileDirectoryInterface.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXFileDirectoryInterface.m
@@ -103,7 +103,7 @@ extern SqueakOSXAppDelegate *gDelegateApp;
         return nil;
     }
 	
-	if ((url = CFBridgingRelease((NSURL *)CFURLCreateFromFSRef(kCFAllocatorDefault, &aliasRef)))) {
+	if ((url = (NSURL *)CFBridgingRelease(CFURLCreateFromFSRef(kCFAllocatorDefault, &aliasRef)))) {
         outString = [url path];
 	}
     


### PR DESCRIPTION
I ported our implementation of posix permission for windows (we were having a lot of problems without it). It would be cool if it becomes common to all VMs, but for the moment is just in PharoVM (I'll let you guys to choose if you want it or not :) ) 

btw, this PR also fixes a bug on `#isDirectory` on macOS: it was not resolving correctly if directory was a symlink