### PR TITLE
Backport winfix to minheadless

### DIFF
--- a/platforms/minheadless/common/sqWindow-Dispatch.c
+++ b/platforms/minheadless/common/sqWindow-Dispatch.c
@@ -92,7 +92,7 @@ ioFormPrint(sqInt bitsAddr, sqInt width, sqInt height, sqInt depth,
 void
 ioNoteDisplayChangedwidthheightdepth(void *b, int w, int h, int d)
 {
-    return currentWindowSystem->noteDisplayChangedWidthHeightDepth(b, w, h, d);
+    currentWindowSystem->noteDisplayChangedWidthHeightDepth(b, w, h, d);
 }
 
 sqInt

--- a/platforms/minheadless/windows/sqPlatformSpecific-Win32.c
+++ b/platforms/minheadless/windows/sqPlatformSpecific-Win32.c
@@ -68,8 +68,21 @@
 # define _MCW_PC 0
 #endif
 
-#define FPU_MASK (_MCW_EM | _MCW_RC | _MCW_PC)
+/* default fpu control word:
+   _RC_NEAR: round to nearest
+   _PC_53 :  double precision arithmetic (instead of extended)
+   _EM_XXX: silent operations (no signals please)
+   NOTE:  precision control and infinity control are not defined on ARM or X64 (SSE oblige), only X86
+*/
+#if defined(_M_IX86) || defined(X86) || defined(_M_I386) || defined(_X86_) \
+	|| defined(i386) || defined(i486) || defined(i586) || defined(i686) \
+	|| defined(__i386__) || defined(__386__) || defined(I386)
+#define FPU_MASK (_MCW_EM | _MCW_RC | _MCW_PC | _MCW_IC)
 #define FPU_DEFAULT (_RC_NEAR + _PC_53 + _EM_INVALID + _EM_ZERODIVIDE + _EM_OVERFLOW + _EM_UNDERFLOW + _EM_INEXACT + _EM_DENORMAL)
+#else
+#define FPU_DEFAULT (_RC_NEAR + _EM_INVALID + _EM_ZERODIVIDE + _EM_OVERFLOW + _EM_UNDERFLOW + _EM_INEXACT + _EM_DENORMAL)
+#define FPU_MASK    (_MCW_EM | _MCW_RC)
+#endif
 
 #define MAXFRAMES 64
 

--- a/platforms/minheadless/windows/sqWin32.h
+++ b/platforms/minheadless/windows/sqWin32.h
@@ -6,6 +6,24 @@
 #endif
 #include <windows.h>
 
+/* Note: a character can require up to 4 bytes in UTF8 encoding
+   But the expansion from UTF16 -> UTF8 is never more than 3 bytes for 1 short
+   U+ 0000-U+  007F - 1byte in utf8, 1 short in utf16.
+   U+ 0080-U+  07FF - 2byte in utf8, 1 short in utf16.
+   U+ 0800-U+  FFFF - 3byte in utf8, 1 short in utf16.
+   U+10000-U+10FFFF - 4byte in utf8, 2 short in utf16.
+*/
+#define MAX_PATH_UTF8 (MAX_PATH*3)
+
+/* required for compilation of SecurityPlugin */
+extern char  squeakIniNameA[];   /* full path to ini file - UTF8 */
+extern WCHAR squeakIniNameW[];   /* full path to ini file - UTF16 */
+#ifdef UNICODE
+#define squeakIniName squeakIniNameW
+#else
+#define squeakIniName squeakIniNameA
+#endif
+
 void printLastError(const TCHAR *prefix);
 int sqMessageBox(DWORD dwFlags, const TCHAR *titleString, const char* fmt, ...);
 

--- a/platforms/minheadless/windows/sqWin32Backtrace.c
+++ b/platforms/minheadless/windows/sqWin32Backtrace.c
@@ -264,6 +264,10 @@ get_modules(void)
 	HANDLE hPsApi = LoadLibraryA("psapi.dll");
 	HMODULE *modules;
 
+	if (!hPsApi) {
+		printLastError(TEXT("LoadLibrary psapi"));
+		return;
+	}
 	EnumProcessModules = (void*)GetProcAddress(hPsApi, "EnumProcessModules");
 	GetModuleInformation=(void*)GetProcAddress(hPsApi, "GetModuleInformation");
 
@@ -403,6 +407,8 @@ compute_exe_symbols(dll_exports *exports)
 {
 #if defined(_MSV_VER)
 # error parse of MSVC .map file as yet unimplemented
+# error Let me (eliot) suggest you get the Makefile to generate a BSD-style
+# error format from the MSVC /map file instead of writing the parser here.
 /* Create the file using "cl .... /link /map"
  * Parse it by looking for lines beginning with " 0001:" where 0001 is the
  * segment number of the .text segment.  Representative lines look like
@@ -553,8 +559,8 @@ compute_dll_symbols(dll_exports *exports)
     printf("  # of Names:      %08X\n", pExportDir->NumberOfNames);
 #endif
 
-    ordinals =	(PWORD)	(dllbase + (DWORD)pExportDir->AddressOfNameOrdinals);
-    functions =	(PDWORD)(dllbase + (DWORD)pExportDir->AddressOfFunctions);
+    ordinals =	(PWORD)	(dllbase + pExportDir->AddressOfNameOrdinals);
+    functions =	(ulong *)(dllbase + pExportDir->AddressOfFunctions);
 
     if (!(exports->sorted_ordinals = calloc(pExportDir->NumberOfNames, sizeof(int)))) {
 		printLastError(TEXT("compute_dll_symbols calloc"));

--- a/platforms/minheadless/windows/sqWin32Common.c
+++ b/platforms/minheadless/windows/sqWin32Common.c
@@ -9,7 +9,9 @@ BOOL fLowRights = 0;
 static TCHAR w_buffer1[MAX_BUFFER]; /* wide buffer 1 */
 static TCHAR w_buffer2[MAX_BUFFER]; /* wide buffer 2 */
 static char  a_buffer1[MAX_BUFFER]; /* ansi buffer 1 */
-TCHAR squeakIniName[MAX_PATH + 1];;
+
+/* Stub for SecurityPlugin */
+WCHAR squeakIniNameW[MAX_PATH + 1];
 
 static TCHAR *
 fromSqueakInto(const char *sqPtr, int sqSize, TCHAR* buffer)

--- a/platforms/minheadless/windows/sqWin32Directory.c
+++ b/platforms/minheadless/windows/sqWin32Directory.c
@@ -60,7 +60,7 @@ static void read_permissions(sqInt *posixPermissions, WCHAR* path, sqInt pathLen
   if (attr & FILE_ATTRIBUTE_DIRECTORY) {
     *posixPermissions |= S_IXUSR | (S_IXUSR>>3) | (S_IXUSR>>6);
   }
-  else if (path && path[pathLength - 4] == L'.') {
+  else if (path && pathLength > 3 && path[pathLength - 4] == L'.') {
     WCHAR *ext = &path[pathLength - 3];
     if (!_wcsicmp (ext, L"COM")) {
       *posixPermissions |= S_IXUSR | (S_IXUSR>>3) | (S_IXUSR>>6);

--- a/platforms/minheadless/windows/sqWin32Heartbeat.c
+++ b/platforms/minheadless/windows/sqWin32Heartbeat.c
@@ -53,8 +53,7 @@
 static DWORD dwTimerPeriod = 0;
 static DWORD timerID = 0;
 
-sqLong
-ioHighResClock(void) {
+sqLong ioHighResClock(void) {
   sqLong value = 0;
 
 #if defined(__GNUC__) && (defined(i386) || defined(__i386) || defined(__i386__))

--- a/platforms/minheadless/windows/sqWin32Heartbeat.c
+++ b/platforms/minheadless/windows/sqWin32Heartbeat.c
@@ -56,8 +56,23 @@ static DWORD timerID = 0;
 sqLong
 ioHighResClock(void) {
   sqLong value = 0;
-#ifdef __GNUC__
-  __asm__ __volatile__ ("rdtsc" : "=A" (value));
+
+#if defined(__GNUC__) && (defined(i386) || defined(__i386) || defined(__i386__))
+    __asm__ __volatile__ ("rdtsc" : "=A"(value));
+#elif defined(__GNUC__) && (defined(x86_64) || defined(__x86_64) || defined (__x86_64__))
+    __asm__ __volatile__ ("rdtsc\n\t"			// Returns the time in EDX:EAX.
+						"shl $32, %%rdx\n\t"	// Shift the upper bits left.
+						"or %%rdx, %0"			// 'Or' in the lower bits.
+						: "=a" (value)
+						: 
+						: "rdx");
+#elif defined(_MSC_VER)
+  LARGE_INTEGER aux;
+  aux.QuadPart = 0;
+  QueryPerformanceCounter(&aux);
+  value = aux.QuadPart;
+#else
+# error "no high res clock defined"
 #endif
   return value;
 }

--- a/platforms/minheadless/windows/sqWin32SpurAlloc.c
+++ b/platforms/minheadless/windows/sqWin32SpurAlloc.c
@@ -30,8 +30,8 @@ LONG CALLBACK sqExceptionFilter(LPEXCEPTION_POINTERS exp)
   return EXCEPTION_WRONG_ACCESS;
 }
 
-static DWORD  pageMask;     /* bit mask for the start of a memory page */
-static DWORD  pageSize;     /* size of a memory page */
+static sqIntptr_t  pageMask;     /* bit mask for the start of a memory page */
+static sqIntptr_t  pageSize;     /* size of a memory page */
 static char  *minAppAddr;	/* SYSTEM_INFO lpMinimumApplicationAddress */
 static char  *maxAppAddr;	/* SYSTEM_INFO lpMaximumApplicationAddress */
 
@@ -63,7 +63,7 @@ sqAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
 	maxAppAddr = sysInfo.lpMaximumApplicationAddress;
 
 	/* choose a suitable starting point. In MinGW the malloc heap is below the
-	 * program, so take the max of a malloc and something form uninitialized
+	 * program, so take the max of a malloc and something from uninitialized
 	 * data.
 	 */
 	hint = malloc(1);

--- a/platforms/minheadless/windows/sqWin32Time.c
+++ b/platforms/minheadless/windows/sqWin32Time.c
@@ -43,15 +43,13 @@
 #endif
 
 /* returns the local wall clock time */
-int
-ioSeconds(void)
+int ioSeconds(void)
 { SYSTEMTIME sysTime;
   GetLocalTime(&sysTime);
   return convertToSqueakTime(sysTime);
 }
 
-int
-ioMSecs()
+int ioMSecs()
 {
   /* Make sure the value fits into Squeak SmallIntegers */
 #ifndef _WIN32_WCE
@@ -62,8 +60,7 @@ ioMSecs()
 }
 
 /* Note: ioMicroMSecs returns *milli*seconds */
-int
-ioMicroMSecs(void)
+int ioMicroMSecs(void)
 {
   /* Make sure the value fits into Squeak SmallIntegers */
   return timeGetTime() & MillisecondClockMask;


### PR DESCRIPTION
Some of these fixes are necessary for compiling the WIN32/WIN64 minheadless version since my UNICODE clean-up of platforms/win32/plugins (they are shared with minheadless, the compatibility problem is for SecurityPlugin).

Other fixes are good to have.
[skip ci] until we add a minheadless build on the CI...