### PR TITLE
Fix issue 119 jpeg plugin crashes in Win64

### DIFF
--- a/platforms/Cross/plugins/JPEGReadWriter2Plugin/Error.c
+++ b/platforms/Cross/plugins/JPEGReadWriter2Plugin/Error.c
@@ -5,7 +5,7 @@
 struct error_mgr2 {
   struct jpeg_error_mgr pub;	/* "public" fields */
 
-  jmp_buf setjmp_buffer;	/* for return to caller */
+  jmp_buf *setjmp_buffer;	/* for return to caller */
 };
 
 typedef struct error_mgr2 * error_ptr2;
@@ -20,5 +20,5 @@ void error_exit (j_common_ptr cinfo)
   error_ptr2 myerr = (error_ptr2) cinfo->err;
 
   /* Return control to the setjmp point */
-  longjmp(myerr->setjmp_buffer, 1);
+  longjmp(*myerr->setjmp_buffer, 1);
 }

--- a/platforms/Cross/plugins/JPEGReadWriter2Plugin/JPEGReadWriter2Plugin.h
+++ b/platforms/Cross/plugins/JPEGReadWriter2Plugin/JPEGReadWriter2Plugin.h
@@ -6,7 +6,7 @@
 struct error_mgr2 {
   struct jpeg_error_mgr pub;	/* "public" fields */
 
-  jmp_buf setjmp_buffer;	/* for return to caller */
+  jmp_buf *setjmp_buffer;	/* for return to caller */
 };
 
 typedef struct error_mgr2* error_ptr2;

--- a/platforms/Cross/plugins/JPEGReadWriter2Plugin/sqJPEGReadWriter2Plugin.c
+++ b/platforms/Cross/plugins/JPEGReadWriter2Plugin/sqJPEGReadWriter2Plugin.c
@@ -54,9 +54,10 @@ primJPEGWriteImageonByteArrayformqualityprogressiveJPEGerrorMgrWriteScanlines(
 	error_ptr2 pjerr = (error_ptr2)jpegErrorMgr2Struct;
 
 	pcinfo->err = jpeg_std_error(&pjerr->pub);
+    pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
 	pjerr->pub.error_exit = error_exit;
 
-	if (setjmp(pjerr->setjmp_buffer)) {
+	if (setjmp(*pjerr->setjmp_buffer)) {
 		jpeg_destroy_compress(pcinfo);
 
 		*destinationSizePtr = 0;
@@ -133,6 +134,7 @@ primJPEGWriteImageonByteArrayformqualityprogressiveJPEGerrorMgrWriteScanlines(
 		jpeg_finish_compress(pcinfo);
 		jpeg_destroy_compress(pcinfo);
 	}
+    free(pjerr->setjmp_buffer);
 }
 
 void
@@ -152,9 +154,10 @@ primJPEGReadImagefromByteArrayonFormdoDitheringerrorMgrReadScanlines(
 
 	int ok = 1;
 	pcinfo->err = jpeg_std_error(&pjerr->pub);
+    pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
 	pjerr->pub.error_exit = error_exit;
 
-	if (setjmp(pjerr->setjmp_buffer)) {
+	if (setjmp(*pjerr->setjmp_buffer)) {
 		jpeg_destroy_decompress(pcinfo);
 		ok = 0;
 	}
@@ -280,6 +283,7 @@ primJPEGReadImagefromByteArrayonFormdoDitheringerrorMgrReadScanlines(
 		jpeg_finish_decompress(pcinfo);
 		jpeg_destroy_decompress(pcinfo);
 	}
+    free(pjerr->setjmp_buffer);
 }
 
 void
@@ -293,9 +297,10 @@ primJPEGReadHeaderfromByteArraysizeerrorMgrReadHeader(
 	error_ptr2 pjerr = (error_ptr2)jpegErrorMgr2Struct;
 
 	pcinfo->err = jpeg_std_error(&pjerr->pub);
+    pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
 	pjerr->pub.error_exit = error_exit;
 
-	if (setjmp(pjerr->setjmp_buffer)) {
+	if (setjmp(*pjerr->setjmp_buffer)) {
 		jpeg_destroy_decompress(pcinfo);
 		sourceSize = 0;
 	}
@@ -305,4 +310,5 @@ primJPEGReadHeaderfromByteArraysizeerrorMgrReadHeader(
 		jpeg_mem_src(pcinfo, source, sourceSize);
 		jpeg_read_header(pcinfo, TRUE);
 	}
+    free(pjerr->setjmp_buffer);
 }

--- a/platforms/Cross/plugins/JPEGReadWriter2Plugin/sqJPEGReadWriter2Plugin.c
+++ b/platforms/Cross/plugins/JPEGReadWriter2Plugin/sqJPEGReadWriter2Plugin.c
@@ -54,7 +54,7 @@ primJPEGWriteImageonByteArrayformqualityprogressiveJPEGerrorMgrWriteScanlines(
 	error_ptr2 pjerr = (error_ptr2)jpegErrorMgr2Struct;
 
 	pcinfo->err = jpeg_std_error(&pjerr->pub);
-    pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
+	pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
 	pjerr->pub.error_exit = error_exit;
 
 	if (setjmp(*pjerr->setjmp_buffer)) {
@@ -134,7 +134,7 @@ primJPEGWriteImageonByteArrayformqualityprogressiveJPEGerrorMgrWriteScanlines(
 		jpeg_finish_compress(pcinfo);
 		jpeg_destroy_compress(pcinfo);
 	}
-    free(pjerr->setjmp_buffer);
+	free(pjerr->setjmp_buffer);
 }
 
 void
@@ -154,7 +154,7 @@ primJPEGReadImagefromByteArrayonFormdoDitheringerrorMgrReadScanlines(
 
 	int ok = 1;
 	pcinfo->err = jpeg_std_error(&pjerr->pub);
-    pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
+	pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
 	pjerr->pub.error_exit = error_exit;
 
 	if (setjmp(*pjerr->setjmp_buffer)) {
@@ -283,7 +283,7 @@ primJPEGReadImagefromByteArrayonFormdoDitheringerrorMgrReadScanlines(
 		jpeg_finish_decompress(pcinfo);
 		jpeg_destroy_decompress(pcinfo);
 	}
-    free(pjerr->setjmp_buffer);
+	free(pjerr->setjmp_buffer);
 }
 
 void
@@ -297,7 +297,7 @@ primJPEGReadHeaderfromByteArraysizeerrorMgrReadHeader(
 	error_ptr2 pjerr = (error_ptr2)jpegErrorMgr2Struct;
 
 	pcinfo->err = jpeg_std_error(&pjerr->pub);
-    pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
+	pjerr->setjmp_buffer = (jmp_buf *) malloc(sizeof(jmp_buf));
 	pjerr->pub.error_exit = error_exit;
 
 	if (setjmp(*pjerr->setjmp_buffer)) {
@@ -310,5 +310,5 @@ primJPEGReadHeaderfromByteArraysizeerrorMgrReadHeader(
 		jpeg_mem_src(pcinfo, source, sourceSize);
 		jpeg_read_header(pcinfo, TRUE);
 	}
-    free(pjerr->setjmp_buffer);
+	free(pjerr->setjmp_buffer);
 }


### PR DESCRIPTION
Solution is to align jump_buf on 16bytes boundary by using malloc/free pairs around setjmp/longjmp calls.
The struct error_mgr2 now contains a pointer to the jump_buf for this purpose.