### PR TITLE
Ignore missing dylibs

### DIFF
--- a/build.macos32x86/common/Makefile.app
+++ b/build.macos32x86/common/Makefile.app
@@ -120,11 +120,16 @@ $(APP)/Contents/Resources/%.bundle: $(BLDDIR)/vm/%.bundle
 		echo cp -pR $< $(APP)/Contents/Resources; \
 		cp -pR $< $(APP)/Contents/Resources; \
 	fi
-	
+
 $(APP)/Contents/MacOS/Plugins/%.dylib: $(BLDDIR)/vm/%.dylib
 	@mkdir -p $(APP)/Contents/MacOS/Plugins
-	cp -p $< $(APP)/Contents/MacOS/Plugins
-	
+	@if [ -f $(basename $<).ignore ]; then \
+		echo $(notdir $<) is being ignored; \
+		rm -rf $^; \
+	else \
+		echo cp -p $< $(APP)/Contents/MacOS/Plugins; \
+		cp -p $< $(APP)/Contents/MacOS/Plugins; \
+	fi
 
 $(VMPLIST): $(OSXDIR)/$(SYSTEM)-Info.plist getversion
 	-mkdir -p $(APP)/Contents

--- a/build.macos64x64/common/Makefile.app
+++ b/build.macos64x64/common/Makefile.app
@@ -120,11 +120,16 @@ $(APP)/Contents/Resources/%.bundle: $(BLDDIR)/vm/%.bundle
 		echo cp -pR $< $(APP)/Contents/Resources; \
 		cp -pR $< $(APP)/Contents/Resources; \
 	fi
-	
+
 $(APP)/Contents/MacOS/Plugins/%.dylib: $(BLDDIR)/vm/%.dylib
 	@mkdir -p $(APP)/Contents/MacOS/Plugins
-	cp -p $< $(APP)/Contents/MacOS/Plugins
-	
+	@if [ -f $(basename $<).ignore ]; then \
+		echo $(notdir $<) is being ignored; \
+		rm -rf $^; \
+	else \
+		echo cp -p $< $(APP)/Contents/MacOS/Plugins; \
+		cp -p $< $(APP)/Contents/MacOS/Plugins; \
+	fi
 
 $(VMPLIST): $(OSXDIR)/$(SYSTEM)-Info.plist getversion
 	-mkdir -p $(APP)/Contents


### PR DESCRIPTION
The ignore mechanism was only implemented for bundles, but not for dylibs, used only in Pharo builds.
This PR introduces the same mechanism as in bundles for dylibs, both in 32 and 64 bit builds.

This should fix pharo osx builds, with no effects on other platforms or builds.