### PR TITLE
Fixes for 64-bit MSVC minheadless build

### DIFF
--- a/platforms/Cross/plugins/IA32ABI/x64win64abicc.c
+++ b/platforms/Cross/plugins/IA32ABI/x64win64abicc.c
@@ -38,6 +38,9 @@ extern
 #endif
 struct VirtualMachine* interpreterProxy;
 
+#ifdef _MSC_VER
+# define alloca _alloca
+#endif
 #if __GNUC__
 # define setsp(sp) __asm__ volatile ("movq %0,%%rsp" : : "m"(sp))
 # define getsp() ({ void *sp; __asm__ volatile ("movq %%rsp,%0" : "=r"(sp) : ); sp;})

--- a/platforms/minheadless/windows/sqPlatformSpecific-Win32.h
+++ b/platforms/minheadless/windows/sqPlatformSpecific-Win32.h
@@ -114,7 +114,7 @@ size_t sqImageFileWrite(const void *ptr, size_t sz, size_t count, sqImageFile h)
 error "Not Win32!"
 #endif /* WIN32 */
 
-int ioSetCursorARGB(sqInt bitsIndex, sqInt w, sqInt h, sqInt x, sqInt y);
+sqInt ioSetCursorARGB(sqInt bitsIndex, sqInt w, sqInt h, sqInt x, sqInt y);
 
 /* poll and profile thread priorities.  The stack vm uses a thread to cause the
  * VM to poll for I/O, check for delay expiry et al at regular intervals.  Both


### PR DESCRIPTION
Following on from @ronsaldo's PR #311, these are some additional fixes for 64-bit MSVC build from my minheadless trial (http://forum.world.st/Minheadless-trial-td5082569.html).  We both made some changes around 32/64 bit detection in CMakeLists.txt so that still needs some work. All my other fixes were already covered in PR #311. 