### PR TITLE
openssl: Update from 1.0.2l to 1.0.2q

### DIFF
--- a/third-party/openssl.spec
+++ b/third-party/openssl.spec
@@ -1,6 +1,6 @@
-openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2l.tar.gz
-openssl_spec_archive_name:=openssl-1.0.2l.tar.gz
-openssl_spec_unpack_dir_name:=openssl-1.0.2l
+openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2q.tar.gz
+openssl_spec_archive_name:=openssl-1.0.2q.tar.gz
+openssl_spec_unpack_dir_name:=openssl-1.0.2q
 openssl_spec_product1_name_macOS:=libssl.1.0.0.dylib
 openssl_spec_product2_name_macOS:=libcrypto.1.0.0.dylib
 openssl_spec_product1_name_linux:=libssl.so.1.0.0


### PR DESCRIPTION
We should be using the latest 1.0.2 openssl library to avoid known vulnerabilities.