### PR TITLE
command line arguments use single dash prefix but also accept doubledash

### DIFF
--- a/platforms/unix/vm-display-Quartz/zzz/sqUnixQuartz.m
+++ b/platforms/unix/vm-display-Quartz/zzz/sqUnixQuartz.m
@@ -101,11 +101,7 @@
 // 
 #undef	FULLSCREEN_FADE	 0.02
 
-#ifdef PharoVM
-# define VMOPTION(arg) "--"arg
-#else
 # define VMOPTION(arg) "-"arg
-#endif
 
 /// 
 /// No more user-serviceable parts in this file.  Stop Tweaking Now!

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -160,11 +160,7 @@
 # define xResName	"squeak"
 #endif
 
-#ifdef PharoVM
-# define VMOPTION(arg) "--"arg
-#else
 # define VMOPTION(arg) "-"arg
-#endif
 
 char		*displayName= 0;	/* name of display, or 0 for $DISPLAY */
 Display		*stDisplay= null;	/* Squeak display */

--- a/platforms/unix/vm-display-null/sqUnixDisplayNull.c
+++ b/platforms/unix/vm-display-null/sqUnixDisplayNull.c
@@ -185,11 +185,7 @@ SqDisplayDefine(null);
 
 static void  display_parseEnvironment(void) {}
 
-#ifdef PharoVM
-# define VMOPTION(arg) "--"arg
-#else
 # define VMOPTION(arg) "-"arg
-#endif
 
 static int   display_parseArgument(int argc, char **argv)
 {

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -1378,7 +1378,7 @@ static void vm_parseEnvironment(void)
 }
 
 
-static void usage(int exitValue);
+static void usage();
 static void versionInfo(void);
 
 
@@ -1464,7 +1464,7 @@ static int vm_parseArgument(int argc, char **argv)
 
   /* vm arguments */
 
-  if      (!strcmp(argv[0], VMOPTION("help")))		{ usage(0);         /*NOTREACHED*/}
+  if      (!strcmp(argv[0], VMOPTION("help")))		{ usage();         	exit(0); }
   else if (!strcmp(argv[0], VMOPTION("version")))	{ versionInfo();	return 0; }
   else if (!strcmp(argv[0], VMOPTION("noevents")))	{ noEvents	= 1;	return 1; }
   else if (!strcmp(argv[0], VMOPTION("nomixer")))	{ noSoundMixer	= 1;	return 1; }
@@ -1689,7 +1689,7 @@ SqModuleDefine(vm, Module);
 /*** options processing ***/
 
 
-static void usage(int exitValue)
+static void usage()
 {
   struct SqModule *m= 0;
   printf("Usage: %s [<option>...] [<imageName> [<argument>...]]\n", argVec[0]);
@@ -1719,7 +1719,6 @@ static void usage(int exitValue)
   printf("\nAvailable drivers:\n");
   for (m= modules;  m->next;  m= m->next)
     printf("  %s\n", m->name);
-  exit(exitValue);
 }
 
 
@@ -1817,8 +1816,8 @@ static void parseArguments(int argc, char **argv)
       if (n == 0)			/* option not recognised */
 	{
 	  fprintf(stderr, "unknown option: %s\n", argv[0]);
-	  usage(1);
-	  /*NOTREACHED*/
+	  usage();
+	  exit(1);
 	}
       while (n--)
 	saveArg();

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -1399,9 +1399,6 @@ static int vm_parseArgument(int argc, char **argv)
   // parse arguments for main vm module including those that
   // implicitly load modules.
 
-  if (argv[0][0] == '-' && argv[0][1] == '-')
-	argv[0]++;	/* skip one dash in double dash options */
-
   if (!strncmp(argv[0], "-psn_", 5))
     {
       displayModule= requireModule("display", "Quartz");
@@ -1805,11 +1802,17 @@ static void parseArguments(int argc, char **argv)
     {
       struct SqModule *m= 0;
       int n= 0;
+      int ddash=0;
       if (!strcmp(*argv, "--"))		/* escape from option processing */
 	break;
+      ddash = (argv[0][1] == '-');
+      if (ddash)
+	argv[0]++;	/* skip one dash in double dash options */
       modulesDo (m)
 	if ((n= m->parseArgument(argc, argv)))
 	  break;
+      if (ddash)
+	argv[0]--;
 #    ifdef DEBUG_IMAGE
       printf("parseArgument n = %d\n", n);
 #    endif


### PR DESCRIPTION
Unix conventions use -- for word options and - for single letter options. But this applies only to Unix commands and not to virtual machines like qemu or squeak.

PharoVM compile time macro replaced - with --. These modifications use a single dash in all help messages while recovering gracefully if two dashes are used for prefixes accomodating both classic squeak and the newer pharo usage.

Using -help or -version no longer exits with non-zero codes as they are valid usages.