### PR TITLE
[ci skip] Correct typos and add documentation about ./mvm -f

### DIFF
--- a/build.linux32ARMv6/HowToBuild
+++ b/build.linux32ARMv6/HowToBuild
@@ -85,11 +85,12 @@ Then cd to the build directory of your choice, e.g.
 	build.linux32x86/squeak.cog.spur/build
 Then execute
 	./mvm
-answering "y" to perform a clean build or "n" to rebuild without recionfiguring.
+	
+answering "y" to perform a clean build or "n" to rebuild without reconfiguring.
 Again, if the configure step fails when "checking for C compiler default output
 file name", you have yet to install all the necessary support (e.g. lubuuid).
 
-The subdirectories confrm to the production/assert/debug x itimer vs threaded
+The subdirectories conform to the production/assert/debug x itimer vs threaded
 heartbeat x single vs multi-threaded parts of the matrix described above.  For
 example, build.linux32x86/squeak.cog.v3 includes
 

--- a/build.linux32ARMv7/HowToBuild
+++ b/build.linux32ARMv7/HowToBuild
@@ -86,11 +86,12 @@ Then cd to the build directory of your choice, e.g.
 	build.linux32x86/squeak.cog.spur/build
 Then execute
 	./mvm
-answering "y" to perform a clean build or "n" to rebuild without recionfiguring.
+	
+answering "y" to perform a clean build or "n" to rebuild without reconfiguring.
 Again, if the configure step fails when "checking for C compiler default output
 file name", you have yet to install all the necessary support (e.g. lubuuid).
 
-The subdirectories confrm to the production/assert/debug x itimer vs threaded
+The subdirectories conform to the production/assert/debug x itimer vs threaded
 heartbeat x single vs multi-threaded parts of the matrix described above.  For
 example, build.linux32x86/squeak.cog.v3 includes
 
@@ -122,7 +123,7 @@ plugins.int and plugins.ext determine the set of plugins to be taken from
 the supplied plugins directory (which defaults to ../src/plugins), and which
 are to be linked into the VM (plugins.int) or compiled as external shared
 objects to be dynamically linked at run-time (plugins.ext).
-
+	
 Finally, at the build.linux32x86 level the makeall script will run all the
 makeallclean scripts it can find.
 

--- a/build.linux32x86/HowToBuild
+++ b/build.linux32x86/HowToBuild
@@ -87,11 +87,12 @@ Then cd to the build directory of your choice, e.g.
 	build.linux32x86/squeak.cog.spur/build
 Then execute
 	./mvm
-answering "y" to perform a clean build or "n" to rebuild without recionfiguring.
+	
+answering "y" to perform a clean build or "n" to rebuild without reconfiguring.
 Again, if the configure step fails when "checking for C compiler default output
 file name", you have yet to install all the necessary support (e.g. lubuuid).
 
-The subdirectories confrm to the production/assert/debug x itimer vs threaded
+The subdirectories conform to the production/assert/debug x itimer vs threaded
 heartbeat x single vs multi-threaded parts of the matrix described above.  For
 example, build.linux32x86/squeak.cog.v3 includes
 
@@ -123,7 +124,7 @@ plugins.int and plugins.ext determine the set of plugins to be taken from
 the supplied plugins directory (which defaults to ../src/plugins), and which
 are to be linked into the VM (plugins.int) or compiled as external shared
 objects to be dynamically linked at run-time (plugins.ext).
-
+	
 Finally, at the build.linux32x86 level the makeall script will run all the
 makeallclean scripts it can find.
 

--- a/build.linux64x64/HowToBuild
+++ b/build.linux64x64/HowToBuild
@@ -86,11 +86,12 @@ Then cd to the build directory of your choice, e.g.
 	build.linux32x86/squeak.cog.spur/build
 Then execute
 	./mvm
-answering "y" to perform a clean build or "n" to rebuild without recionfiguring.
+	
+answering "y" to perform a clean build or "n" to rebuild without reconfiguring.
 Again, if the configure step fails when "checking for C compiler default output
 file name", you have yet to install all the necessary support (e.g. lubuuid).
 
-The subdirectories confrm to the production/assert/debug x itimer vs threaded
+The subdirectories conform to the production/assert/debug x itimer vs threaded
 heartbeat x single vs multi-threaded parts of the matrix described above.  For
 example, build.linux32x86/squeak.cog.v3 includes
 

--- a/build.macos32x86/HowToBuild
+++ b/build.macos32x86/HowToBuild
@@ -96,6 +96,7 @@ to fix this.
 2. cd to the VM configuration of your choice and run the mvm script, e.g.
 	cd buiild.macos32x86/squeak.cog.spur
 	./mvm -A
+
 This will build CocoaFast.app, CocoaDebug.app and CocoaAssert.app applications
 (or maybe Squeak.app, SqueakAssert.app, SqueakDebug.app, Pharo.app,
  PharoAssert.app, PharoDebug.app, etc) containing the three VM configurations.
@@ -103,6 +104,9 @@ If the configuration includes the multi-threaded VM you can use mvm -S to make
 the single-threaded VMs, mvm -T to make the multi-threadeds in FastMT.app et al,
 and mvm -A to make them all.  mvm -d will make the Debug.app VM, etc.  mvm -?
 provides the gory details.
+
+In order to only build the production vm, you can launch the command:
+	./mvm -f
 
 Each build directory contains three files
 	plugins.int

--- a/build.macos64x64/HowToBuild
+++ b/build.macos64x64/HowToBuild
@@ -96,6 +96,7 @@ to fix this.
 2. cd to the VM configuration of your choice and run the mvm script, e.g.
 	cd buiild.macos64x64/squeak.cog.spur
 	./mvm -A
+	
 This will build CocoaFast.app, CocoaDebug.app and CocoaAssert.app applications
 (or maybe Squeak.app, SqueakAssert.app, SqueakDebug.app, Pharo.app,
  PharoAssert.app, PharoDebug.app, etc) containing the three VM configurations.
@@ -103,6 +104,9 @@ If the configuration includes the multi-threaded VM you can use mvm -S to make
 the single-threaded VMs, mvm -T to make the multi-threadeds in FastMT.app et al,
 and mvm -A to make them all.  mvm -d will make the Debug.app VM, etc.  mvm -?
 provides the gory details.
+
+In order to only build the production vm, you can launch the command:
+	./mvm -f
 
 Each build directory contains three files
 	plugins.int

--- a/build.win32x86/HowToBuild
+++ b/build.win32x86/HowToBuild
@@ -79,12 +79,16 @@ Then cd to the build directory of your choice, e.g.
 	build.win32x86/squeak.cog.spur/
 Then execute
 	./mvm
+	
 This builds debug, assert and production versions of the VM in builddbg/vm,
 buildast/vm and build/vm.  If the configuration includes multi-threaded builds
 it will also create VMs in buildmtdbg/vm, buildmtast/vm and buildmt/vm.  The
 system builds two VMs in each build/vm directory, e.g. Squeak.exe and
 SqueakConsole.exe.  The latter is to be used with console applications that wish
 to access standard i/o.
+
+In order to only build the production vm, you can launch the command:
+	./mvm -f
 
 For building with clang instead of gcc, it is possible to pass options to make via mvm after --:
 	./mvm -f -- CC=i686-w64-mingw32-clang

--- a/build.win64x64/HowToBuild
+++ b/build.win64x64/HowToBuild
@@ -75,12 +75,16 @@ Then cd to the build directory of your choice, e.g.
 	build.win64x64/squeak.stack.spur/
 Then execute
 	./mvm
+	
 This builds debug, assert and production versions of the VM in builddbg/vm,
 buildast/vm and build/vm.  If the configuration includes multi-threaded builds
 it will also create VMs in buildmtdbg/vm, buildmtast/vm and buildmt/vm.  The
 system builds two VMs in each build/vm directory, e.g. Squeak.exe and
 SqueakConsole.exe.  The latter is to be used with console applications that wish
 to access standard i/o.
+
+In order to only build the production vm, you can launch the command:
+	./mvm -f
 
 For building with clang instead of gcc, it is possible to pass options to make via mvm after --:
 	./mvm -f -- CC=x86_64-w64-mingw32-clang


### PR DESCRIPTION
I heard that in windows and OSX it is possible to only compile the production vm with `./mvm -f`. Since it was not written in the HozToBuild files, this PR add the documentation. 

Please correct me if I'm wrong!