### PR TITLE
x11: emit mouse wheel events, drop the ctrl+arrow workaround

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -3682,17 +3682,18 @@ static void handleEvent(XEvent *evt)
 	  buttonState |= x2sqButton(evt->xbutton.button);
 	  recordMouseEvent();
 	  break;
-	case 4: case 5:	case 6: case 7: /* mouse wheel */
-	  {
-	    int keyCode = mouseWheel2Squeak[evt->xbutton.button - 4];
-		/* Set every meta bit to distinguish the fake event from a real
-		 * right/left arrow.
-		 */
-		int modifiers = modifierState | CtrlKeyBit | OptionKeyBit | CommandKeyBit | ShiftKeyBit);
-	    recordKeyboardEvent(keyCode, EventKeyDown, modifiers, keyCode);
-	    recordKeyboardEvent(keyCode, EventKeyChar, modifiers, keyCode);
-	    recordKeyboardEvent(keyCode, EventKeyUp,   modifiers, keyCode);
-	  }
+#define MOUSE_WHEEL_INCREMENT 120
+	case 4: /* mouse wheel up */
+	  recordMouseWheelEvent(0, 120);
+	  break;
+	case 5: /* mouse wheel down */
+	  recordMouseWheelEvent(0, -120);
+	  break;
+	case 6: /* mouse wheel right */
+	  recordMouseWheelEvent(-120, 0);
+	  break;
+	case 7: /* mouse wheel left */
+	  recordMouseWheelEvent(120, 0);
 	  break;
 	default:
 	  ioBeep();

--- a/platforms/unix/vm/sqUnixEvent.c
+++ b/platforms/unix/vm/sqUnixEvent.c
@@ -116,6 +116,10 @@ static sqInputEvent *allocateInputEvent(int eventType)
   (sqMouseEvent *)allocateInputEvent(EventTypeMouse) \
 )
 
+#define allocateMouseWheelEvent() ( \
+  (sqMouseEvent *)allocateInputEvent(EventTypeMouseWheel) \
+)
+
 #define allocateKeyboardEvent() ( \
   (sqKeyboardEvent *)allocateInputEvent(EventTypeKeyboard) \
 )
@@ -166,6 +170,14 @@ static void signalInputEvent(void)
     signalSemaphoreWithIndex(inputEventSemaIndex);
 }
 
+static void recordMouseWheelEvent(int dx, int dy) {
+  sqMouseEvent *evt = allocateMouseWheelEvent();
+  evt->x = dx;
+  evt->y = dy;
+  // VM reads fifth (4th 0-based) field for event's modifiers
+  evt->buttons = (getButtonState() >> 3);
+  signalInputEvent();
+}
 
 static void recordMouseEvent(void)
 {


### PR DESCRIPTION
These changes fixed the horizontal scrolling issues for me. Cursory testing revealed no unintended sideeffects, but more testing should be done. I did not find an easy way to test if horizontal scrolling works as intended, plainly logging the events looks good, however.

No image-side changes were necessary, so I would claim that the VMs for the other platforms can continue to work as normal, even with this change just on x11.

Using the workaround to mark a scroll event by detecting all modifiers being pressed down instead, will require an image-side change though.