### PR TITLE
Added comments and removed PharoVM guards for windowing support

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -69,30 +69,21 @@ static int buttonState=0;
 
 - (void) pumpRunLoopEventSendAndSignal:(BOOL)signal {
     NSEvent *event;
-    
-#ifdef PharoVM
-    while ((event = [gDelegateApp.window nextEventMatchingMask:NSEventMaskAny
+    while (event = [NSApp nextEventMatchingMask:NSEventMaskAny
                                        untilDate:nil
                                           inMode:NSEventTrackingRunLoopMode
-                                         dequeue:NO])) {
-        if (event.window == 0 || event.window == gDelegateApp.window) {
-          event = [gDelegateApp.window nextEventMatchingMask:NSEventMaskAny
-                                                 untilDate:nil
-                                                    inMode:NSEventTrackingRunLoopMode
-                                                   dequeue:YES];
-        }
-        else{
-          // STOP THE LOOP
-          // We have an event that does not correspond to our window
+                                         dequeue:NO]) {
+        // If the event is not a system event or an event of *this* window, stop consuming events
+        // In case of multi window applications, it is the responsibility of the other windowing systems to consume their own events
+        // This is a cooperative event handling mechanism for simplicity
+        // Single window systems will be not affected by it
+        if (!(event.window == 0 || event.window == gDelegateApp.window)){
           break;
         }
-#else
-    while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                                       untilDate:nil
-                                          inMode:NSEventTrackingRunLoopMode
-                                         dequeue:YES])) {
-#endif
-        [NSApp sendEvent: event];
+        [NSApp sendEvent: [NSApp nextEventMatchingMask:NSEventMaskAny
+                                 untilDate:nil
+                                 inMode:NSEventTrackingRunLoopMode
+                                 dequeue:YES]];
         if (signal) {
             interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
         }


### PR DESCRIPTION
Last integration of #295 went too fast :)

This PR does some cleanups:
 - remove the PharoVM guards,
 - added comments

Answering the questions from the other thread: this should have no effect on systems using a single window. However, with multiple windowing systems,  this makes the consumption of events a cooperative task. If let's say SDL does not consume its events (because we don't call the event processing routine), then those events stay in the queue for ever.

To make it more robust I've been trying to use a separate queue to store alien events and repost them in the queue afterwads, but I could not manage to make it work. And Cocoa's support/documentation does not help here...