### PR TITLE
Normal way to #include <errno.h>

### DIFF
--- a/platforms/iOS/vm/OSX/sqMacUnixExternalPrims.m
+++ b/platforms/iOS/vm/OSX/sqMacUnixExternalPrims.m
@@ -54,7 +54,7 @@ extern SqueakOSXAppDelegate *gDelegateApp;
 #include <dlfcn.h> 
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 /* get a value for RTLD_NOW, with increasing levels of desperation... */
 

--- a/platforms/unix/vm-sound-pulse/sqUnixSoundPulseAudio.c
+++ b/platforms/unix/vm-sound-pulse/sqUnixSoundPulseAudio.c
@@ -38,7 +38,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/errno.h>
 #include <sys/mman.h>
 #include <string.h>
 #include <unistd.h>

--- a/platforms/unix/vm/sqUnixExternalPrims.c
+++ b/platforms/unix/vm/sqUnixExternalPrims.c
@@ -61,11 +61,7 @@
  
 #include <sys/param.h>
 #include <sys/stat.h>
-#ifdef __OpenBSD__
-#   include <errno.h>
-#else
-#   include <sys/errno.h>
-#endif
+#include <errno.h>
 
 /* get a value for RTLD_NOW, with increasing levels of desperation... */
 


### PR DESCRIPTION
I'm pretty certain that
#include <errno.h>
is the right way to do it everywhere.