### PR TITLE
compile win32 squeak.sista.spur + lowcode with clang

### DIFF
--- a/build.win32x86/squeak.cog.spur.lowcode/Makefile
+++ b/build.win32x86/squeak.cog.spur.lowcode/Makefile
@@ -7,5 +7,6 @@ VM:=Squeak
 VMSRCDIR:=../../spurlowcodesrc/vm
 
 COGDEFS:= -DSTACK_ALIGN_BYTES=16 -DALLOCA_LIES_SO_USE_GETSP=0
+COMPILER_TO_USE:=clang
 	
 include ../common/Makefile

--- a/build.win32x86/squeak.sista.spur/Makefile
+++ b/build.win32x86/squeak.sista.spur/Makefile
@@ -6,4 +6,6 @@
 VM:=Squeak
 VMSRCDIR:=../../spursistasrc/vm
 
+COMPILER_TO_USE:=clang
+
 include ../common/Makefile


### PR DESCRIPTION
Same as we done for Pharo to workaround gcc bug
It just fix the two appveyor red builds (for which failure is allowed) and does not touch anything else, so it is safe to merge.
[ci skip]