### PR TITLE
Do only handle events that correspond to the VM window

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -70,10 +70,28 @@ static int buttonState=0;
 - (void) pumpRunLoopEventSendAndSignal:(BOOL)signal {
     NSEvent *event;
     
+#ifdef PharoVM
+    while ((event = [gDelegateApp.window nextEventMatchingMask:NSEventMaskAny
+                                       untilDate:nil
+                                          inMode:NSEventTrackingRunLoopMode
+                                         dequeue:NO])) {
+        if (event.window == 0 || event.window == gDelegateApp.window) {
+          event = [gDelegateApp.window nextEventMatchingMask:NSEventMaskAny
+                                                 untilDate:nil
+                                                    inMode:NSEventTrackingRunLoopMode
+                                                   dequeue:YES];
+        }
+        else{
+          // STOP THE LOOP
+          // We have an event that does not correspond to our window
+          break;
+        }
+#else
     while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
                                        untilDate:nil
                                           inMode:NSEventTrackingRunLoopMode
                                          dequeue:YES])) {
+#endif
         [NSApp sendEvent: event];
         if (signal) {
             interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);


### PR DESCRIPTION
While playing with SDL on OSX we have noticed that the main window in the VM is randomly eating events that belong to other windows. This happens because we are consuming events regardless the window they come from.

The corresponding code is in the method pumpRunLoopEventSendAndSignal: in
   https://github.com/OpenSmalltalk/opensmalltalk-vm/blob/Cog/platforms/iOS/vm/OSX/sqSqueakOSXApplication%2Bevents.m

I've playing around with making the VM consume only events that come from its own window or from no window (window=null). This seems to work correctly, and I've had run into no issues in the last couple of hours.

I've put a guard so my code is only valid for PHAROVM builds, but I'd gladly remove the guards if people think this is a good move for all the community.