### PR TITLE
linux32ARMv6 mvm missing quotes

### DIFF
--- a/build.linux32ARMv6/pharo.cog.spur/build/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build/mvm
@@ -4,7 +4,7 @@ set -e
 INSTALLDIR=phcogspurlinuxhtRPi
 # disable build of all dependencies by default because travis build takes too much time then fails.
 # in case we build "non-dependency" version, we need to remove plugins with dependencies (SDL2 in particular)
-if [ $1 = "all" ]; then
+if [ "$1" = "all" ]; then
 THIRDPARTYLIBS="libsdl2 libssh2 libgit2"
 EXTERNALPLUGINS="plugins.ext.all"
 shift 


### PR DESCRIPTION
build.linux32ARMv6/pharo.cog.spur/build/mvm is missing quotes around a
parameter triggering a syntax error