### PR TITLE
FilePlugin>>primitiveFileAtEnd for non-regular files

### DIFF
--- a/platforms/Cross/plugins/FilePlugin/FilePlugin.h
+++ b/platforms/Cross/plugins/FilePlugin/FilePlugin.h
@@ -18,7 +18,6 @@
 */
 /* File support definitions */
 
-#include <sys/stat.h>
 #include <sys/types.h>
 
 #ifdef _MSC_VER
@@ -31,7 +30,6 @@ typedef int mode_t;
 typedef struct {
   int			 sessionID;	/* ikp: must be first */
   void			*file;
-  mode_t		st_mode;	/* from stat() */
 #if defined(ACORN)
 // ACORN has to have 'lastOp' as at least a 32 bit field in order to work
   int lastOp; // actually used to save file position

--- a/platforms/Cross/plugins/FilePlugin/FilePlugin.h
+++ b/platforms/Cross/plugins/FilePlugin/FilePlugin.h
@@ -18,6 +18,7 @@
 */
 /* File support definitions */
 
+#include <sys/stat.h>
 #include <sys/types.h>
 
 #ifdef _MSC_VER
@@ -30,6 +31,7 @@ typedef int mode_t;
 typedef struct {
   int			 sessionID;	/* ikp: must be first */
   void			*file;
+  mode_t		st_mode;	/* from stat() */
 #if defined(ACORN)
 // ACORN has to have 'lastOp' as at least a 32 bit field in order to work
   int lastOp; // actually used to save file position

--- a/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
+++ b/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
@@ -121,18 +121,6 @@ static squeakFileOffsetType getSize(SQFile *f)
   return size;
 }
 
-static int setMode(SQFile *f)
-{
-  int fd;
-  struct stat statBuf;
-
-  fd = fileno(getFile(f));
-  if (fstat(fd, &statBuf))
-    return -1;
-  f->st_mode = statBuf.st_mode;
-  return 0;
-}
-
 #if 0
 # define pentry(func) do { int fn = fileno(getFile(f)); if (f->isStdioStream) printf("\n"#func "(%s) %lld %d\n", fn == 0 ? "in" : fn == 1 ? "out" : "err", (long long)ftell(getFile(f)), f->lastChar); } while (0)
 # define pexit(expr) (f->isStdioStream && printf("\n\t^"#expr " %lld %d\n", (long long)(sqFileValid(f) ? ftell(getFile(f)) : -1), f->lastChar)), expr
@@ -393,8 +381,6 @@ sqFileOpen(SQFile *f, char *sqFileName, sqInt sqFileNameSize, sqInt writeFlag) {
 
 			f->writable = writeFlag ? true : false;
 			f->lastOp = UNCOMMITTED;
-			if (setMode(f))
-				return interpreterProxy->success(false);
 			return 1;
 		}
 
@@ -475,8 +461,6 @@ sqFileOpenNew(SQFile *f, char *sqFileName, sqInt sqFileNameSize, sqInt *exists) 
 			setFile(f, file);
 			f->writable = true;
 			f->lastOp = UNCOMMITTED;
-			if (setMode(f))
-				return interpreterProxy->success(false);
 			return 1;
 		}
 
@@ -524,8 +508,6 @@ sqConnectToFile(SQFile *sqFile, void *file, sqInt writeFlag)
 	sqFile->sessionID = thisSession;
 	sqFile->lastOp = UNCOMMITTED;
 	sqFile->writable = writeFlag;
-	if (setMode(sqFile))
-		return interpreterProxy->success(false);
 	return 1;
 }
 


### PR DESCRIPTION
FilePlugin currently splits files in to two groups: 1) Stdio streams and
2) everything else.

To test for the end of file, FilePlugin>>primitiveFileAtEnd:

1) Uses feof() for stdio streams.
2) Compares the current position to the file size for everything else.

This returns the expected results for regular files, but fails for
non-regular files, e.g.:

(FileSystem / 'dev' / 'urandom') binaryReadStream next: 8.

returns an empty array.

On Unix, the proper way to check is to read past the end of the file and
then call feof() to confirm that it is in fact at the end.

Pharo has plenty of code that assumes that a file position >= the file
size means that the file is at the end, and as stated above this
generally works for regular files.

This patch modifies FilePlugin>>primitiveFileAtEnd to:

a) Keep the current behaviour of using the file position test for
regular files.
b) Keep the current behaviour of using feof() for stdio streams.
c) Use feof() for non-regular files, e.g. /dev/urandom.

This allows existing code to continue to function, and allows
non-regular files to be tested correctly.

After applying the patch, the example code above answers the expected
result, e.g.:

(FileSystem / 'dev' / 'urandom') binaryReadStream next: 8.
" #[179 136 227 226 28 147 197 125]"

On Windows, as far as I can tell, all files are regular, and the
position test is used regularly, so no change is requried.

Fogbugz: https://pharo.fogbugz.com/f/cases/21643/