### PR TITLE
getGoodSpur[64]VM.sh sort for latest VM

### DIFF
--- a/image/getGoodSpur64VM.sh
+++ b/image/getGoodSpur64VM.sh
@@ -9,7 +9,7 @@ if [ "$1" = -vm -a -n "$2" -a -x "`which "$2"`" ]; then
 	shift;shift
 else
 	echo checking for latest 64-bit VM on bintray...
-	LATESTRELEASE=`curl -s -L "https://bintray.com/opensmalltalk/notifications" | grep 'has released version' | head -1 | sed 's/^.*[0-9]">\([0-9][0-9]*\).*$/\1/'`
+	LATESTRELEASE=`curl -s -L "https://bintray.com/opensmalltalk/notifications" | grep 'has released version' | sort -r | head -1 | sed 's/^.*[0-9]">\([0-9][0-9]*\).*$/\1/'`
 	if [ -z "$LATESTRELEASE" ]; then
 		echo "cannot find latest release on https://bintray.com/opensmalltalk/notifications" 1>&2
 		echo "If you've built your own VM you can substitute that using the -vm myvm argument to this script." 1>&2

--- a/image/getGoodSpurVM.sh
+++ b/image/getGoodSpurVM.sh
@@ -9,7 +9,7 @@ if [ "$1" = -vm -a -n "$2" -a -x "`which "$2"`" ]; then
 	shift;shift
 else
 	echo checking for latest 32-bit VM on bintray...
-	LATESTRELEASE=`curl -s -L "https://bintray.com/opensmalltalk/notifications" | grep 'has released version' | head -1 | sed 's/^.*[0-9]">\([0-9][0-9]*\).*$/\1/'`
+	LATESTRELEASE=`curl -s -L "https://bintray.com/opensmalltalk/notifications" | grep 'has released version' | sort -r | head -1 | sed 's/^.*[0-9]">\([0-9][0-9]*\).*$/\1/'`
 	if [ -z "$LATESTRELEASE" ]; then
 		echo "cannot find latest release on https://bintray.com/opensmalltalk/notifications" 1>&2
 		echo "If you've built your own VM you can substitute that using the -vm myvm argument to this script." 1>&2


### PR DESCRIPTION
BinTray sorts the notifications page by the notification timestamp, but
this is not always in the same order as the VM timestamp.  Sort the
output before taking the desired entry.

[ci skip]