### PR TITLE
Simplify gitignore build directories [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,40 +22,15 @@
 platforms/unix/config/autom4te.cache/
 
 # Don't track build directories 
-/build*/**/*
-# except do track these files
-!branding.gmk
-!branding-sed-rules.gmk
-!conf.COG
-!conf.COG.dbg
-!Croquet.def.in
-!Croquet.exe.manifest
-!Croquet.ico
-!Croquet.rc
-!GreenCogSqueak.ico
-!HowToBuild
-!makeall
-!makeallclean
-!makealldirty
-!makeclean
-!makeem
-!Makefile
-!Makefile.plugin
-!Makefile.rules
-!Makefile.tools
-!makeproduct
-!makeproductclean
-!mkNamedPrims.sh
-!mvm
-!NotYetImplemented
-!plugins.ext
-!plugins.int
-!Squeak.def.in
-!Squeak.exe.manifest
-!squeak.ico
-!Squeak.rc
-!editnewspeakinstall.sh
-!/build.linux32ARMv6/asasm
+# Track build config files,  e.g. /build.platform/dialect.type.mem/files
+# but not build directories, e.g. /build.platform/dialect.type.mem/build_directory/
+# distiguished by trailing slash...
+/build*/*/*/
+
+# except specially exclude a few generated files mixed with config files
+/build*/*/LOG*
+/build*/*/mkNamedPrims.exe
+/build*/*/sqNamedPrims.h
 
 # Ignore special Cadence-only build directories
 /build*/glue*
@@ -80,6 +55,7 @@ platforms/unix/config/autom4te.cache/
 # but ignore these files (derived from `grep xcode .gitignore.orig`)
 /build.macos32x86/xcode/*/Template.xcodeproj/*.mode1v3
 /build.macos32x86/xcode/*/Template.xcodeproj/*.pbxuser
+
 
 # Not sure what to do with nsvm files/directories. Track to be conservative.
 !nsvm*


### PR DESCRIPTION
I noticed that modified Makefiles weren't being pickup up by `git status`.
It was too tedious trying to fix the existing definitions, so I've condensed them down to 4 lines from 34.
I'm reasonably sure the result is the same, but if I've missed something its low impact, so maybe just integrate first to let everyone suck-n-see.  
Doing a `git status` before each `git commit` will let you confirm that its working.