### PR TITLE
Make updateSCCSVersions work in more situations

### DIFF
--- a/scripts/updateSCCSVersions
+++ b/scripts/updateSCCSVersions
@@ -3,15 +3,13 @@
 # platforms/Cross/vm/sqSCCSVersion.h to be checked-in so that its version
 # info reflects that of the current check-in.
 
-if [ -d `dirname $0`/../.git ]; then
-	hooks_dir="`git rev-parse --git-dir`/hooks"
-    mkdir -p $hooks_dir
-    cp -f $0 $hooks_dir/post-commit
-    cp -f $0 $hooks_dir/post-merge
-    cp -f $0 $hooks_dir/post-checkout
-    cd `dirname $0`/..
+if [ "$(cd "$(dirname $0)" && git rev-parse --is-inside-git-dir)" = false ]; then
+    hooks_dir="`git rev-parse --git-dir`/hooks"
+    mkdir -p "$hooks_dir"
+    cp -f "$0" "$hooks_dir/post-commit"
+    cp -f "$0" "$hooks_dir/post-merge"
+    cp -f "$0" "$hooks_dir/post-checkout"
 else
-    cd `dirname $0`/../..
     if [[ "$(basename $0)" == "post-checkout" ]]; then
         prevHEAD=$1
         newHEAD=$2
@@ -24,10 +22,10 @@ else
     fi
 fi
 
+cd `git rev-parse --show-toplevel`
+versionfiles="platforms/Cross/vm/sqSCCSVersion.h platforms/Cross/plugins/sqPluginsSCCSVersion.h"
 git config --local include.path ../.gitconfig
-git stash -q || true
-echo "//" >> platforms/Cross/vm/sqSCCSVersion.h
-echo "//" >> platforms/Cross/plugins/sqPluginsSCCSVersion.h
-git checkout HEAD -- platforms/Cross/vm/sqSCCSVersion.h
-git checkout HEAD -- platforms/Cross/plugins/sqPluginsSCCSVersion.h
-git stash pop -q || true
+versionfilechanges=`git diff $versionfiles`
+touch $versionfiles
+git checkout HEAD -- $versionfiles
+echo "$versionfilechanges" | git apply


### PR DESCRIPTION
- allow spaces in paths (added quotes)
- support cases where the repository is not in a .git directory at the top of the working tree
- do not hardcode the directory level of this script
- avoid stashing the whole working tree when only two well-known files need to be updated
- touch should suffice to make a file different from its index version (i. e., eligible for checkout)

Please review for compatibility and pick those parts of the changes that you like.