### PR TITLE
Fix compile for Windows serial

### DIFF
--- a/platforms/Cross/plugins/SerialPlugin/sqNullSerialPort.c
+++ b/platforms/Cross/plugins/SerialPlugin/sqNullSerialPort.c
@@ -14,6 +14,7 @@
 
 #include "sq.h"
 #include "SerialPlugin.h"
+#define NO_ERROR 0
 
 extern struct VirtualMachine *interpreterProxy;
 
@@ -133,7 +134,7 @@ EXPORT (int) serialPortWriteFrom(int portNum, int count, void *bufferPtr) {
 	}
 
 	osErr = FSWrite(outRefNum[portNum], &byteCount, (char *) bufferPtr);
-	if (osErr != noErr) {
+	if (osErr != NO_ERROR) {
 		return interpreterProxy->success(false);
 	}
 	return byteCount;


### PR DESCRIPTION
Recently platforms/Cross/plugins/SerialPlugin/sqNullSerialPort.c 
was copied from platforms/iOS/plugins/SerialPlugin/sqNullSerialPort.c
but "noErr" enum from https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/MacTypes.h
doesn't exist on Windows. 
Change it to a #define.