### PR TITLE
libtool: Help people living in the past

### DIFF
--- a/platforms/unix/config/ltmain.sh
+++ b/platforms/unix/config/ltmain.sh
@@ -186,6 +186,9 @@ do
     prev=execute_dlfiles
     ;;
 
+  --preserve-dup-deps)
+    ;;
+
   -*)
     $echo "$modename: unrecognized option \`$arg'" 1>&2
     $echo "$help" 1>&2


### PR DESCRIPTION
Teach the old libtool a new option (that is enabled anyway).
This will help people not re-generating their buildsystem. As
the old configure has been patched by hand, I think adding
this option is in line as well.

In commit fec94cb81299d8a76105eff3667dbe8588649220 I made it
possible to run autoreconf and the newer libtool required us
to pass --preserve-dup-deps to list objects multiple times.
Adding this option sadly broke the build when using the
already generated ltmain.sh/libtool. Try to fix that.