### PR TITLE
sqFilePluginBasicPrims.c add sqFileDescriptorType()

### DIFF
--- a/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
+++ b/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
@@ -582,8 +582,19 @@ sqFileStdioHandlesInto(SQFile files[])
 * 4 - cygwin terminal (windows only)
 */
 sqInt sqFileDescriptorType(int fdNum) {
-	/* TODO  Implement the unix version */
-	return isatty(fdNum);
+        int status;
+        struct stat statBuf;
+
+        /* Is this a terminal? */
+        if (isatty(fdNum)) return 1;
+
+        /* Is this a pipe? */
+        status = fstat(fdNum, &statBuf);
+        if (status) return -1;
+        if (S_ISFIFO(statBuf.st_mode)) return 2;
+
+        /* Must be a normal file */
+        return 3;
 }
 
 


### PR DESCRIPTION
Add the Unix implementation of sqFileDescriptorType() to answer an
enumerated type indicating whether the supplied file descriptor is a
terminal, pipe or file.

The Windows implementation was added 15 May 2018 in commit 858bed2.