### PR TITLE
Use output of xcode-select to determine path of Xcode in Mac Makefile…

### DIFF
--- a/build.macos32x86/common/Makefile.flags
+++ b/build.macos32x86/common/Makefile.flags
@@ -3,7 +3,7 @@
 #
 # These are derived from Xcode v 6.2 for Apple LLVM version 6.0 (clang-600.0.57)
 
-XCODE:=/Applications/Xcode.app/Contents/Developer
+XCODE:=$(shell /usr/bin/xcode-select -p)
 XCUB:=$(XCODE)/usr/bin
 SDKsDIR:=$(XCODE)/Platforms/MacOSX.platform/Developer/SDKs
 #Build the oldest SDK installed

--- a/build.macos64x64/common/Makefile.flags
+++ b/build.macos64x64/common/Makefile.flags
@@ -3,11 +3,11 @@
 #
 # These are derived from Xcode v 6.2 for Apple LLVM version 6.0 (clang-600.0.57)
 
-XCODE:=/Applications/Xcode.app/Contents/Developer
+XCODE:=$(shell /usr/bin/xcode-select -p)
 XCUB:=$(XCODE)/usr/bin
 SDKsDIR:=$(XCODE)/Platforms/MacOSX.platform/Developer/SDKs
 #Build the oldest SDK installed (must be MacOSX10.10.sdk and later)
-SDKs:=MacOSX10.10.sdk MacOSX10.11.sdk MacOSX10.12.sdk MacOSX10.13.sdk
+SDKs:=MacOSX10.10.sdk MacOSX10.11.sdk MacOSX10.12.sdk MacOSX10.13.sdk MacOSX10.14.sdk
 SDK:=$(firstword $(realpath $(addprefix $(SDKsDIR)/, $(SDKs))))
 ifeq ($(strip $(SDK)),)
 $(error could not find a valid SDK)


### PR DESCRIPTION
…, instead of hard-coding.

xcode-select allows for multiple versions of Xcode to be installed and to be selected by the user.
DO NOT put a space in a renamed Xcode.app, however: this will break SDK detection in the Makefile.

Add OS X 10.14 SDKs for x64 build, as supplied by Xcode 10.