### PR TITLE
Do not convert line ending of image/*.sh files on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Bash needs lf even on windows/cygwin
 /scripts/* eol=lf
 /image/*.st eol=lf
+/image/*.sh eol=lf
 mvm eol=lf
 sq*SCCSVersion.h filter=RevDateURL ident
 *.changes -diff


### PR DESCRIPTION
Cygwin cannot run scripts with crlf. I added image/*.sh to the gitattributes to not convert their line ending.