### PR TITLE
Patch callback thunkEntry to not optimize

### DIFF
--- a/platforms/Cross/plugins/IA32ABI/ia32abicc.c
+++ b/platforms/Cross/plugins/IA32ABI/ia32abicc.c
@@ -169,7 +169,7 @@ getMostRecentCallbackContext() { return mostRecentCallbackContext; }
  * args would get copied into a struct on the stack. A pointer to the struct
  * is then passed as an element of the VMCallbackContext.
  */
-long
+long __attribute__((optimize("O0")))
 thunkEntry(void *thunkp, sqIntptr_t *stackp)
 {
 	VMCallbackContext vmcc;


### PR DESCRIPTION
O2 and O1 compilation produce a segmentation fault due to stack corruption (when debugging we saw some extra pushes from the stack) on callbacks return. This happens on windows 32, when compiling with mingw gcc 7.4.0.

The issue can be reproduced easily by running the Alien qsort example in latest vms in both Pharo and Squeak.

This PR proposes to patch just the thunkEntry function. Not optimizing just that function solves the issue in our environment, though maybe there is a more fine-grained solution. We should still investigate what is the particular optimization that causes the problem.