### PR TITLE
Consume all events in the event queue to avoid application lockups

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -67,27 +67,37 @@ static int buttonState=0;
 
 @implementation sqSqueakOSXApplication (events)
 
+// Consume all pending events in the NSApp
+// Events may come from the window open by the VM or windows open by other windowing systems
+// We need to consume all events in the queue, otherwise this may produce lockups when e.g., switching resolutions
+// If the event does not correspond to this window, we take it from the event queue anyways and re-post it afterwards
+// This gives other windows the opportunity to consume their events
 - (void) pumpRunLoopEventSendAndSignal:(BOOL)signal {
-    NSEvent *event;
-    while (event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                                       untilDate:nil
-                                          inMode:NSEventTrackingRunLoopMode
-                                         dequeue:NO]) {
-        // If the event is not a system event or an event of *this* window, stop consuming events
-        // In case of multi window applications, it is the responsibility of the other windowing systems to consume their own events
-        // This is a cooperative event handling mechanism for simplicity
-        // Single window systems will be not affected by it
-        if (!(event.window == 0 || event.window == gDelegateApp.window)){
-          break;
-        }
-        [NSApp sendEvent: [NSApp nextEventMatchingMask:NSEventMaskAny
-                                 untilDate:nil
-                                 inMode:NSEventTrackingRunLoopMode
-                                 dequeue:YES]];
-        if (signal) {
-            interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
-        }
-    }
+       NSEvent *event;
+       NSMutableArray *alienEventQueue = [[NSMutableArray alloc] init];
+       while (event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                             untilDate:nil
+                             inMode:NSEventTrackingRunLoopMode
+                             dequeue:YES]) {
+         // If the event is not a system event or an event of *this* window, queue the event
+         // Otherwise treat the event normally and send it to the app
+         if (event.window && event.window != gDelegateApp.window){
+           [alienEventQueue addObject: event];
+         }else{
+           [NSApp sendEvent: event];
+           if (signal) {
+               interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
+           }
+         }
+     }
+
+     // Put back in the queue all events that did not belong to this window
+     // They will be managed by other windowing systems
+     // (or by a subsequent invocation to this function)
+     while (event = [alienEventQueue firstObject]){
+       [NSApp postEvent: event atStart: NO];
+       [alienEventQueue removeObject: event];
+     }
 }
 
 - (void) pumpRunLoop {	


### PR DESCRIPTION
It seems that "peeking" from the event queue does not yield events in case of changing resolutions:

```
NSApp nextEventMatchingMask:NSEventMaskAny
                             untilDate:nil
                             inMode:NSEventTrackingRunLoopMode
                             dequeue: ***NO***
```

And then it never enters the loop...

Of course, apple's doc says nothing about this: https://developer.apple.com/documentation/appkit/nsapplication/1428485-nexteventmatchingmask?language=objc
So all this is speculation ^^.

This new version consumes all pending events in the NSApp, and it does not show any lockups when e.g., switching resolutions. If the event does not correspond to this window, we take it from the event queue anyways and re-post it afterwards, to give other windows the opportunity to consume their events.