### PR TITLE
Fixed getGoodSpur64VM.sh: 64-bit VM directory name is different

### DIFF
--- a/image/getGoodSpur64VM.sh
+++ b/image/getGoodSpur64VM.sh
@@ -33,7 +33,7 @@ else
 			echo Downloading $LATESTVM from bintray
 			curl -L "https://dl.bintray.com/opensmalltalk/vm/$LATESTVM" -o "$LATESTVM"
 			tar xzf "$LATESTVM"
-			mv sqcogspurlinuxht $VM
+			mv sqcogspur64linuxht $VM
 			rm -f "$LATESTVM"
 		fi
 		VM=$VM/squeak;;


### PR DESCRIPTION
mv quit with an error, because the directory didn't exist.