### PR TITLE
replace valloc() with mmap() when allocating executable pages for cal…

### DIFF
--- a/platforms/Cross/plugins/IA32ABI/ia32abicc.c
+++ b/platforms/Cross/plugins/IA32ABI/ia32abicc.c
@@ -292,14 +292,11 @@ allocateExecutablePage(long *size)
 #else
 	long pagesize = getpagesize();
 
-	if (!(mem = valloc(pagesize)))
+	if (!(mem = mmap(0, pagesize, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0)))
 		return 0;
 
+	// MAP_ANON should zero out the allocated page, but explicitly doing it shouldn't hurt
 	memset(mem, 0, pagesize);
-	if (mprotect(mem, pagesize, PROT_READ | PROT_WRITE | PROT_EXEC) < 0) {
-		free(mem);
-		return 0;
-	}
 	*size = pagesize;
 #endif
 	return mem;

--- a/platforms/Cross/plugins/IA32ABI/x64sysvabicc.c
+++ b/platforms/Cross/plugins/IA32ABI/x64sysvabicc.c
@@ -282,14 +282,11 @@ allocateExecutablePage(long *size)
 #else
 	long pagesize = getpagesize();
 
-	if (!(mem = valloc(pagesize)))
+	if (!(mem = mmap(0, pagesize, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0)))
 		return 0;
 
+	// MAP_ANON should zero out the allocated page, but explicitly doing it shouldn't hurt
 	memset(mem, 0, pagesize);
-	if (mprotect(mem, pagesize, PROT_READ | PROT_WRITE | PROT_EXEC) < 0) {
-		free(mem);
-		return 0;
-	}
 	*size = pagesize;
 #endif
 	return mem;


### PR DESCRIPTION
…lbacks

Under linux, if SELinux is enabled (i.e. not permisive or disabled), then
the heap memory allocated with vmalloc() and marked as executable with mprotect()
will fail.  In order to have this work with SELinux enabled (and not providing
a module policy file to allow execheap) mmap() should be used.

Note, it might be possible to remove the stdlib.h and sys/mman.h header
file references.

See: http://lists.squeakfoundation.org/pipermail/vm-dev/2018-October/029102.html