### PR TITLE
Suppress rtprio warning when ${CI} env var is set

### DIFF
--- a/platforms/unix/vm/sqUnixHeartbeat.c
+++ b/platforms/unix/vm/sqUnixHeartbeat.c
@@ -330,6 +330,7 @@ beatStateMachine(void *careLess)
 #else
 # define VMNAME "squeak"
 #endif
+      if (!getenv("CI")) {
         fprintf(stderr, "This VM uses a separate heartbeat thread to update its internal clock\n");
         fprintf(stderr, "and handle events.  For best operation, this thread should run at a\n");
         fprintf(stderr, "higher priority, however the VM was unable to change the priority.  The\n");
@@ -344,11 +345,11 @@ beatStateMachine(void *careLess)
         fprintf(stderr, "\nYou will need to log out and log back in for the limits to take effect.\n");
         fprintf(stderr, "For more information please see\n");
         fprintf(stderr, "https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/tag/r3732#linux\n");
-        // exit(errno);
 		// The VM may have issues with clock jitter due to the heartbeat thread
 		// not running at elevated priority. An exit may be appropriate in some
 		// cases, but for most users the above warning is sufficient.
 		// exit(errno);
+      }
 	}
 	beatState = active;
 	while (beatState != condemned) {


### PR DESCRIPTION
This makes the rtprio warning less verbose when the `${CI}` env var is set.
`${CI}` is usually set by common CI providers, see:
- https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
- https://www.appveyor.com/docs/environment-variables/
- https://docs.gitlab.com/ee/ci/variables/#predefined-variables-environment-variables

"pthread_setschedparam failed: Operation not permitted" is still printed to inform about the misconfiguration.

If no one objects, I will merge this in the next couple of days...

Closes #275