### PR TITLE
add linux and mac VMProfilePlugins for Pharo

### DIFF
--- a/build.linux32ARMv6/pharo.cog.spur/plugins.int
+++ b/build.linux32ARMv6/pharo.cog.spur/plugins.int
@@ -31,4 +31,6 @@ SoundPlugin \
 StarSqueakPlugin \
 LocalePlugin \
 UnixOSProcessPlugin \
+VMProfileLinuxSupportPlugin \
 #Klatt \
+

--- a/build.linux32x86/pharo.cog.spur.lowcode/plugins.int
+++ b/build.linux32x86/pharo.cog.spur.lowcode/plugins.int
@@ -31,4 +31,6 @@ SoundPlugin \
 StarSqueakPlugin \
 LocalePlugin \
 UnixOSProcessPlugin \
+VMProfileLinuxSupportPlugin \
 #Klatt \
+

--- a/build.linux32x86/pharo.cog.spur/plugins.int
+++ b/build.linux32x86/pharo.cog.spur/plugins.int
@@ -31,4 +31,6 @@ SoundPlugin \
 StarSqueakPlugin \
 LocalePlugin \
 UnixOSProcessPlugin \
+VMProfileLinuxSupportPlugin \
 #Klatt \
+

--- a/build.linux32x86/pharo.stack.spur.lowcode/plugins.int
+++ b/build.linux32x86/pharo.stack.spur.lowcode/plugins.int
@@ -31,4 +31,6 @@ SoundPlugin \
 StarSqueakPlugin \
 LocalePlugin \
 UnixOSProcessPlugin \
+VMProfileLinuxSupportPlugin \
 #Klatt \
+

--- a/build.linux64x64/pharo.cog.spur/plugins.int
+++ b/build.linux64x64/pharo.cog.spur/plugins.int
@@ -31,4 +31,6 @@ SoundPlugin \
 StarSqueakPlugin \
 LocalePlugin \
 UnixOSProcessPlugin \
+VMProfileLinuxSupportPlugin \
 #Klatt \
+

--- a/build.macos32x86/pharo.cog.spur.lowcode/plugins.int
+++ b/build.macos32x86/pharo.cog.spur.lowcode/plugins.int
@@ -25,5 +25,7 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt
+# Klatt 
+

--- a/build.macos32x86/pharo.cog.spur/plugins.int
+++ b/build.macos32x86/pharo.cog.spur/plugins.int
@@ -25,5 +25,7 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt
+# Klatt 
+

--- a/build.macos32x86/pharo.stack.spur.lowcode/plugins.int
+++ b/build.macos32x86/pharo.stack.spur.lowcode/plugins.int
@@ -25,5 +25,6 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt
+# Klatt 

--- a/build.macos32x86/pharo.stack.spur/plugins.int
+++ b/build.macos32x86/pharo.stack.spur/plugins.int
@@ -25,5 +25,7 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt
+# Klatt 
+

--- a/build.macos64x64/pharo.cog.spur.lowcode/plugins.int
+++ b/build.macos64x64/pharo.cog.spur.lowcode/plugins.int
@@ -25,5 +25,6 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt \
+# Klatt 

--- a/build.macos64x64/pharo.cog.spur/plugins.int
+++ b/build.macos64x64/pharo.cog.spur/plugins.int
@@ -25,5 +25,6 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt \
+# Klatt 

--- a/build.macos64x64/pharo.stack.spur.lowcode/plugins.int
+++ b/build.macos64x64/pharo.stack.spur.lowcode/plugins.int
@@ -25,5 +25,6 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt \
+# Klatt 

--- a/build.macos64x64/pharo.stack.spur/plugins.int
+++ b/build.macos64x64/pharo.stack.spur/plugins.int
@@ -25,5 +25,6 @@ SoundPlugin \
 SqueakFFIPrims \
 StarSqueakPlugin \
 UnixOSProcessPlugin \
+VMProfileMacSupportPlugin \
 ZipPlugin \
-# Klatt \
+# Klatt 


### PR DESCRIPTION
The VMProfiler is currently being ported to Pharo. These light plugins are needed to make it work.
see : http://forum.world.st/Missing-plugins-to-make-the-vmProfiler-work-on-Pharo-td4946444.html 