### PR TITLE
libgit2 build logging

### DIFF
--- a/build.linux32x86/third-party/Makefile.libgit2
+++ b/build.linux32x86/third-party/Makefile.libgit2
@@ -27,6 +27,12 @@ $(LIBGIT2ARCHIVE):
 $(THIRDPARTYLIBDIR)/$(LIBGIT2LIBNAME): $(LIBGIT2ARCHIVE)
 	tar x -f $(LIBGIT2ARCHIVE) -C $(THIRDPARTYDIR)
 	cd $(LIBGIT2DIR) \
+		&& echo "AKG Check library presence: $(THIRDPARTYLIBDIR)" \
+		&& ls -l $(THIRDPARTYLIBDIR) \
+		&& echo "AKG ldd $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1" \
+		&& ldd $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1 \
+		&& echo "AKG ls -l ../libssh2-1.7.0" \
+		&& ls -l ../libssh2-1.7.0 \
 		&& cmake \
 			-DCMAKE_INSTALL_PREFIX=$(THIRDPARTYOUTDIR) \
 			-DUSE_SSH=ON \

--- a/build.linux32x86/third-party/Makefile.libgit2
+++ b/build.linux32x86/third-party/Makefile.libgit2
@@ -29,8 +29,10 @@ $(THIRDPARTYLIBDIR)/$(LIBGIT2LIBNAME): $(LIBGIT2ARCHIVE)
 	cd $(LIBGIT2DIR) \
 		&& echo "AKG Check library presence: $(THIRDPARTYLIBDIR)" \
 		&& ls -l $(THIRDPARTYLIBDIR) \
-		&& echo "AKG ldd $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1" \
+		&& echo "AKG info $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1" \
+		&& file $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1 \
 		&& ldd $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1 \
+		&& readelf -aW $(THIRDPARTYLIBDIR)/libssh2.so.1.0.1 \
 		&& echo "AKG ls -l ../libssh2-1.7.0" \
 		&& ls -l ../libssh2-1.7.0 \
 		&& cmake \


### PR DESCRIPTION
Temporary debug logging to try and figure out why libssh2 isn't
correctly referenced in libgit2.

This should NOT be merged in to the main code.