### PR TITLE
Add instructions to download squeak vm for cygwin to build VMMaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ platforms/unix/config/autom4te.cache/
 /image/Cog.app
 /image/cogspurlinux*
 /image/sqlinux*
+/image/sqwin*
 /image/cogspurwin
 /image/CogSpur.app
 /image/Squeak*.app

--- a/image/getGoodSpurVM.sh
+++ b/image/getGoodSpurVM.sh
@@ -55,6 +55,23 @@ else
 			rm -f "$LATESTVM"
 		fi
 		VM=$VM/squeak;;
+	CYGWIN_NT*)
+		VOLUME="squeak.cog.spur_win32x86_$LATESTRELEASE"
+		LATESTVM="$VOLUME.zip"
+		VM=sqwin.$LATESTRELEASE
+		if [ ! -d $VM ]; then
+			URL="https://dl.bintray.com/opensmalltalk/vm/$LATESTVM"
+			echo Downloading $LATESTVM from $URL
+			if [ "$1" = -test ]; then
+				echo curl -L "$URL" -o "$LATESTVM"
+				exit
+			fi
+			echo curl -L "$URL" -o "$LATESTVM"
+			curl -L "$URL" -o "$LATESTVM"
+			unzip $LATESTVM -d sqwin.$LATESTRELEASE
+			rm -f $LATESTVM
+		fi
+		VM=sqwin.$LATESTRELEASE/SqueakConsole.exe;;
 	*)	echo do not know how to download a VM for your system 1>&2; exit 1
 	esac
 fi


### PR DESCRIPTION
In the image directory, there are scripts to prepare a VMMaker image with squeak.

Those scripts have instructions to download the latest squeak vm depending on the OS. Currently, there is only Darwin and Linux. This PR add instructions for Cygwin.