### PR TITLE
Win64 cleanups

### DIFF
--- a/platforms/Cross/plugins/B3DAcceleratorPlugin/sqOpenGLRenderer.c
+++ b/platforms/Cross/plugins/B3DAcceleratorPlugin/sqOpenGLRenderer.c
@@ -119,6 +119,7 @@ print3Dlog(char *fmt, ...)
 	va_end(args);
 	if (forceFlush) /* from sqOpenGLRenderer.h */
 		fflush(logfile);
+	return 0;
 }
 
 /*****************************************************************************/

--- a/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
+++ b/platforms/Cross/plugins/FilePlugin/sqFilePluginBasicPrims.c
@@ -40,6 +40,12 @@
 #include <limits.h>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+#ifndef S_ISFIFO
+#define S_ISFIFO(x) 0
+#endif
+#endif
+
 #include "sqMemoryAccess.h"
 #include "FilePlugin.h" /* must be included after sq.h */
 

--- a/platforms/win32/plugins/B3DAcceleratorPlugin/sqWin32OpenGL.c
+++ b/platforms/win32/plugins/B3DAcceleratorPlugin/sqWin32OpenGL.c
@@ -123,7 +123,7 @@ static HWND glCreateClientWindow(HWND parentWindow, int x, int y, int w, int h)
 {
   WNDCLASS 	windowClass;
   HINSTANCE	hInstance;
-  const char *className = "Squeak-OpenGLWindow";
+  const TCHAR *className = TEXT("Squeak-OpenGLWindow");
 
   if(!parentWindow) return NULL;
   hInstance = (HINSTANCE) GetWindowLongPtr((HWND)parentWindow,GWLP_HINSTANCE);
@@ -138,7 +138,7 @@ static HWND glCreateClientWindow(HWND parentWindow, int x, int y, int w, int h)
   windowClass.lpszMenuName = NULL;
   windowClass.lpszClassName = className;
   RegisterClass(&windowClass);
-  return CreateWindow(className,"",
+  return CreateWindow(className,TEXT(""),
 		      WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS |WS_VISIBLE,
 		      x,y,w,h,
 		      (HWND) parentWindow,

--- a/platforms/win32/plugins/CroquetPlugin/sqWin32CroquetPlugin.c
+++ b/platforms/win32/plugins/CroquetPlugin/sqWin32CroquetPlugin.c
@@ -8,7 +8,7 @@ static BOOLEAN (__stdcall *RtlGenRandom)(PVOID, ULONG) = NULL;
 int ioGatherEntropy(char *bufPtr, int bufSize) {
   if(!loaded) {
     loaded = 1;
-    hAdvApi32 = LoadLibrary("advapi32.dll");
+    hAdvApi32 = LoadLibraryA("advapi32.dll");
     RtlGenRandom = (void*)GetProcAddress(hAdvApi32, "SystemFunction036");
   }
   if(!RtlGenRandom) return 0;

--- a/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
+++ b/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
@@ -423,7 +423,7 @@ sqInt ioSetIconOfWindow(sqInt windowIndex, char * iconPath, sqInt sizeOfPath) {
 	HICON hIcon = (HICON)LoadImage(NULL, iconPath, IMAGE_ICON, 0, 0, LR_LOADFROMFILE);
 	if (hIcon == 0)
 		return -2;
-	SendMessage(hwnd, WM_SETICON, ICON_BIG, (LONG)hIcon); 
+	SendMessage(hwnd, WM_SETICON, ICON_BIG, (LONG_PTR)hIcon); 
 	return 0;
 }
 

--- a/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
+++ b/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
@@ -306,7 +306,7 @@ sqInt ioShowDisplayOnWindow(unsigned char* dispBits, sqInt width,
 
   if(lines == 0) {
     printLastError(TEXT("SetDIBitsToDevice failed"));
-    warnPrintf(TEXT("width=%" PRIdSQINT ",height=%" PRIdSQINT ",bits=%" PRIXSQPTR ",dc=%" PRIXSQPTR "\n"),
+    warnPrintf(TEXT("width=%") TEXT(PRIdSQINT) TEXT(",height=%") TEXT(PRIdSQINT) TEXT(",bits=%") TEXT(PRIXSQPTR) TEXT(",dc=%") TEXT(PRIXSQPTR) TEXT("\n"),
 	       width, height, (usqIntptr_t)dispBits, (usqIntptr_t)dc);
   }
   /* reverse the image bits if necessary */

--- a/platforms/win32/plugins/LocalePlugin/sqWin32Locale.c
+++ b/platforms/win32/plugins/LocalePlugin/sqWin32Locale.c
@@ -36,7 +36,7 @@ void	sqLocGetCountryInto(char * str) {
 
 	char currString[6];
 	int length;
-	length = GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SISO3166CTRYNAME,currString, 6);
+	length = GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SISO3166CTRYNAME,currString, 6);
 	strncpy(str, currString, length-1);
 
 }
@@ -49,7 +49,7 @@ void	sqLocGetLanguageInto(char * str) {
 
 	char currString[6];
 	int length;
-	length = GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SISO639LANGNAME,currString, 6);
+	length = GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SISO639LANGNAME,currString, 6);
 	strncpy(str, currString, length-1);
 }
 
@@ -59,7 +59,7 @@ void	sqLocGetLanguageInto(char * str) {
  *currency amount */
 sqInt	sqLocCurrencyNotation(void) {
 	DWORD icurrency;
-	if (GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_ICURRENCY | LOCALE_RETURN_NUMBER,(char *)&icurrency, sizeof(icurrency)/sizeof(TCHAR)) != 0){
+	if (GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_ICURRENCY | LOCALE_RETURN_NUMBER,(char *)&icurrency, sizeof(icurrency)/sizeof(TCHAR)) != 0){
 		return((icurrency % 2) == 0);
 	}
 	return 0;
@@ -68,14 +68,14 @@ sqInt	sqLocCurrencyNotation(void) {
 /* return the length in chars of the curency symbol string */
 sqInt	sqLocCurrencySymbolSize(void) {
 	char currString[6];
-	return GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SCURRENCY,currString, 6)-1;
+	return GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SCURRENCY,currString, 6)-1;
 }
 
 /* write the currency symbol into the string ptr */
 void	sqLocGetCurrencySymbolInto(char * str) {
 	char currString[6];
 	int length;
-	length = GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SCURRENCY,currString, 6);
+	length = GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SCURRENCY,currString, 6);
 	strncpy(str, currString, length-1);
 
 
@@ -88,7 +88,7 @@ void	sqLocGetCurrencySymbolInto(char * str) {
  * (USA is about it) */
 sqInt	sqLocMeasurementMetric(void) {
 	char resultString[2];
-	if (GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_IMEASURE,resultString, 2) != 0){
+	if (GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_IMEASURE,resultString, 2) != 0){
 		if (strcmp (resultString,"0")) return false;
 		else return true;
 	}
@@ -99,7 +99,7 @@ sqInt	sqLocMeasurementMetric(void) {
  * Usually this is . or ,  as in 1,000,000 */
 void	sqLocGetDigitGroupingSymbolInto(char * str) {
 	char groupString[4];
-	GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_STHOUSAND,groupString, 4);
+	GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_STHOUSAND,groupString, 4);
 	strncpy(str, groupString, 1);
 
 }
@@ -107,7 +107,7 @@ void	sqLocGetDigitGroupingSymbolInto(char * str) {
  * Usually this is . or , */
 void	sqLocGetDecimalSymbolInto(char * str) {
 	char deciString[4];
-	GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SDECIMAL, deciString, 4);
+	GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SDECIMAL, deciString, 4);
 	strncpy(str, deciString, 1);
 }
 
@@ -142,7 +142,7 @@ sqInt	sqLocDaylightSavings(void) {
 static char longDateFormat[] = "dddd dd mmmm yy";
 /* return the size in chars of the long date format string */
 sqInt	sqLocLongDateFormatSize(void) {
-	return GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SLONGDATE, NULL, 0)-1;
+	return GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SLONGDATE, NULL, 0)-1;
 }
 
 /*Write the string describing the long date formatting into string ptr.
@@ -155,14 +155,14 @@ sqInt	sqLocLongDateFormatSize(void) {
 void	sqLocGetLongDateFormatInto(char * str) {
 	char dateString[80];
 	int length;
-	length = GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SLONGDATE, dateString, 80);
+	length = GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SLONGDATE, dateString, 80);
 	strncpy(str, dateString, length-1);
 }
 
 static char shortDateFormat[] = "dd/mm/yy";
 /* return the size in chars of the short date format string */
 sqInt	sqLocShortDateFormatSize(void) {
-	return GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SSHORTDATE, NULL, 0)-1;
+	return GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SSHORTDATE, NULL, 0)-1;
 }
 
 /*Write the string describing the short date formatting into string ptr.
@@ -174,14 +174,14 @@ sqInt	sqLocShortDateFormatSize(void) {
 void	sqLocGetShortDateFormatInto(char * str) {
 	char dateString[80];
 	int length;
-	length = GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_SSHORTDATE, dateString, 80);
+	length = GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_SSHORTDATE, dateString, 80);
 	strncpy(str, dateString, length-1);
 }
 
 static char timeFormat[] = "h:m:s";
 /* return the size in chars of the time format string */
 sqInt	sqLocTimeFormatSize(void) {
-	return GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_STIMEFORMAT, NULL, 0)-1;
+	return GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_STIMEFORMAT, NULL, 0)-1;
 }
 
 /* write the string describing the time formatting into string ptr.
@@ -191,6 +191,6 @@ sqInt	sqLocTimeFormatSize(void) {
 void	sqLocGetTimeFormatInto(char * str) {
 	char timeString[80];
 	int length;
-	length = GetLocaleInfo(LOCALE_USER_DEFAULT,LOCALE_STIMEFORMAT, timeString, 80);
+	length = GetLocaleInfoA(LOCALE_USER_DEFAULT,LOCALE_STIMEFORMAT, timeString, 80);
 	strncpy(str, timeString, length-1);
 }

--- a/platforms/win32/plugins/SecurityPlugin/sqWin32Security.c
+++ b/platforms/win32/plugins/SecurityPlugin/sqWin32Security.c
@@ -108,30 +108,43 @@ static int isAccessiblePathName(WCHAR *pathName, int writeFlag) {
   return 0;
 }
 
+static int isAccessibleUTF8PathName(char *pathName, int pathLen , int writeFlag) {
+	DWORD success;
+	WCHAR widePath[MAX_PATH];
+	widePath[MAX_PATH - 1] = 0;
+	success = MultiByteToWideChar(CP_UTF8, 0, pathName, pathLen, widePath, MAX_PATH-1);
+	if (! success) return 0; /* if conversion fails, then it's not accessible */
+	return isAccessiblePathName(widePath, writeFlag);
+}
+
 static int isAccessibleFileName(WCHAR *fileName, int writeFlag) {
   return isAccessiblePathName(fileName, writeFlag);
+}
+
+static int isAccessibleUTF8FileName(char *fileName, int fileLen, int writeFlag) {
+	return isAccessibleUTF8PathName(fileName, fileLen , writeFlag);
 }
 
 /* directory access */
 int ioCanCreatePathOfSize(char* pathString, int pathStringLength) {
   if(allowFileAccess) return 1;
-  return isAccessiblePathName(fromSqueak(pathString, pathStringLength), 1);
+  return isAccessibleUTF8PathName(pathString, pathStringLength, 1);
 }
 
 int ioCanListPathOfSize(char* pathString, int pathStringLength) {
   if(allowFileAccess) return 1;
-  return isAccessiblePathName(fromSqueak(pathString, pathStringLength), 0);
+  return isAccessibleUTF8PathName(pathString, pathStringLength, 0);
 }
 
 int ioCanDeletePathOfSize(char* pathString, int pathStringLength) {
   if(allowFileAccess) return 1;
-  return isAccessiblePathName(fromSqueak(pathString, pathStringLength), 1);
+  return isAccessibleUTF8PathName(pathString, pathStringLength, 1);
 }
 
 /* file access */
 int ioCanOpenFileOfSizeWritable(char* pathString, int pathStringLength, int writeFlag) {
   if(allowFileAccess) return 1;
-  return isAccessibleFileName(fromSqueak(pathString, pathStringLength), writeFlag);
+  return isAccessibleUTF8FileName(pathString, pathStringLength, writeFlag);
 }
 
 int ioCanOpenAsyncFileOfSizeWritable(char* pathString, int pathStringLength, int writeFlag) {
@@ -139,12 +152,12 @@ int ioCanOpenAsyncFileOfSizeWritable(char* pathString, int pathStringLength, int
 }
 int ioCanDeleteFileOfSize(char* pathString, int pathStringLength) {
   if(allowFileAccess) return 1;
-  return isAccessibleFileName(fromSqueak(pathString, pathStringLength), 1);
+  return isAccessibleUTF8FileName(pathString, pathStringLength, 1);
 }
 
 int ioCanRenameFileOfSize(char* pathString, int pathStringLength) {
   if(allowFileAccess) return 1;
-  return isAccessibleFileName(fromSqueak(pathString, pathStringLength), 1);
+  return isAccessibleUTF8FileName(pathString, pathStringLength, 1);
 }
 
 

--- a/platforms/win32/plugins/SoundPlugin/sqWin32Sound.c
+++ b/platforms/win32/plugins/SoundPlugin/sqWin32Sound.c
@@ -279,7 +279,7 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
     DPRINTF(("# Creating playback thread\n"));
     hPlayThread = CreateThread(NULL, 0, playCallback, NULL, 0, &threadID);
     if(hPlayThread == 0) {
-      printLastError("sndStart: CreateThread failed");
+      printLastError(TEXT("sndStart: CreateThread failed"));
       snd_StopPlaying();
       return 0;
     }

--- a/platforms/win32/plugins/SoundPlugin/sqWin32Sound.c
+++ b/platforms/win32/plugins/SoundPlugin/sqWin32Sound.c
@@ -408,7 +408,7 @@ snd_StartRecording(sqInt samplesPerSec, sqInt stereo, sqInt semaIndex) {
   recSemaphore = semaIndex;
   hRecThread = CreateThread(NULL, 0, recCallback, NULL, 0, &threadID);
   if(hRecThread == 0) {
-    printLastError("snd_StartRec: CreateThread failed");
+    printLastError(TEXT("snd_StartRec: CreateThread failed"));
     snd_StopRecording();
     return 0;
   }

--- a/platforms/win32/plugins/SoundPlugin/sqWin32Sound.c
+++ b/platforms/win32/plugins/SoundPlugin/sqWin32Sound.c
@@ -72,7 +72,7 @@ soundInit(void) {
 
 sqInt
 soundShutdown(void) {
-  DPRINTF(("soundShutDown\n"));
+  DPRINTF((TEXT("soundShutDown\n")));
   snd_StopPlaying();
   snd_StopRecording();
   CloseHandle(hPlayEvent);
@@ -84,7 +84,7 @@ sqInt
 snd_StopPlaying(void) {
   playTerminate = 0;
   if(lpdPlayBuffer) {
-    DPRINTF(("Shutting down DSound\n"));
+    DPRINTF((TEXT("Shutting down DSound\n")));
     IDirectSoundBuffer_Stop(lpdPlayBuffer);
     IDirectSoundBuffer_Release(lpdPlayBuffer);
     lpdPlayBuffer = NULL;
@@ -115,7 +115,7 @@ playCallback( LPVOID ignored ) {
     if(WaitForSingleObject(hPlayEvent, INFINITE) == WAIT_OBJECT_0) {
       if(playTerminate) {
 	hPlayThread = NULL;
-	DPRINTF(("playCallback shutdown\n"));
+	DPRINTF((TEXT("playCallback shutdown\n")));
 	snd_StopPlaying();
 	return 0; /* done playing */
       }
@@ -170,7 +170,7 @@ snd_PlaySamplesFromAtLength(sqInt frameCount, void* srcBufPtr,
   if(bytesWritten < playBufferSize)
     return 0;
 
-  DPRINTF(("[%d", frameCount));
+  DPRINTF((TEXT("[%d"), frameCount));
 
   hRes = IDirectSoundBuffer_Lock(lpdPlayBuffer, 
 				 playBufferSize * playBufferIndex,
@@ -179,7 +179,7 @@ snd_PlaySamplesFromAtLength(sqInt frameCount, void* srcBufPtr,
 				 NULL, NULL, 
 				 0);
   if(FAILED(hRes)) {
-    DPRINTF(("snd_Play: IDirectSoundBuffer_Lock failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("snd_Play: IDirectSoundBuffer_Lock failed (errCode: %x)\n"), hRes));
     return 0;
   }
   /* mix in stuff */
@@ -188,13 +188,13 @@ snd_PlaySamplesFromAtLength(sqInt frameCount, void* srcBufPtr,
     short *shortSrc = (short*)(((char*)srcBufPtr)+startIndex);
     short *shortDst = (short*)dstPtr;
     dstLen /=2;
-    DPRINTF(("|%d", dstLen));
+    DPRINTF((TEXT("|%d"), dstLen));
     for(i=0;i<dstLen;i++) {
       *shortDst++ = *(shortSrc++);
     }
   }
   IDirectSoundBuffer_Unlock(lpdPlayBuffer, dstPtr, dstLen, NULL, 0);
-  DPRINTF(("]"));
+  DPRINTF((TEXT("]")));
   playBufferAvailable = 0;
   return bytesWritten / waveOutFormat.nBlockAlign;
 }
@@ -220,7 +220,7 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
      (samplesPerSec != waveOutFormat.nSamplesPerSec) || 
      ((stereo == 0) != (waveOutFormat.nChannels == 1))) {
     /* format change */
-    DPRINTF(("DXSound format change (%d, %d, %s)\n", frameCount, samplesPerSec, (stereo ? "stereo" : "mono")));
+    DPRINTF((TEXT("DXSound format change (%d, %d, %s)\n"), frameCount, samplesPerSec, (stereo ? "stereo" : "mono")));
     snd_StopPlaying();
   }
 
@@ -228,27 +228,27 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
     /* keep playing */
     playTerminate = 0;
     playSemaphore = semaIndex; /* might have changed */
-    DPRINTF(("Continuing DSound\n"));
+    DPRINTF((TEXT("Continuing DSound\n")));
     return 1;
   }
 
-  DPRINTF(("Starting DSound\n"));
+  DPRINTF((TEXT("Starting DSound\n")));
   if(!lpdSound) {
     /* Initialize DirectSound */
-    DPRINTF(("# Creating lpdSound\n"));
+    DPRINTF((TEXT("# Creating lpdSound\n")));
     hRes = CoCreateInstance(&CLSID_DirectSound,
 			    NULL, 
 			    CLSCTX_INPROC_SERVER,
 			    &IID_IDirectSound,
 			    (void**)&lpdSound);
     if(FAILED(hRes)) {
-      DPRINTF(("sndStart: CoCreateInstance() failed (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("sndStart: CoCreateInstance() failed (errCode: %x)\n"), hRes));
       return 0;
     }
-    DPRINTF(("# Initializing lpdSound\n"));
+    DPRINTF((TEXT("# Initializing lpdSound\n")));
     hRes = IDirectSound_Initialize(lpdSound, NULL);
     if(FAILED(hRes)) {
-      DPRINTF(("sndStart: IDirectSound_Initialize() failed (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("sndStart: IDirectSound_Initialize() failed (errCode: %x)\n"), hRes));
       IDirectSound_Release(lpdSound);
       lpdSound = NULL;
       return 0;
@@ -256,17 +256,17 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
     /* set the cooperative level (DSSCL_PRIORITY is recommended) */
     hRes = IDirectSound_SetCooperativeLevel(lpdSound, stWindow, DSSCL_PRIORITY);
     if(FAILED(hRes)) {
-      DPRINTF(("sndStart: IDirectSound_SetCooperativeLevel failed (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("sndStart: IDirectSound_SetCooperativeLevel failed (errCode: %x)\n"), hRes));
       /* for now don't fail because of lack in cooperation */
     }
     /* grab the primary sound buffer for handling format changes */
     ZeroMemory(&dsbd, sizeof(dsbd));
     dsbd.dwSize = sizeof(dsbd);
     dsbd.dwFlags = DSBCAPS_PRIMARYBUFFER;
-    DPRINTF(("# Creating primary buffer\n"));
+    DPRINTF((TEXT("# Creating primary buffer\n")));
     hRes = IDirectSound_CreateSoundBuffer(lpdSound, &dsbd, &lpdPrimaryBuffer, NULL);
     if(FAILED(hRes)) {
-      DPRINTF(("sndStart: Failed to create primary buffer (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("sndStart: Failed to create primary buffer (errCode: %x)\n"), hRes));
       snd_StopPlaying();
       return 0;
     }
@@ -276,7 +276,7 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
 
   if(!hPlayThread) {
     /* create the playback notification thread */
-    DPRINTF(("# Creating playback thread\n"));
+    DPRINTF((TEXT("# Creating playback thread\n")));
     hPlayThread = CreateThread(NULL, 0, playCallback, NULL, 0, &threadID);
     if(hPlayThread == 0) {
       printLastError(TEXT("sndStart: CreateThread failed"));
@@ -315,14 +315,14 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
   if(lpdPrimaryBuffer) {
     hRes = IDirectSoundBuffer_SetFormat(lpdPrimaryBuffer, &waveOutFormat);
     if(FAILED(hRes)) {
-      DPRINTF(("sndStart: Failed to set primary buffer format (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("sndStart: Failed to set primary buffer format (errCode: %x)\n"), hRes));
     }
   }
 
-  DPRINTF(("# Creating play buffer\n"));
+  DPRINTF((TEXT("# Creating play buffer\n")));
   hRes = IDirectSound_CreateSoundBuffer(lpdSound, &dsbd, &lpdPlayBuffer, NULL);
   if(FAILED(hRes)) {
-    DPRINTF(("sndStart: IDirectSound_CreateSoundBuffer() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("sndStart: IDirectSound_CreateSoundBuffer() failed (errCode: %x)\n"), hRes));
     snd_StopPlaying();
     /* and try again */
     return 0;
@@ -333,7 +333,7 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
 					   &IID_IDirectSoundNotify, 
 					   (void**)&lpdNotify );
   if(FAILED(hRes)) {
-    DPRINTF(("sndStart: QueryInterface(IDirectSoundNotify) failed (errCode: %x)\n"));
+    DPRINTF((TEXT("sndStart: QueryInterface(IDirectSoundNotify) failed (errCode: %x)\n")));
     snd_StopPlaying();
     return 0;
   }
@@ -341,19 +341,19 @@ snd_Start(sqInt frameCount, sqInt samplesPerSec, sqInt stereo, sqInt semaIndex)
   posNotify[1].dwOffset = 2 * playBufferSize - 1;
   posNotify[0].hEventNotify = hPlayEvent;
   posNotify[1].hEventNotify = hPlayEvent;
-  DPRINTF(("# Setting notifications\n"));
+  DPRINTF((TEXT("# Setting notifications\n")));
   hRes = IDirectSoundNotify_SetNotificationPositions(lpdNotify, 2, posNotify);
   IDirectSoundNotify_Release(lpdNotify);
   if(FAILED(hRes)) {
-    DPRINTF(("sndStart: IDirectSoundNotify_SetNotificationPositions() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("sndStart: IDirectSoundNotify_SetNotificationPositions() failed (errCode: %x)\n"), hRes));
     snd_StopPlaying();
     return 0;
   }
 
-  DPRINTF(("# Starting to play buffer\n"));
+  DPRINTF((TEXT("# Starting to play buffer\n")));
   hRes = IDirectSoundBuffer_Play(lpdPlayBuffer, 0, 0, DSBPLAY_LOOPING);
   if(FAILED(hRes)) {
-    DPRINTF(("sndStart: IDirectSoundBuffer_Play() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("sndStart: IDirectSoundBuffer_Play() failed (errCode: %x)\n"), hRes));
     snd_StopPlaying();
     return 0;
   }
@@ -393,12 +393,12 @@ snd_StartRecording(sqInt samplesPerSec, sqInt stereo, sqInt semaIndex) {
 			    &IID_IDirectSoundCapture,
 			    (void**)&lpdCapture);
     if(FAILED(hRes)) {
-      DPRINTF(("snd_StartRec: CoCreateInstance() failed (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("snd_StartRec: CoCreateInstance() failed (errCode: %x)\n"), hRes));
       return 0;
     }
     hRes = IDirectSoundCapture_Initialize(lpdCapture, NULL);
     if(FAILED(hRes)) {
-      DPRINTF(("snd_StartRec: IDirectSoundCapture_Initialize() failed (errCode: %x)\n", hRes));
+      DPRINTF((TEXT("snd_StartRec: IDirectSoundCapture_Initialize() failed (errCode: %x)\n"), hRes));
       lpdCapture = NULL;
       return 0;
     }
@@ -436,14 +436,14 @@ snd_StartRecording(sqInt samplesPerSec, sqInt stereo, sqInt semaIndex) {
   dscb.lpwfxFormat = &waveInFormat;
   hRes = IDirectSoundCapture_CreateCaptureBuffer(lpdCapture, &dscb, &lpdRecBuffer, NULL);
   if(FAILED(hRes)) {
-    DPRINTF(("snd_StartRec: IDirectSoundCapture_CreateCaptureBuffer() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("snd_StartRec: IDirectSoundCapture_CreateCaptureBuffer() failed (errCode: %x)\n"), hRes));
     return 0;
   }
   hRes = IDirectSoundCaptureBuffer_QueryInterface(lpdRecBuffer,
 						  &IID_IDirectSoundNotify, 
 						  (void**)&lpdNotify );
   if(FAILED(hRes)) {
-    DPRINTF(("snd_StartRec: QueryInterface(IDirectSoundNotify) failed (errCode: %x)\n"));
+    DPRINTF((TEXT("snd_StartRec: QueryInterface(IDirectSoundNotify) failed (errCode: %x)\n")));
     snd_StopRecording();
     return 0;
   }
@@ -454,13 +454,13 @@ snd_StartRecording(sqInt samplesPerSec, sqInt stereo, sqInt semaIndex) {
   hRes = IDirectSoundNotify_SetNotificationPositions(lpdNotify, 2, posNotify);
   IDirectSoundNotify_Release(lpdNotify);
   if(FAILED(hRes)) {
-    DPRINTF(("snd_StartRec: IDirectSoundNotify_SetNotificationPositions() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("snd_StartRec: IDirectSoundNotify_SetNotificationPositions() failed (errCode: %x)\n"), hRes));
     snd_StopRecording();
     return 0;
   }
   hRes = IDirectSoundCaptureBuffer_Start(lpdRecBuffer, DSCBSTART_LOOPING);
   if(FAILED(hRes)) {
-    DPRINTF(("snd_StartRec: IDirectSoundCaptureBuffer_Start() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("snd_StartRec: IDirectSoundCaptureBuffer_Start() failed (errCode: %x)\n"), hRes));
     snd_StopRecording();
     return 0;
   }
@@ -530,7 +530,7 @@ snd_RecordSamplesIntoAtLength(void* buf, sqInt startSliceIndex,
 					NULL, NULL,
 					0);
   if(FAILED(hRes)) {
-    DPRINTF(("snd_Rec: IDirectSoundCaptureBuffer_Lock() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("snd_Rec: IDirectSoundCaptureBuffer_Lock() failed (errCode: %x)\n"), hRes));
     return 0;
   }
 
@@ -544,7 +544,7 @@ snd_RecordSamplesIntoAtLength(void* buf, sqInt startSliceIndex,
 					  srcPtr, srcLen,
 					  NULL, 0);
   if(FAILED(hRes)) {
-    DPRINTF(("snd_Rec: IDirectSoundCaptureBuffer_Unlock() failed (errCode: %x)\n", hRes));
+    DPRINTF((TEXT("snd_Rec: IDirectSoundCaptureBuffer_Unlock() failed (errCode: %x)\n"), hRes));
   }
 
   return bytesCopied / bytesPerSlice;

--- a/platforms/win32/plugins/SqueakSSL/sqWin32SSL.c
+++ b/platforms/win32/plugins/SqueakSSL/sqWin32SSL.c
@@ -173,7 +173,7 @@ static sqInt sqSetupCert(sqSSL *ssl, char *certName, int server) {
 	char  bFriendlyName[MAX_NAME_SIZE];
 
 	if(certName) {
-		hStore = CertOpenSystemStore(0, L"MY");
+		hStore = CertOpenSystemStore(0, TEXT("MY"));
 		if(!hStore) {
 			if(ssl->loglevel) printf("sqSetupCert: CertOpenSystemStore failed\n");
 			return 0;
@@ -923,7 +923,7 @@ static sqInt sqAddPfxCertToStore(char *pfxData, sqInt pfxLen, char *passData, sq
 	if(!pfxStore) return 0;
 
 	/* And copy the certificates to MY store */
-	myStore = CertOpenSystemStore(0, L"MY");
+	myStore = CertOpenSystemStore(0, TEXT("MY"));
 	pContext = NULL;
 	while(pContext = CertEnumCertificatesInStore(pfxStore, pContext)) {
 		CertAddCertificateContextToStore(myStore, pContext, CERT_STORE_ADD_REPLACE_EXISTING, NULL);

--- a/platforms/win32/plugins/SqueakSSL/sqWin32SSL.c
+++ b/platforms/win32/plugins/SqueakSSL/sqWin32SSL.c
@@ -102,7 +102,7 @@ static void sqPrintSBD(char *title, SecBufferDesc sbd) {
 	printf("%s\n", title);
 	for(i=0; i<sbd.cBuffers; i++) {
 		SecBuffer *buf = sbd.pBuffers + i;
-		printf("\tbuf[%d]: %d (%d bytes) ptr=%x\n", i,buf->BufferType, buf->cbBuffer, (int)buf->pvBuffer);
+		printf("\tbuf[%d]: %d (%d bytes) ptr=%"PRIxSQPTR"\n", i,buf->BufferType, buf->cbBuffer, (sqIntptr_t)buf->pvBuffer);
 	}
 }
 
@@ -505,7 +505,7 @@ sqInt sqConnectSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 		if (!ssl->dataBuf) return SQSSL_OUT_OF_MEMORY;
 	}
 	if(ssl->loglevel) 
-		printf("sqConnectSSL: input token %d bytes\n", srcLen);
+		printf("sqConnectSSL: input token %" PRIdSQINT " bytes\n", srcLen);
 	memcpy(ssl->dataBuf + ssl->dataLen, srcBuf, srcLen);
 	ssl->dataLen += srcLen;
 
@@ -737,7 +737,7 @@ sqInt sqEncryptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 
 	if(ssl == NULL || ssl->state != SQSSL_CONNECTED) return SQSSL_INVALID_STATE;
 
-	if(ssl->loglevel) printf("sqEncryptSSL: Encrypting %d bytes\n", srcLen);
+	if(ssl->loglevel) printf("sqEncryptSSL: Encrypting %" PRIdSQINT " bytes\n", srcLen);
 
 	if(srcLen > (int)ssl->sslSizes.cbMaximumMessage) 
 		return SQSSL_INPUT_TOO_LARGE;
@@ -810,7 +810,7 @@ sqInt sqDecryptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 		ssl->dataBuf = realloc(ssl->dataBuf, ssl->dataMax);
 		if(!ssl->dataBuf) return SQSSL_OUT_OF_MEMORY;
 	}
-	if(ssl->loglevel) printf("sqDecryptSSL: Input data %d bytes\n", srcLen);
+	if(ssl->loglevel) printf("sqDecryptSSL: Input data %" PRIdSQINT " bytes\n", srcLen);
 	memcpy(ssl->dataBuf + ssl->dataLen, srcBuf, srcLen);
 	ssl->dataLen += srcLen;
 
@@ -847,7 +847,7 @@ sqInt sqDecryptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 		int buftype = ssl->inbuf[i].BufferType;
 		int count = ssl->inbuf[i].cbBuffer;
 		char *buffer = ssl->inbuf[i].pvBuffer;
-		if(ssl->loglevel) printf("buf[%d]: %d (%d bytes) ptr=%x\n", i,buftype, count, (int)buffer);
+		if(ssl->loglevel) printf("buf[%d]: %d (%d bytes) ptr=%"PRIxSQPTR"\n", i,buftype, count, (sqIntptr_t)buffer);
 		if(buftype == SECBUFFER_DATA) {
 			if(count > dstLen) return SQSSL_BUFFER_TOO_SMALL;
 			memcpy(dstBuf, buffer, count);
@@ -1014,7 +1014,7 @@ sqInt sqSetIntPropertySSL(sqInt handle, sqInt propID, sqInt propValue) {
 	switch(propID) {
 		case SQSSL_PROP_LOGLEVEL: ssl->loglevel = propValue; break;
 		default:
-			if(ssl->loglevel) printf("sqSetIntPropertySSL: Unknown property ID %d\n", propID);
+			if(ssl->loglevel) printf("sqSetIntPropertySSL: Unknown property ID %" PRIdSQINT "\n", propID);
 			return 0;
 	}
 	return 1;

--- a/platforms/win32/vm/sqWin32.h
+++ b/platforms/win32/vm/sqWin32.h
@@ -263,7 +263,7 @@ extern char imageName[];		/* full path and name to image */
 extern TCHAR imagePath[];		/* full path to image */
 extern TCHAR vmPath[];		    /* full path to interpreter's directory */
 extern TCHAR vmName[];		    /* name of the interpreter's executable */
-extern TCHAR windowTitle[];             /* window title string */
+extern char windowTitle[];             /* window title string */
 extern char vmBuildString[];            /* the vm build string */
 extern TCHAR windowClassName[];    /* class name for the window */
 

--- a/platforms/win32/vm/sqWin32Alloc.c
+++ b/platforms/win32/vm/sqWin32Alloc.c
@@ -99,19 +99,19 @@ void *sqAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
 int sqGrowMemoryBy(int oldLimit, int delta) {
   /* round delta UP to page size */
   if(fShowAllocations) {
-    warnPrintf("Growing memory by %d...", delta);
+    warnPrintf(TEXT("Growing memory by %d..."), delta);
   }
   delta = (delta + pageSize) & pageMask;
   if(!VirtualAlloc(pageLimit, delta, MEM_COMMIT, PAGE_READWRITE)) {
     if(fShowAllocations) {
-      warnPrintf("failed\n");
+      warnPrintf(TEXT("failed\n"));
     }
     /* failed to grow */
     return oldLimit;
   }
   /* otherwise, expand pageLimit and return new top limit */
   if(fShowAllocations) {
-    warnPrintf("okay\n");
+    warnPrintf(TEXT("okay\n"));
   }
   pageLimit += delta;
   usedMemory += delta;
@@ -124,26 +124,26 @@ int sqGrowMemoryBy(int oldLimit, int delta) {
 int sqShrinkMemoryBy(int oldLimit, int delta) {
   /* round delta DOWN to page size */
   if(fShowAllocations) {
-    warnPrintf("Shrinking by %d...",delta);
+    warnPrintf(TEXT("Shrinking by %d..."),delta);
   }
 #ifdef DO_NOT_SHRINK
   {
     /* Experimental - do not unmap memory and avoid OGL crashes */
-    if(fShowAllocations) warnPrintf(" - ignored\n");
+    if(fShowAllocations) warnPrintf(TEXT(" - ignored\n"));
     return oldLimit;
   }
 #endif
   delta &= pageMask;
   if(!VirtualFree(pageLimit-delta, delta, MEM_DECOMMIT)) {
     if(fShowAllocations) {
-      warnPrintf("failed\n");
+      warnPrintf(TEXT("failed\n"));
     }
     /* failed to shrink */
     return oldLimit;
   }
   /* otherwise, shrink pageLimit and return new top limit */
   if(fShowAllocations) {
-    warnPrintf("okay\n");
+    warnPrintf(TEXT("okay\n"));
   }
   pageLimit -= delta;
   usedMemory -= delta;

--- a/platforms/win32/vm/sqWin32Backtrace.c
+++ b/platforms/win32/vm/sqWin32Backtrace.c
@@ -261,14 +261,14 @@ get_modules(void)
 {
 	DWORD moduleCount2, i;
 	HANDLE me = GetCurrentProcess();
-	HANDLE hPsApi = LoadLibrary("psapi.dll");
+	HANDLE hPsApi = LoadLibraryA("psapi.dll");
 	HMODULE *modules;
 
 	EnumProcessModules = (void*)GetProcAddress(hPsApi, "EnumProcessModules");
 	GetModuleInformation=(void*)GetProcAddress(hPsApi, "GetModuleInformation");
 
 	if (!EnumProcessModules(me, (HMODULE *)&modules, sizeof(modules), &moduleCount)) {
-		printLastError("EnumProcessModules 1");
+		printLastError(TEXT("EnumProcessModules 1"));
 		return;
 	}
 	modules = malloc(moduleCount);
@@ -280,14 +280,14 @@ get_modules(void)
 	all_exports = calloc(moduleCount / sizeof(HMODULE) + EXTRAMODULES,
 						 sizeof(dll_exports));
 	if (!modules || !all_exports) {
-		printLastError("get_modules out of memory");
+		printLastError(TEXT("get_modules out of memory"));
 		if (modules)
 			free(modules);
 		return;
 	}
 
 	if (!EnumProcessModules(me, modules, moduleCount, &moduleCount2)) {
-		printLastError("EnumProcessModules 2");
+		printLastError(TEXT("EnumProcessModules 2"));
 		free(modules);
 		return;
 	}
@@ -295,10 +295,10 @@ get_modules(void)
 
 	for (i = 0; i < moduleCount; i++) {
 		all_exports[i].module = modules[i];
-		if (!GetModuleFileName(modules[i], all_exports[i].name, MAX_PATH))
-			printLastError("GetModuleFileName");
+		if (!GetModuleFileNameA(modules[i], all_exports[i].name, MAX_PATH))
+			printLastError(TEXT("GetModuleFileName"));
 		if (!GetModuleInformation(me, modules[i], &all_exports[i].info, sizeof(MODULEINFO)))
-			printLastError("GetModuleInformation");
+			printLastError(TEXT("GetModuleInformation"));
 		all_exports[i].find_symbol = find_in_dll;
 	}
 	free(modules);
@@ -447,19 +447,19 @@ compute_exe_symbols(dll_exports *exports)
 	strcpy(strrchr(filename,'.')+1,"map");
 
 	if (!(f = fopen(filename,"r"))) {
-		printLastError("fopen");
+		printLastError(TEXT("fopen"));
 		return;
 	}
 	fseek(f,0,SEEK_END);
 	len = ftell(f);
 	fseek(f,0,SEEK_SET);
 	if (!(contents = malloc(len))) {
-		printLastError("malloc");
+		printLastError(TEXT("malloc"));
 		fclose(f);
 		return;
 	}
 	if (fread(contents, sizeof(char), len, f) != len) {
-		printLastError("fread");
+		printLastError(TEXT("fread"));
 		fclose(f);
 		return;
 	}
@@ -476,7 +476,7 @@ compute_exe_symbols(dll_exports *exports)
 
 	if (!(exports->functions	= calloc(nlines,sizeof(ulong)))
 	 || !(exports->u.funcNames	= calloc(nlines,sizeof(char *)))) {
-		printLastError("malloc");
+		printLastError(TEXT("malloc"));
 		fclose(f);
 		return;
 	}
@@ -559,7 +559,7 @@ compute_dll_symbols(dll_exports *exports)
     functions =	(ulong *)(dllbase + pExportDir->AddressOfFunctions);
 
     if (!(exports->sorted_ordinals = calloc(pExportDir->NumberOfNames, sizeof(int)))) {
-		printLastError("compute_dll_symbols calloc");
+		printLastError(TEXT("compute_dll_symbols calloc"));
 		return;
 	}
 	exports->functions = functions;

--- a/platforms/win32/vm/sqWin32DirectInput.c
+++ b/platforms/win32/vm/sqWin32DirectInput.c
@@ -23,7 +23,11 @@
 #ifndef NO_DIRECTINPUT
 
 #ifndef DIRECTINPUT_VERSION
-#define DIRECTINPUT_VERSION 0x700 /* restrict to DX7 */
+#ifdef _MSC_VER
+#define DIRECTINPUT_VERSION 0x800 /* DX8 */
+#else
+#define DIRECTINPUT_VERSION 0x700 /* use DX7 via mingw/cygwin */
+#endif
 #endif 
 
 #include <windows.h>

--- a/platforms/win32/vm/sqWin32Directory.c
+++ b/platforms/win32/vm/sqWin32Directory.c
@@ -19,6 +19,17 @@
 # include <sys/types.h>
 # include <sys/stat.h>
 
+/**
+ * Posix permissions are not defined in Windows, except when using
+ * Mingw or Cygwin. Since these constants are just standard, we define
+ * them for our purpose of emulating permissions.
+ */
+#ifndef S_IRUSR
+#define S_IRUSR 0400
+#define S_IWUSR 0200
+#define S_IXUSR 0100
+#endif
+
 extern struct VirtualMachine *interpreterProxy;
 
 #define FAIL() { return interpreterProxy->primitiveFail(); }

--- a/platforms/win32/vm/sqWin32Directory.c
+++ b/platforms/win32/vm/sqWin32Directory.c
@@ -49,7 +49,7 @@ static void read_permissions(sqInt *posixPermissions, WCHAR* path, sqInt pathLen
   if (attr & FILE_ATTRIBUTE_DIRECTORY) {
     *posixPermissions |= S_IXUSR | (S_IXUSR>>3) | (S_IXUSR>>6);
   }
-  else if (path && path[pathLength - 4] == L'.') {
+  else if (path && pathLength > 3 && path[pathLength - 4] == L'.') {
     WCHAR *ext = &path[pathLength - 3];
     if (!_wcsicmp (ext, L"COM")) {
       *posixPermissions |= S_IXUSR | (S_IXUSR>>3) | (S_IXUSR>>6);

--- a/platforms/win32/vm/sqWin32ExternalPrims.c
+++ b/platforms/win32/vm/sqWin32ExternalPrims.c
@@ -69,19 +69,11 @@ ioFindExternalFunctionInAccessorDepthInto(char *lookupName, void *moduleHandle,
 	void *f;
 	char buffer[256];
 
-# ifdef UNICODE
-	f = GetProcAddress(moduleHandle, toUnicode(lookupName));
-# else
 	f = GetProcAddress(moduleHandle, lookupName);
-# endif
 	if (f && accessorDepthPtr) {
 		void *accessorDepthVarPtr;
 		snprintf(buffer,256,"%sAccessorDepth",lookupName);
-# ifdef UNICODE
-		accessorDepthVarPtr = GetProcAddress(moduleHandle, toUnicode(buffer));
-# else
 		accessorDepthVarPtr = GetProcAddress(moduleHandle, buffer);
-# endif
 		/* The Slang machinery assumes accessor depth defaults to -1, which
 		 * means "no accessor depth".  It saves space not outputting -1 depths.
 		 */
@@ -95,11 +87,7 @@ ioFindExternalFunctionInAccessorDepthInto(char *lookupName, void *moduleHandle,
 void *
 ioFindExternalFunctionIn(char *lookupName, void *moduleHandle)
 {
-# ifdef UNICODE
-	return GetProcAddress((HANDLE)moduleHandle, toUnicode(lookupName));
-# else
 	return GetProcAddress((HANDLE)moduleHandle, lookupName);
-# endif
 }
 #endif /* SPURVM */
 

--- a/platforms/win32/vm/sqWin32Heartbeat.c
+++ b/platforms/win32/vm/sqWin32Heartbeat.c
@@ -65,6 +65,11 @@ sqLong ioHighResClock(void) {
 						: "=a" (value)
 						: 
 						: "rdx");
+#elif defined(_MSC_VER)
+  LARGE_INTEGER aux;
+  aux.QuadPart = 0;
+  QueryPerformanceCounter(&aux);
+  value = aux.QuadPart;
 #else
 # error "no high res clock defined"
 #endif

--- a/platforms/win32/vm/sqWin32Main.c
+++ b/platforms/win32/vm/sqWin32Main.c
@@ -540,7 +540,7 @@ void gatherSystemInfo(void) {
 
 
   {
-    HANDLE hUser = LoadLibrary( "user32.dll" );
+    HANDLE hUser = LoadLibraryA( "user32.dll" );
     pfnEnumDisplayDevices pEnumDisplayDevices = (pfnEnumDisplayDevices)
       GetProcAddress(hUser, "EnumDisplayDevicesA");
     ZeroMemory(&gDev, sizeof(gDev));

--- a/platforms/win32/vm/sqWin32PluginSupport.c
+++ b/platforms/win32/vm/sqWin32PluginSupport.c
@@ -342,7 +342,7 @@ void pluginGetURLRequest(int id, void* urlIndex, int urlSize,
   DWORD dwWritten;
   
   if(!hBrowserPipe) {
-    warnPrintf("Cannot submit URL request -- there is no connection to a browser\n");
+    warnPrintf(TEXT("Cannot submit URL request -- there is no connection to a browser\n"));
     return;
   }
 
@@ -376,7 +376,7 @@ void pluginPostURLRequest(int id, void* urlIndex, int urlSize,
   DWORD dwWritten;
 
   if(!hBrowserPipe) {
-    warnPrintf("Cannot submit URL post request -- there is no connection to a browser\n");
+    warnPrintf(TEXT("Cannot submit URL post request -- there is no connection to a browser\n"));
     return;
   }
 

--- a/platforms/win32/vm/sqWin32PluginSupport.c
+++ b/platforms/win32/vm/sqWin32PluginSupport.c
@@ -352,19 +352,19 @@ void pluginGetURLRequest(int id, void* urlIndex, int urlSize,
   SetLastError(0);
   ok = WriteFile(hBrowserPipe, &urlSize, 4, &dwWritten, NULL);
   if(!ok || dwWritten != 4)
-    printLastError("Failed to write url size");
+    printLastError(TEXT("Failed to write url size"));
   if(urlSize > 0) {
     ok = WriteFile(hBrowserPipe, urlIndex, urlSize, &dwWritten, NULL);
     if(!ok || dwWritten != urlSize)
-      printLastError("Failed to write url request");
+      printLastError(TEXT("Failed to write url request"));
   }
   ok = WriteFile(hBrowserPipe, &targetSize, 4, &dwWritten, NULL);
   if(!ok || dwWritten != 4)
-    printLastError("Failed to write target size");
+    printLastError(TEXT("Failed to write target size"));
   if(targetSize > 0) {
     ok = WriteFile(hBrowserPipe, targetIndex, targetSize, &dwWritten, NULL);
     if(!ok || dwWritten != targetSize)
-      printLastError("Failed to write url request");
+      printLastError(TEXT("Failed to write url request"));
   }
 }
 
@@ -386,29 +386,29 @@ void pluginPostURLRequest(int id, void* urlIndex, int urlSize,
   SetLastError(0);
   ok = WriteFile(hBrowserPipe, &urlSize, 4, &dwWritten, NULL);
   if(!ok || dwWritten != 4)
-    printLastError("Failed to write url size");
+    printLastError(TEXT("Failed to write url size"));
   if(urlSize > 0) {
     ok = WriteFile(hBrowserPipe, urlIndex, urlSize, &dwWritten, NULL);
     if(!ok || dwWritten != urlSize)
-      printLastError("Failed to write url request");
+      printLastError(TEXT("Failed to write url request"));
   }
 
   ok = WriteFile(hBrowserPipe, &targetSize, 4, &dwWritten, NULL);
   if(!ok || dwWritten != 4)
-    printLastError("Failed to write url size");
+    printLastError(TEXT("Failed to write url size"));
   if(targetSize > 0) {
     ok = WriteFile(hBrowserPipe, targetIndex, targetSize, &dwWritten, NULL);
     if(!ok || dwWritten != targetSize)
-      printLastError("Failed to write target request");
+      printLastError(TEXT("Failed to write target request"));
   }
 
   ok = WriteFile(hBrowserPipe, &postDataSize, 4, &dwWritten, NULL);
   if(!ok || dwWritten != 4)
-    printLastError("Failed to write post data size");
+    printLastError(TEXT("Failed to write post data size"));
   if(postDataSize > 0) {
     ok = WriteFile(hBrowserPipe, postDataIndex, postDataSize, &dwWritten, NULL);
     if(!ok || dwWritten != postDataSize)
-      printLastError("Failed to write data request");
+      printLastError(TEXT("Failed to write data request"));
   }
 }
 
@@ -428,7 +428,7 @@ void pluginSetBrowserPipe(MSG *msg)
   if(hBrowserPipe) CloseHandle(hBrowserPipe);
   hBrowserPipe = (HANDLE) msg->lParam;
   if(!CreatePipe(&hClientReadEnd, &hClientWriteEnd, NULL, 4096))
-    printLastError("CreatePipe failed");
+    printLastError(TEXT("CreatePipe failed"));
   
   /* And pass our the write end back to the plugin */
   PostMessage(browserWindow, g_WM_CLIENT_PIPE, (WPARAM) GetCurrentProcess(), (LPARAM) hClientWriteEnd);

--- a/platforms/win32/vm/sqWin32PluginSupport.c
+++ b/platforms/win32/vm/sqWin32PluginSupport.c
@@ -81,7 +81,7 @@ EXPORT(int) primitivePluginBrowserReady(void)
 {
   if(!fBrowserMode) {
     /* fast failure is better when not in browser */
-    DPRINTF(("fBrowserMode == 0\n"));
+    DPRINTF((TEXT("fBrowserMode == 0\n")));
     return primitiveFail();
   }
   pop(1);
@@ -424,7 +424,7 @@ void pluginPostURLRequest(int id, void* urlIndex, int urlSize,
 */
 void pluginSetBrowserPipe(MSG *msg)
 {
-  DPRINTF(("New browser pipe: %x\n",msg->lParam));
+  DPRINTF((TEXT("New browser pipe: %x\n"),msg->lParam));
   if(hBrowserPipe) CloseHandle(hBrowserPipe);
   hBrowserPipe = (HANDLE) msg->lParam;
   if(!CreatePipe(&hClientReadEnd, &hClientWriteEnd, NULL, 4096))
@@ -469,15 +469,15 @@ void pluginInit(void)
 */
 void pluginHandleEvent(MSG *msg)
 {
-  DPRINTF(("Checking for plugin message (%x)\n",msg->message));
-  DPRINTF(("\tg_WM_QUIT_SESSION: %x\n",g_WM_QUIT_SESSION));
-  DPRINTF(("\tg_WM_BWND_SIZE: %x\n",g_WM_BWND_SIZE));
-  DPRINTF(("\tg_WM_REQUEST_DATA: %x\n",g_WM_REQUEST_DATA));
-  DPRINTF(("\tg_WM_POST_DATA: %x\n",g_WM_POST_DATA));
-  DPRINTF(("\tg_WM_RECEIVE_DATA: %x\n",g_WM_RECEIVE_DATA));
-  DPRINTF(("\tg_WM_INVALIDATE: %x\n",g_WM_INVALIDATE));
-  DPRINTF(("\tg_WM_BROWSER_PIPE: %x\n",g_WM_BROWSER_PIPE));
-  DPRINTF(("\tg_WM_CLIENT_PIPE: %x\n",g_WM_CLIENT_PIPE));
+  DPRINTF((TEXT("Checking for plugin message (%x)\n"),msg->message));
+  DPRINTF((TEXT("\tg_WM_QUIT_SESSION: %x\n"),g_WM_QUIT_SESSION));
+  DPRINTF((TEXT("\tg_WM_BWND_SIZE: %x\n"),g_WM_BWND_SIZE));
+  DPRINTF((TEXT("\tg_WM_REQUEST_DATA: %x\n"),g_WM_REQUEST_DATA));
+  DPRINTF((TEXT("\tg_WM_POST_DATA: %x\n"),g_WM_POST_DATA));
+  DPRINTF((TEXT("\tg_WM_RECEIVE_DATA: %x\n"),g_WM_RECEIVE_DATA));
+  DPRINTF((TEXT("\tg_WM_INVALIDATE: %x\n"),g_WM_INVALIDATE));
+  DPRINTF((TEXT("\tg_WM_BROWSER_PIPE: %x\n"),g_WM_BROWSER_PIPE));
+  DPRINTF((TEXT("\tg_WM_CLIENT_PIPE: %x\n"),g_WM_CLIENT_PIPE));
 
   /* Messages posted from a different process */
   if(msg->message == g_WM_QUIT_SESSION) exit(0);

--- a/platforms/win32/vm/sqWin32Prefs.c
+++ b/platforms/win32/vm/sqWin32Prefs.c
@@ -207,8 +207,17 @@ void LoadPreferences()
   }
 
   /* get window title from ini file */
+#ifdef UNICODE
+  {
+    TCHAR windowTitleT[MAX_PATH];
+    GetPrivateProfileString(U_GLOBAL, TEXT("WindowTitle"),
+      TEXT(""), windowTitleT, MAX_PATH, squeakIniName);
+    WideCharToMultiByte(CP_UTF8, 0, windowTitleT, -1, windowTitle, MAX_PATH, NULL, NULL);
+  }
+#else
   GetPrivateProfileString(U_GLOBAL, TEXT("WindowTitle"), 
 			 TEXT(""), windowTitle, MAX_PATH, squeakIniName);
+#endif
 
   /* get the window class name from the ini file */
   GetPrivateProfileString(U_GLOBAL, TEXT("WindowClassName"), 

--- a/platforms/win32/vm/sqWin32Prefs.c
+++ b/platforms/win32/vm/sqWin32Prefs.c
@@ -212,7 +212,10 @@ void LoadPreferences()
     TCHAR windowTitleT[MAX_PATH];
     GetPrivateProfileString(U_GLOBAL, TEXT("WindowTitle"),
       TEXT(""), windowTitleT, MAX_PATH, squeakIniName);
-    WideCharToMultiByte(CP_UTF8, 0, windowTitleT, -1, windowTitle, MAX_PATH, NULL, NULL);
+	if (WideCharToMultiByte(CP_UTF8, 0, windowTitleT, -1, windowTitle, MAX_PATH, NULL, NULL) == 0) {
+		printLastError(TEXT("Failed to convert WindowTitle preference to UTF-8"));
+		windowTitle[0] = 0;
+	};
   }
 #else
   GetPrivateProfileString(U_GLOBAL, TEXT("WindowTitle"), 

--- a/platforms/win32/vm/sqWin32Threads.c
+++ b/platforms/win32/vm/sqWin32Threads.c
@@ -197,7 +197,7 @@ ioNewOSSemaphore(sqOSSemaphore *sem)
 							LONG_MAX, /* sky's the limit */
 							0 /* don't need no stinkin' name */);
 	if (!*sem)
-		printLastError("ioNewOSSemaphore CreateSemaphore");
+		printLastError(TEXT("ioNewOSSemaphore CreateSemaphore"));
 	return *sem ? 0 : GetLastError();
 }
 

--- a/platforms/win32/vm/sqWin32Threads.c
+++ b/platforms/win32/vm/sqWin32Threads.c
@@ -78,7 +78,7 @@ duplicateAndSetThreadHandleForCurrentThread(void)
 		return 0;
 	}
 	lastError = GetLastError();
-	printLastError("DuplicateHandle");
+	printLastError(TEXT("DuplicateHandle"));
 	return lastError;
 }
 

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -3308,6 +3308,7 @@ void HideSplashScreen(void) {
 /****************************************************************************/
 
 # define VMOPTION(arg) "-"arg
+# define TVMOPTION(arg) TEXT("-") TEXT(arg)
 
 /* print usage with different output levels */
 int printUsage(int level)
@@ -3320,43 +3321,43 @@ int printUsage(int level)
       abortMessage(TEXT("%s\n"),
                    TEXT("Usage: ") TEXT(VM_NAME) TEXT(" [vmOptions] imageFile [imageOptions]\n\n")
                    TEXT("vmOptions:")
-                   TEXT("\n\t") TEXT(VMOPTION("service:")) TEXT(" ServiceName \t(install VM as NT service)")
-                   TEXT("\n\t") TEXT(VMOPTION("headless")) TEXT(" \t\t(force VM to run headless)")
-                   TEXT("\n\t") TEXT(VMOPTION("timephases")) TEXT(" \t\t(print start load and run times)")
-                   TEXT("\n\t") TEXT(VMOPTION("log:")) TEXT(" LogFile \t\t(use LogFile for VM messages)")
-                   TEXT("\n\t") TEXT(VMOPTION("memory:")) TEXT(" megaByte \t(set memory to megaByte MB)")
+                   TEXT("\n\t") TVMOPTION("service:") TEXT(" ServiceName \t(install VM as NT service)")
+                   TEXT("\n\t") TVMOPTION("headless") TEXT(" \t\t(force VM to run headless)")
+                   TEXT("\n\t") TVMOPTION("timephases") TEXT(" \t\t(print start load and run times)")
+                   TEXT("\n\t") TVMOPTION("log:") TEXT(" LogFile \t\t(use LogFile for VM messages)")
+                   TEXT("\n\t") TVMOPTION("memory:") TEXT(" megaByte \t(set memory to megaByte MB)")
 #if STACKVM || NewspeakVM
-                   TEXT("\n\t") TEXT(VMOPTION("breaksel:")) TEXT(" string \t(call warning on send of sel for debug)")
+                   TEXT("\n\t") TVMOPTION("breaksel:") TEXT(" string \t(call warning on send of sel for debug)")
 #endif /* STACKVM || NewspeakVM */
 #if STACKVM
-                   TEXT("\n\t") TEXT(VMOPTION("breakmnu:")) TEXT(" string \t(call warning on MNU of sel for debug)")
-                   TEXT("\n\t") TEXT(VMOPTION("leakcheck:")) TEXT(" n \t\t(leak check on GC (1=full,2=incr,3=both))")
-                   TEXT("\n\t") TEXT(VMOPTION("eden:")) TEXT(" bytes \t\t(set eden memory size to bytes)")
-                   TEXT("\n\t") TEXT(VMOPTION("stackpages:")) TEXT(" n \t\t(use n stack pages)")
-                   TEXT("\n\t") TEXT(VMOPTION("numextsems:")) TEXT(" n \t\t(allow up to n external semaphores)")
-                   TEXT("\n\t") TEXT(VMOPTION("checkpluginwrites")) TEXT(" \t(check for writes past end of object in plugins")
-                   TEXT("\n\t") TEXT(VMOPTION("noheartbeat")) TEXT(" \t\t(no heartbeat for debug)")
+                   TEXT("\n\t") TVMOPTION("breakmnu:") TEXT(" string \t(call warning on MNU of sel for debug)")
+                   TEXT("\n\t") TVMOPTION("leakcheck:") TEXT(" n \t\t(leak check on GC (1=full,2=incr,3=both))")
+                   TEXT("\n\t") TVMOPTION("eden:") TEXT(" bytes \t\t(set eden memory size to bytes)")
+                   TEXT("\n\t") TVMOPTION("stackpages:") TEXT(" n \t\t(use n stack pages)")
+                   TEXT("\n\t") TVMOPTION("numextsems:") TEXT(" n \t\t(allow up to n external semaphores)")
+                   TEXT("\n\t") TVMOPTION("checkpluginwrites") TEXT(" \t(check for writes past end of object in plugins")
+                   TEXT("\n\t") TVMOPTION("noheartbeat") TEXT(" \t\t(no heartbeat for debug)")
 #endif /* STACKVM */
 #if STACKVM || NewspeakVM
 # if COGVM
-                   TEXT("\n\t") TEXT(VMOPTION("trace")) TEXT("[=num]\t\tenable tracing (optionally to a specific value)")
+                   TEXT("\n\t") TVMOPTION("trace") TEXT("[=num]\t\tenable tracing (optionally to a specific value)")
 # else
-                   TEXT("\n\t") TEXT(VMOPTION("sendtrace")) TEXT(" \t\t(trace sends to stdout for debug)")
+                   TEXT("\n\t") TVMOPTION("sendtrace") TEXT(" \t\t(trace sends to stdout for debug)")
 # endif
-                   TEXT("\n\t") TEXT(VMOPTION("warnpid")) TEXT("   \t\t(print pid in warnings)")
-                   TEXT("\n\t") TEXT(VMOPTION("[no]failonffiexception")) TEXT("   \t\t([never]always catch exceptions in FFI calls)")
+                   TEXT("\n\t") TVMOPTION("warnpid") TEXT("   \t\t(print pid in warnings)")
+                   TEXT("\n\t") TVMOPTION("[no]failonffiexception") TEXT("   \t\t([never]always catch exceptions in FFI calls)")
 #endif
 #if COGVM
-                   TEXT("\n\t") TEXT(VMOPTION("codesize:")) TEXT(" bytes \t(set machine-code memory size to bytes)")
-                   TEXT("\n\t") TEXT(VMOPTION("cogmaxlits:")) TEXT(" n \t\t(set max number of literals for methods to be compiled to machine code)")
-                   TEXT("\n\t") TEXT(VMOPTION("cogminjumps:")) TEXT(" n \t(set min number of backward jumps for interpreted methods to be considered for compilation to machine code)")
-                   TEXT("\n\t") TEXT(VMOPTION("tracestores")) TEXT(" \t\t(assert-check stores for debug)")
-                   TEXT("\n\t") TEXT(VMOPTION("reportheadroom")) TEXT(" \t(report unused stack headroom on exit)")
-                   TEXT("\n\t") TEXT(VMOPTION("dpcso:")) TEXT(" bytes \t\t(stack offset for prim calls for debug)")
+                   TEXT("\n\t") TVMOPTION("codesize:") TEXT(" bytes \t(set machine-code memory size to bytes)")
+                   TEXT("\n\t") TVMOPTION("cogmaxlits:") TEXT(" n \t\t(set max number of literals for methods to be compiled to machine code)")
+                   TEXT("\n\t") TVMOPTION("cogminjumps:") TEXT(" n \t(set min number of backward jumps for interpreted methods to be considered for compilation to machine code)")
+                   TEXT("\n\t") TVMOPTION("tracestores") TEXT(" \t\t(assert-check stores for debug)")
+                   TEXT("\n\t") TVMOPTION("reportheadroom") TEXT(" \t(report unused stack headroom on exit)")
+                   TEXT("\n\t") TVMOPTION("dpcso:") TEXT(" bytes \t\t(stack offset for prim calls for debug)")
 #endif /* COGVM */
 #if SPURVM
-                   TEXT("\n\t") TEXT(VMOPTION("maxoldspace:")) TEXT(" bytes \t(set max size of old space memory to bytes)")
-                   TEXT("\n\t") TEXT(VMOPTION("logscavenge")) TEXT(" \t\t(log scavenging to scavenge.log)")
+                   TEXT("\n\t") TVMOPTION("maxoldspace:") TEXT(" bytes \t(set max size of old space memory to bytes)")
+                   TEXT("\n\t") TVMOPTION("logscavenge") TEXT(" \t\t(log scavenging to scavenge.log)")
 #endif
                    TEXT("\n") TEXT("Options begin with single -, but -- prefix is silently accepted")
                    TEXT("\n") TEXT("Options with arguments -opt:n are also accepted with separators -opt n")

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -62,7 +62,7 @@ char imageName[MAX_PATH+1];		  /* full path and name to image */
 TCHAR imagePath[MAX_PATH+1];	  /* full path to image */
 TCHAR vmPath[MAX_PATH+1];		    /* full path to interpreter's directory */
 TCHAR vmName[MAX_PATH+1];		    /* name of the interpreter's executable */
-TCHAR windowTitle[MAX_PATH];        /* what should we display in the title? */
+char windowTitle[MAX_PATH];        /* what should we display in the title? */
 TCHAR squeakIniName[MAX_PATH+1];    /* full path and name to ini file */
 TCHAR windowClassName[MAX_PATH+1];        /* Window class name */
 

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -3221,21 +3221,21 @@ static LRESULT CALLBACK SplashWndProcA(HWND hwnd,
 
 void ShowSplashScreen(void) {
   WNDCLASS wc;
-  char splashFile[1024];
-  char splashTitle[1024];
+  TCHAR splashFile[1024];
+  TCHAR splashTitle[1024];
   BITMAP bm;
   RECT wa, rSplash;
 
   /* Look if we have a splash file somewhere */
-  GetPrivateProfileString("Global", "SplashScreen", "Splash.bmp", 
+  GetPrivateProfileString(TEXT("Global"), TEXT("SplashScreen"), TEXT("Splash.bmp"), 
 			  splashFile, 1024, squeakIniName);
 
   /* Also get the title for the splash window */
-  GetPrivateProfileString("Global", "SplashTitle", VM_NAME"!",
+  GetPrivateProfileString(TEXT("Global"), TEXT("SplashTitle"), TEXT(VM_NAME) TEXT("!"),
 			  splashTitle, 1024, squeakIniName);
 
   /* Look for the mimimum splash time to use */
-  splashTime = GetPrivateProfileInt("Global", "SplashTime", 
+  splashTime = GetPrivateProfileInt(TEXT("Global"), TEXT("SplashTime"), 
 				    1000, squeakIniName);
 
   if(!splashFile[0]) return; /* no splash file */

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -2587,7 +2587,7 @@ sqInt ioShowDisplay(sqInt dispBits, sqInt width, sqInt height, sqInt depth,
 
   if(lines == 0) {
     printLastError(TEXT("SetDIBitsToDevice failed"));
-    warnPrintf(TEXT("width=%" PRIdSQINT ",height=%" PRIdSQINT ",bits=%" PRIXSQINT ",dc=%" PRIXSQPTR "\n"),
+    warnPrintf(TEXT("width=%") TEXT(PRIdSQINT) TEXT(",height=%") TEXT(PRIdSQINT) TEXT(",bits=%") TEXT(PRIXSQINT) TEXT(",dc=%") TEXT(PRIXSQPTR) TEXT("\n"),
 	       width, height, dispBits,(usqIntptr_t)dc);
   }
   /* reverse the image bits if necessary */

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -3246,7 +3246,7 @@ void ShowSplashScreen(void) {
   if(!hSplashDIB) {
     /* ignore the common case but print failures for the others */
     if(GetLastError() != ERROR_FILE_NOT_FOUND)
-      printLastError("LoadImage failed");
+      printLastError(TEXT("LoadImage failed"));
     return;
   }
   GetObject(hSplashDIB, sizeof(bm), &bm);

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -3008,59 +3008,6 @@ void SetupFilesAndPath(){
 
 #else /* defined(_WIN32_WCE) */
 
-void
-LongFileNameFromPossiblyShortName(TCHAR *nameBuffer)
-{ TCHAR oldDir[MAX_PATH+1];
-  TCHAR testName[13];
-  TCHAR nameBuf[MAX_PATH+1];
-  TCHAR *shortName;
-  WIN32_FIND_DATA findData;
-  HANDLE findHandle;
-
-  GetCurrentDirectory(MAX_PATH,oldDir);
-  shortName = lstrrchr(nameBuffer,U_BACKSLASH[0]);
-  if(!shortName) shortName = lstrrchr(nameBuffer,U_SLASH[0]);
-  if(!shortName) return;
-  /* if the file name is longer than 8.3
-     this can't be a short name */
-  *(shortName++) = 0;
-  if(lstrlen(shortName) > 12)
-    goto notFound;
-
-  /* back up the old and change to the given directory,
-     this makes searching easier */
-  lstrcpy(nameBuf, nameBuffer);
-  lstrcat(nameBuf,TEXT("\\"));
-  SetCurrentDirectory(nameBuf);
-
-  /* now search the directory */
-  findHandle = FindFirstFile(TEXT("*.*"),&findData);
-  if(findHandle == INVALID_HANDLE_VALUE) goto notFound; /* nothing found */
-  do {
-    if(lstrcmp(findData.cFileName,TEXT("..")) && lstrcmp(findData.cFileName,TEXT(".")))
-      lstrcpy(testName,findData.cAlternateFileName);
-    else
-      *testName = 0;
-    if(lstrcmp(testName,shortName) == 0) /* gotcha! */
-      {
-        FindClose(findHandle);
-        /* recurse down */
-        lstrcpy(nameBuf, findData.cFileName);
-        goto recurseDown;
-      }
-  } while(FindNextFile(findHandle,&findData) != 0);
-  /* nothing appropriate found */
-  FindClose(findHandle);
-notFound:
-  lstrcpy(nameBuf, shortName);
-recurseDown:
-  /* recurse down */
-  LongFileNameFromPossiblyShortName(nameBuffer);
-  lstrcat(nameBuffer,TEXT("\\"));
-  lstrcat(nameBuffer,nameBuf);
-  SetCurrentDirectory(oldDir);
-}
-
 void SetupFilesAndPath() {
   char *tmp;
   WCHAR tmpName[MAX_PATH];


### PR DESCRIPTION
This is essentially sanitizing and cleanups of existing win32 platform code.
There's no new feature or behavior change except this one: path passed to security plugin will be interpreted as UTF-8 encoded on windows VM.
These changes are required before cleaning the contract between image and VM, especially about encoding of various strings passed: they should be encoded in UTF8 which seems best for platform interoperability.
It's a step forward for enabling the -DUNICODE as attempted by Tobias about 2 years ago.

It is also very important to reduce the number of compiler warnings. 9 times out of 10, these warnings are false positive, but the tenth is indicating a true problem that we'd better not ignore. If we let the benign warnings overflow us, then we are depriving ourself of a useful tool. 