### PR TITLE
HowToBuild doesn't have to mention missing libssl

### DIFF
--- a/build.macos32x86/HowToBuild
+++ b/build.macos32x86/HowToBuild
@@ -172,23 +172,28 @@ enough to build the system.  The 32-bit build requires at least the 10.9 SDK.
 To obtain SDKs it is best to web search for "obtaining older sdks for Xcode",
 and follow the instructions you find.
 
-On Sierra people have reported that the support libraries for the SSLPlugin
-(libssl.dylib and libcrypto.dylib) are missing.  The symptom is an error
-message such as this in the output (and the LOG file produced) of the make:
+If some library is missing, as indicated by an error message in the console,
+(and the LOG file produced), say for example foobar:
 
-ld: library not found for -lssl
-clang: error: linker command failed with exit code 1 (use -v to see invocation)
-make[1]: *** [build/vm/SqueakSSL.bundle/Contents/MacOS/SqueakSSL] Error 1
+    ld: library not found for -lfoobar
+    clang: error: linker command failed with exit code 1 (use -v to see invocation)
+    make[1]: *** [build/vm/SqueakFoobar.bundle/Contents/MacOS/SqueakFoobar] Error 1
 
-These libraries should be in the /usr/lib directory for the SDK being used.  Use
+Then you might search if some libfoobar.dylib is present in the system
+(for example in places like /usr/lib or /usr/local/lib).
+If so, copy them or link them to the SDK directory.
 
-make print-sdks
+You can locate the SDK that you are using with:
 
-to print the SDK, which might be e.g. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk.
-Libraries would then be found in /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/usr/lib.
-If they, or any other Apple support libraries, are missing, locate them (they
-may be in /usr/lib) and copy or link them into the SDK /usr/lib and retry the
-build.
+    make print-sdks
+
+If it answers e.g.
+
+    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk
+    
+then libfoobar.dylib should then be copied/linked in
+
+    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/usr/lib
 
 
 Signing Problems


### PR DESCRIPTION
Because we don't need to link against libssl.
Keep the hint from Eliot for an hypothetical libfoobar.dylib missing.