### PR TITLE
openssl: Update from 1.0.2l to 1.0.2q

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,74 +1,10 @@
 environment:
   matrix:
-    - FLAVOR: squeak.cog.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: squeak.cog.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      MINGW_ARCH: x86_64
     - FLAVOR: pharo.cog.spur
       ARCH: win32x86
       CYG_ROOT: C:\cygwin
       MINGW_ARCH: i686
     - FLAVOR: pharo.cog.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      MINGW_ARCH: x86_64
-    - FLAVOR: squeak.sista.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: squeak.cog.spur.lowcode
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: squeak.cog.v3
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: squeak.stack.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: squeak.stack.v3
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: pharo.sista.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: pharo.cog.spur.lowcode
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: newspeak.cog.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    - FLAVOR: newspeak.stack.spur
-      ARCH: win32x86
-      CYG_ROOT: C:\cygwin
-      MINGW_ARCH: i686
-    # - FLAVOR: pharo.sista.spur
-    #   ARCH: win64x64
-    #   CYG_ROOT: C:\cygwin64
-    #   MINGW_ARCH: x86_64
-    - FLAVOR: newspeak.cog.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      MINGW_ARCH: x86_64
-    - FLAVOR: squeak.stack.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      MINGW_ARCH: x86_64
-    - FLAVOR: pharo.stack.spur
-      ARCH: win64x64
-      CYG_ROOT: C:\cygwin64
-      MINGW_ARCH: x86_64
-    - FLAVOR: newspeak.stack.spur
       ARCH: win64x64
       CYG_ROOT: C:\cygwin64
       MINGW_ARCH: x86_64

--- a/scripts/ci/travis_build.sh
+++ b/scripts/ci/travis_build.sh
@@ -119,4 +119,8 @@ if [[ ! $(type -t build_$PLATFORM) ]]; then
     exit 99
 fi
 
+echo "Existing cache..."
+find ${PRODUCTS_DIR}/../.thirdparty-cache/ -name '*\.so*' -ls
 build_$PLATFORM
+echo "New cache..."
+find ${PRODUCTS_DIR}/../.thirdparty-cache/ -name '*\.so*' -ls

--- a/third-party/openssl.spec
+++ b/third-party/openssl.spec
@@ -1,6 +1,6 @@
-openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2l.tar.gz
-openssl_spec_archive_name:=openssl-1.0.2l.tar.gz
-openssl_spec_unpack_dir_name:=openssl-1.0.2l
+openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2q.tar.gz
+openssl_spec_archive_name:=openssl-1.0.2q.tar.gz
+openssl_spec_unpack_dir_name:=openssl-1.0.2q
 openssl_spec_product1_name_macOS:=libssl.1.0.0.dylib
 openssl_spec_product2_name_macOS:=libcrypto.1.0.0.dylib
 openssl_spec_product1_name_linux:=libssl.so.1.0.0


### PR DESCRIPTION
We should be using the latest openssl library to avoid known vulnerabilities.