### PR TITLE
Compile sista with clang

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,12 +3,27 @@ environment:
   BINTRAYAPIKEY:
     secure: uknPzww818XWJiLecwur9p1MfrkACOyx9d3iNrw/TuD89EoPSc8zLqKdPZjWdcQd
   matrix:
-    - FLAVOR: squeak.sista.spur
+    - FLAVOR: squeak.cog.spur
       ARCH: win32x86
       CYG_ROOT: C:\cygwin
       CYG_SETUP: setup-x86.exe
       MINGW_ARCH: i686
     - FLAVOR: squeak.cog.spur
+      ARCH: win64x64
+      CYG_ROOT: C:\cygwin64
+      CYG_SETUP: setup-x86_64.exe
+      MINGW_ARCH: x86_64
+    - FLAVOR: pharo.cog.spur
+      ARCH: win32x86
+      CYG_ROOT: C:\cygwin
+      CYG_SETUP: setup-x86.exe
+      MINGW_ARCH: i686
+    - FLAVOR: pharo.cog.spur
+      ARCH: win64x64
+      CYG_ROOT: C:\cygwin64
+      CYG_SETUP: setup-x86_64.exe
+      MINGW_ARCH: x86_64
+    - FLAVOR: squeak.sista.spur
       ARCH: win32x86
       CYG_ROOT: C:\cygwin
       CYG_SETUP: setup-x86.exe
@@ -33,11 +48,6 @@ environment:
       CYG_ROOT: C:\cygwin
       CYG_SETUP: setup-x86.exe
       MINGW_ARCH: i686
-    - FLAVOR: pharo.cog.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      CYG_SETUP: setup-x86.exe
-      MINGW_ARCH: i686
     - FLAVOR: pharo.sista.spur
       ARCH: win32x86
       CYG_ROOT: C:\cygwin
@@ -58,16 +68,6 @@ environment:
       CYG_ROOT: C:\cygwin
       CYG_SETUP: setup-x86.exe
       MINGW_ARCH: i686
-    - FLAVOR: squeak.cog.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      CYG_SETUP: setup-x86_64.exe
-      MINGW_ARCH: x86_64
-    - FLAVOR: pharo.cog.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      CYG_SETUP: setup-x86_64.exe
-      MINGW_ARCH: x86_64
     # - FLAVOR: pharo.sista.spur
     #   ARCH: win64x64
     #   CYG_ROOT: C:\cygwin64
@@ -113,8 +113,8 @@ cache:
   - .thirdparty-cache
 
 install:
-  - 'curl -fsS --retry 4 -m 600 -o "setup-x86.exe" "http://cygwin.com/setup-x86.exe" '
-  - 'curl -fsS --retry 4 -m 600 -o "setup-x86_64.exe" "http://cygwin.com/setup-x86_64.exe" '
+  - 'curl -fsSL --retry 4 -m 600 -o "setup-x86.exe" "http://cygwin.com/setup-x86.exe" '
+  - 'curl -fsSL --retry 4 -m 600 -o "setup-x86_64.exe" "http://cygwin.com/setup-x86_64.exe" '
   - '%CYG_SETUP% -dgnqNO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_ROOT%\var\cache\setup" -P mingw64-%MINGW_ARCH%-gcc-core,mingw64-%MINGW_ARCH%-gcc-g++,mingw64-%MINGW_ARCH%-headers,mingw64-%MINGW_ARCH%-runtime,zip,mingw64-%MINGW_ARCH%-clang,mingw64-%MINGW_ARCH%-openssl,libiconv-devel,libglib2.0-devel,perl,mingw64-%MINGW_ARCH%-zlib,make,cmake,wget,mingw64-%MINGW_ARCH%-win-iconv'
 
 # Cygwin build script

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -113,8 +113,8 @@ cache:
   - .thirdparty-cache
 
 install:
-  - 'curl -fsS --retry 4 - m 600 -o "setup-x86.exe" "http://cygwin.com/setup-x86.exe" '
-  - 'curl -fsS --retry 4 - m 600 -o "setup-x86_64.exe" "http://cygwin.com/setup-x86_64.exe" '
+  - 'curl -fsS --retry 4 -m 600 -o "setup-x86.exe" "http://cygwin.com/setup-x86.exe" '
+  - 'curl -fsS --retry 4 -m 600 -o "setup-x86_64.exe" "http://cygwin.com/setup-x86_64.exe" '
   - '%CYG_SETUP% -dgnqNO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_ROOT%\var\cache\setup" -P mingw64-%MINGW_ARCH%-gcc-core,mingw64-%MINGW_ARCH%-gcc-g++,mingw64-%MINGW_ARCH%-headers,mingw64-%MINGW_ARCH%-runtime,zip,mingw64-%MINGW_ARCH%-clang,mingw64-%MINGW_ARCH%-openssl,libiconv-devel,libglib2.0-devel,perl,mingw64-%MINGW_ARCH%-zlib,make,cmake,wget,mingw64-%MINGW_ARCH%-win-iconv'
 
 # Cygwin build script

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -113,8 +113,8 @@ cache:
   - .thirdparty-cache
 
 install:
-  - ps: 'Start-FileDownload "http://cygwin.com/setup-x86.exe" -FileName "setup-x86.exe"'
-  - ps: 'Start-FileDownload "http://cygwin.com/setup-x86_64.exe" -FileName "setup-x86_64.exe"'
+  - 'curl -fsS --retry 4 - m 600 -o "setup-x86.exe" "http://cygwin.com/setup-x86.exe" '
+  - 'curl -fsS --retry 4 - m 600 -o "setup-x86_64.exe" "http://cygwin.com/setup-x86_64.exe" '
   - '%CYG_SETUP% -dgnqNO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_ROOT%\var\cache\setup" -P mingw64-%MINGW_ARCH%-gcc-core,mingw64-%MINGW_ARCH%-gcc-g++,mingw64-%MINGW_ARCH%-headers,mingw64-%MINGW_ARCH%-runtime,zip,mingw64-%MINGW_ARCH%-clang,mingw64-%MINGW_ARCH%-openssl,libiconv-devel,libglib2.0-devel,perl,mingw64-%MINGW_ARCH%-zlib,make,cmake,wget,mingw64-%MINGW_ARCH%-win-iconv'
 
 # Cygwin build script

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,10 @@ jobs:
   - env: ARCH="linux32x86" FLAVOR="squeak.cog.v3"
   - env: ARCH="linux32x86" FLAVOR="squeak.sista.spur"
   - env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" HEARTBEAT="itimer"
-  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" CC="clang" HEARTBEAT="threaded"
-  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" CC="clang" HEARTBEAT="itimer" 
+  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" HEARTBEAT="threaded"
+    compiler: clang
+  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" HEARTBEAT="itimer" 
+    compiler: clang
 
   - stage: "Other Mac builds"
     env: ARCH="macos64x64" FLAVOR="newspeak.cog.spur"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ jobs:
   - env: ARCH="linux32x86" FLAVOR="squeak.cog.v3"
   - env: ARCH="linux32x86" FLAVOR="squeak.sista.spur"
   - env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" HEARTBEAT="itimer"
-  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" HEARTBEAT="threaded"
-  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" HEARTBEAT="itimer"
+  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" CC="clang" HEARTBEAT="threaded"
+  - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" CC="clang" HEARTBEAT="itimer" 
 
   - stage: "Other Mac builds"
     env: ARCH="macos64x64" FLAVOR="newspeak.cog.spur"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,41 +23,43 @@ notifications:
 jobs:
   fast_finish: true
   include:
-  - stage: "Linux builds"
-    env: ARCH="linux64x64" FLAVOR="newspeak.cog.spur"
+  - stage: "Main Squeak and Pharo builds"
+    env: ARCH="linux32x86" FLAVOR="squeak.cog.spur"
+  - env: ARCH="macos32x86" FLAVOR="squeak.cog.spur"
+    <<: *mac-build
   - env: ARCH="linux64x64" FLAVOR="squeak.cog.spur"
+  - env: ARCH="macos64x64" FLAVOR="squeak.cog.spur"
+    <<: *mac-build
+  - env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" HEARTBEAT="threaded"
+  - env: ARCH="macos32x86" FLAVOR="pharo.cog.spur"
+    <<: *mac-build
   - env: ARCH="linux64x64" FLAVOR="pharo.cog.spur" HEARTBEAT="threaded"
+  - env: ARCH="macos64x64" FLAVOR="pharo.cog.spur"
+    <<: *mac-build
+
+  - stage: "Other Linux builds"
+    env: ARCH="linux64x64" FLAVOR="newspeak.cog.spur"
   - env: ARCH="linux64x64" FLAVOR="pharo.cog.spur" HEARTBEAT="itimer"
   # - env: ARCH="linux64x64" FLAVOR="pharo.sista.spur" HEARTBEAT="threaded"
   - env: ARCH="linux32x86" FLAVOR="newspeak.cog.spur"
-  - env: ARCH="linux32x86" FLAVOR="squeak.cog.spur"
   - env: ARCH="linux32x86" FLAVOR="squeak.cog.v3"
   - env: ARCH="linux32x86" FLAVOR="squeak.sista.spur"
-  - env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" HEARTBEAT="threaded"
   - env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" HEARTBEAT="itimer"
   - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" HEARTBEAT="threaded"
   - env: ARCH="linux32x86" FLAVOR="pharo.sista.spur" HEARTBEAT="itimer"
 
-  - stage: "Mac builds"
+  - stage: "Other Mac builds"
     env: ARCH="macos64x64" FLAVOR="newspeak.cog.spur"
-    <<: *mac-build
-  - env: ARCH="macos64x64" FLAVOR="pharo.cog.spur"
     <<: *mac-build
   # - env: ARCH="macos64x64" FLAVOR="pharo.sista.spur"
   #   <<: *mac-build
   - env: ARCH="macos64x64" FLAVOR="pharo.cog.spur.lowcode"
     <<: *mac-build
-  - env: ARCH="macos64x64" FLAVOR="squeak.cog.spur"
-    <<: *mac-build
   - env: ARCH="macos32x86" FLAVOR="newspeak.cog.spur"
-    <<: *mac-build
-  - env: ARCH="macos32x86" FLAVOR="pharo.cog.spur"
     <<: *mac-build
   - env: ARCH="macos32x86" FLAVOR="pharo.sista.spur"
     <<: *mac-build
   - env: ARCH="macos32x86" FLAVOR="pharo.cog.spur.lowcode"
-    <<: *mac-build
-  - env: ARCH="macos32x86" FLAVOR="squeak.cog.spur"
     <<: *mac-build
   - env: ARCH="macos32x86" FLAVOR="squeak.cog.v3"
     <<: *mac-build

--- a/build.linux32x86/pharo.sista.spur/build/mvm
+++ b/build.linux32x86/pharo.sista.spur/build/mvm
@@ -38,6 +38,7 @@ test -f config.h || ../../../platforms/unix/config/configure \
 		--with-vmversion=5.0 \
 		--with-src=spursistasrc \
 	TARGET_ARCH="-m32" \
+	CC=clang \
 	CFLAGS="$OPT -msse2 -DCOGMTVM=0" \
 	LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' "
 rm -f vm/sqUnixMain.o # nuke version info

--- a/build.linux32x86/pharo.sista.spur/build/mvm
+++ b/build.linux32x86/pharo.sista.spur/build/mvm
@@ -33,7 +33,7 @@ esac
 test -f plugins.int || (test -f ../plugins.int && cp -p ../plugins.int . || cp -p ../../plugins.int .)
 test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -p ../../plugins.ext .)
 
-test -f config.h || ../../../platforms/unix/config/configure \
+test -f config.h || CC=clang ../../../platforms/unix/config/configure \
 		--without-npsqueak \
 		--with-vmversion=5.0 \
 		--with-src=spursistasrc \

--- a/build.win32x86/pharo.cog.spur.lowcode/Makefile
+++ b/build.win32x86/pharo.cog.spur.lowcode/Makefile
@@ -15,6 +15,8 @@ VMSRCDIR:=../../spurlowcodesrc/vm
 #COGDEFS:= -DPharoVM=1 -DSTACK_ALIGN_BYTES=16 -DALLOCA_LIES_SO_USE_GETSP=0
 COGDEFS:= -DPharoVM=1
 
+COMPILER_TO_USE:=clang
+
 THIRDPARTYLIBS:=pkgconfig openssl libssh2 libgit2 libsdl2 zlib libpng freetype2 pixman cairo libgcc
 	
 include ../common/Makefile

--- a/build.win32x86/pharo.sista.spur/Makefile
+++ b/build.win32x86/pharo.sista.spur/Makefile
@@ -17,6 +17,8 @@ COGDEFS:= -DPharoVM=1
 
 THIRDPARTYLIBS:=pkgconfig openssl libssh2 libgit2 libsdl2 zlib libpng freetype2 pixman cairo libgcc
 	
+COMPILER_TO_USE:=clang
+
 include ../common/Makefile
 
 # third-party libraries

--- a/platforms/unix/vm-sound-ALSA/sqUnixSoundALSA.c
+++ b/platforms/unix/vm-sound-ALSA/sqUnixSoundALSA.c
@@ -670,7 +670,7 @@ mixer_default_volume_get_set(int captureFlag, double *get, double set)
 
 	if (mixer.error) {
 		mixer_close(&mixer);
-		return;
+		return -1;
 	}
 
 	/* Iterate over all mixer controls */


### PR DESCRIPTION
This builds pharo.sista.spur with clang in order to workaround gcc bugs
This also re-arrange the build matrix order for appveyor and build stages order for travis
This also fix a compiler warning for ALSA sound, necessary for compiling with clang (it's treated as an error in clang, not in gcc)

[ci skip] the build is green in its branch and no concurrent feature happened, so let's not wait another pair of hours.