### PR TITLE
openssl: Upgrade to minor release "l" to address multiple issues

### DIFF
--- a/third-party/openssl.spec
+++ b/third-party/openssl.spec
@@ -1,6 +1,6 @@
-openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2j.tar.gz
-openssl_spec_archive_name:=openssl-1.0.2j.tar.gz
-openssl_spec_unpack_dir_name:=openssl-1.0.2j
+openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2l.tar.gz
+openssl_spec_archive_name:=openssl-1.0.2l.tar.gz
+openssl_spec_unpack_dir_name:=openssl-1.0.2l
 openssl_spec_product1_name_macOS:=libssl.1.0.0.dylib
 openssl_spec_product2_name_macOS:=libcrypto.1.0.0.dylib
 openssl_spec_product1_name_linux:=libssl.so.1.0.0


### PR DESCRIPTION
According to https://www.openssl.org/news/vulnerabilities.html#y2017
this should fix:

CVE-2017-3731, CVE-2017-3732, CVE-2016-7055.

The download should have the sha256sum of:
ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c