### PR TITLE
Check sanity of curled gzip data

### DIFF
--- a/image/getGoodSpur64VM.sh
+++ b/image/getGoodSpur64VM.sh
@@ -52,7 +52,14 @@ else
 				exit
 			fi
 			curl -L "$URL" -o "$LATESTVM"
-			tar xzf "$LATESTVM"
+			# bug in bintray: on a 404 error,
+			# it will return a 200 with garbage data
+			if [[ $(file "$LATESTVM" | grep 'gzip compressed data') ]]; then 
+			  tar xzf "$LATESTVM"
+			else
+			  echo No gzip data at "$URL"
+			  exit
+			fi
 			mv sqcogspur64linuxht $VM
 			rm -f "$LATESTVM"
 		fi

--- a/image/getGoodSpurVM.sh
+++ b/image/getGoodSpurVM.sh
@@ -52,6 +52,14 @@ else
 				exit
 			fi
 			curl -L "$URL" -o "$LATESTVM"
+			# bug in bintray: on a 404 error,
+			# it will return a 200 with garbage data
+			if [[ $(file "$LATESTVM" | grep 'gzip compressed data') ]]; then 
+			  tar xzf "$LATESTVM"
+			else
+			  echo No gzip data at "$URL"
+			  exit
+			fi
 			tar xzf "$LATESTVM"
 			mv sqcogspurlinuxht $VM
 			rm -f "$LATESTVM"


### PR DESCRIPTION
The getGoodSpur*VM.sh scripts assume that the VM mentioned in the
topmost notification, is always there on bintray.  This is not
always the case.  Unfortunately, bintray will not return a 404 code
on a 404 error, but instead give a 200 with garbage data.  While we
can't do anything about that, at least make an attempt to bail if
the file doesn't even look like gzip-compressed data.