### PR TITLE
Rename freetype library as expected by cairo in 64bit windows

### DIFF
--- a/build.win64x64/third-party/Makefile.freetype2
+++ b/build.win64x64/third-party/Makefile.freetype2
@@ -4,16 +4,18 @@ ifndef THIRDPARTYDIR
 	include ../common/Makefile.lib.extra
 endif
 include ../../third-party/freetype2.spec
+include ../../third-party/freetype2.spec.win64
 
 EXTERNALFILESURL:=https://files.pharo.org/vm/pharo-spur64/win/third-party
-FREETYPE2LIBNAME:=$(freetype2_spec_product_name_windows)
-FREETYPE2LIB:=$(THIRDPARTYINSTALLDIR)/$(FREETYPE2LIBNAME)
+FREETYPE2LIBNAME:=$(freetype2_spec_download_artifact_name_windows)
+FREETYPE2LIBINSTALLNAME:=$(freetype2_spec_product_name_windows)
+FREETYPE2LIB:=$(THIRDPARTYINSTALLDIR)/$(FREETYPE2LIBINSTALLNAME)
 
 $(THIRDPARTYLIBDIR)/$(FREETYPE2LIBNAME):
 	echo 
 	$(WGET) -O $(THIRDPARTYLIBDIR)/$(FREETYPE2LIBNAME) $(EXTERNALFILESURL)/$(FREETYPE2LIBNAME)
 
 $(FREETYPE2LIB): pkgconfig libpng $(THIRDPARTYLIBDIR)/$(FREETYPE2LIBNAME)
-	cp -f $(THIRDPARTYLIBDIR)/$(FREETYPE2LIBNAME) $(THIRDPARTYINSTALLDIR)
+	cp -f $(THIRDPARTYLIBDIR)/$(FREETYPE2LIBNAME) $(FREETYPE2LIB)
 
 freetype2: $(FREETYPE2LIB)

--- a/third-party/freetype2.spec
+++ b/third-party/freetype2.spec
@@ -4,4 +4,5 @@ freetype2_spec_unpack_dir_name:=freetype-2.9.1
 freetype2_spec_product_name_macOS:=libfreetype.6.dylib
 freetype2_spec_product_name_linux:=
 freetype2_spec_product_name_windows:=libfreetype.dll
+freetype2_spec_download_artifact_name_windows:=libfreetype.dll
 freetype2_spec_symlinks_macOS:=libfreetype*.dylib


### PR DESCRIPTION
Rename freetype library as expected by cairo in 64bit windows.

This PR only affects pharo builds for windows, and particularly windows 64.