### PR TITLE
[skip ci] uuid-dev is needed on Ubuntu for configure script.

### DIFF
--- a/build.linux64x64/HowToBuild
+++ b/build.linux64x64/HowToBuild
@@ -248,7 +248,6 @@ and then retry.
 
 
 Ubuntu
-	sudo apt-get install libcairo2-dev   
-	sudo apt-get install libpango1.0-dev
+	sudo apt-get install uuid-dev libcairo2-dev libpango1.0-dev libgl1-mesa-dev libgl1-mesa-glx
 
 More advice and examples for other distros gratefully received.


### PR DESCRIPTION
Updated build instructions to add uuid-dev and GL libraries for configure script to run on Ubuntu. Without uuid-dev configure would fail with an error message about missing uuid library.