### PR TITLE
20341-libpng-source-is-no-longer-available

### DIFF
--- a/third-party/libpng.spec.win
+++ b/third-party/libpng.spec.win
@@ -2,9 +2,9 @@
 # because 1.6.28 may fail on macOS (1.6.26 did).
 # this cannot be good and eventually it will be a source of problems... so we need to reunite 
 # versions as soon as possible.
-libpng_spec_download_url:=ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.29.tar.gz
-libpng_spec_archive_name:=libpng-1.6.29.tar.gz
-libpng_spec_unpack_dir_name:=libpng-1.6.29
+libpng_spec_download_url:=http://prdownloads.sourceforge.net/libpng/libpng-1.6.30.tar.gz
+libpng_spec_archive_name:=libpng-1.6.30.tar.gz
+libpng_spec_unpack_dir_name:=libpng-1.6.30
 libpng_spec_product_name_macOS:=libpng16.16.dylib
 libpng_spec_product_name_linux:=
 # Yes, 16-16 for some weird reason

--- a/third-party/libpng.spec.win
+++ b/third-party/libpng.spec.win
@@ -2,9 +2,9 @@
 # because 1.6.28 may fail on macOS (1.6.26 did).
 # this cannot be good and eventually it will be a source of problems... so we need to reunite 
 # versions as soon as possible.
-libpng_spec_download_url:=http://prdownloads.sourceforge.net/libpng/libpng-1.6.30.tar.gz
-libpng_spec_archive_name:=libpng-1.6.30.tar.gz
-libpng_spec_unpack_dir_name:=libpng-1.6.30
+libpng_spec_download_url:=ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.32.tar.gz
+libpng_spec_archive_name:=libpng-1.6.32.tar.gz
+libpng_spec_unpack_dir_name:=libpng-1.6.32
 libpng_spec_product_name_macOS:=libpng16.16.dylib
 libpng_spec_product_name_linux:=
 # Yes, 16-16 for some weird reason


### PR DESCRIPTION
The source at ftp.simplesystems.org seems to have gone away.

Based on information at http://www.libpng.org/pub/png/libpng.html
update the download url to point to sourceforge and update to 1.6.30.