### PR TITLE
365: Remove PharoV50.sources from linux builds

### DIFF
--- a/build.linux32ARMv6/editpharoinstall.sh
+++ b/build.linux32ARMv6/editpharoinstall.sh
@@ -7,16 +7,6 @@ INSTALLDIR="$1"
 shift
 cd $INSTALLDIR
 
-if [ "$1" = -source ]; then
-	SourceFile="$2"
-	shift; shift
-else
-	SourceFile="PharoV50"
-fi
-mkdir -p "$OSVMROOTDIR/sources"
-SOURCE=$OSVMROOTDIR/sources/$SourceFile.sources
-test -f $SOURCE || wget -O $SOURCE http://files.pharo.org/sources/$SourceFile
-
 if [ -f squeak ]; then
 	mv squeak pharo
 	sed -i 's/squeak/pharo/g' pharo
@@ -29,13 +19,4 @@ rm -rf man doc
 LIBDIR="`echo lib/squeak/[0-9.-]*`"
 test -f $LIBDIR/squeak && mv $LIBDIR/squeak $LIBDIR/pharo
 test -d lib/squeak && mv lib/squeak lib/pharo
-LIBDIR="`echo lib/pharo/[0-9.-]*`"
-if [ "$1" = -copysource ]; then
-	cp $SOURCE $LIBDIR
-elif [ -h $SOURCE ]; then
-	ln "`readlink $SOURCE`" $LIBDIR
-elif [ -f $SOURCE ]; then
-	ln $SOURCE $LIBDIR
-else
-	echo "can't find `basename $SOURCE`" 1>&2
-fi
+

--- a/build.linux32x86/editpharoinstall.sh
+++ b/build.linux32x86/editpharoinstall.sh
@@ -7,16 +7,6 @@ INSTALLDIR="$1"
 shift
 cd $INSTALLDIR
 
-if [ "$1" = -source ]; then
-	SourceFile="$2"
-	shift; shift
-else
-	SourceFile="PharoV50"
-fi
-mkdir -p "$OSVMROOTDIR/sources"
-SOURCE=$OSVMROOTDIR/sources/$SourceFile.sources
-test -f $SOURCE || wget -O $SOURCE http://files.pharo.org/sources/$SourceFile
-
 if [ -f squeak ]; then
 	mv squeak pharo
 	sed -i 's/squeak/pharo/g' pharo
@@ -29,13 +19,4 @@ rm -rf man doc
 LIBDIR="`echo lib/squeak/[0-9.-]*`"
 test -f $LIBDIR/squeak && mv $LIBDIR/squeak $LIBDIR/pharo
 test -d lib/squeak && mv lib/squeak lib/pharo
-LIBDIR="`echo lib/pharo/[0-9.-]*`"
-if [ "$1" = -copysource ]; then
-	cp $SOURCE $LIBDIR
-elif [ -h $SOURCE ]; then
-	ln "`readlink $SOURCE`" $LIBDIR
-elif [ -f $SOURCE ]; then
-	ln $SOURCE $LIBDIR
-else
-	echo "can't find `basename $SOURCE`" 1>&2
-fi
+

--- a/build.linux64x64/editpharoinstall.sh
+++ b/build.linux64x64/editpharoinstall.sh
@@ -7,16 +7,6 @@ INSTALLDIR="$1"
 shift
 cd $INSTALLDIR
 
-if [ "$1" = -source ]; then
-	SourceFile="$2"
-	shift; shift
-else
-	SourceFile="PharoV50"
-fi
-mkdir -p "$OSVMROOTDIR/sources"
-SOURCE=$OSVMROOTDIR/sources/$SourceFile.sources
-test -f $SOURCE || wget -O $SOURCE http://files.pharo.org/sources/$SourceFile
-
 if [ -f squeak ]; then
 	mv squeak pharo
 	sed -i 's/squeak/pharo/g' pharo
@@ -29,13 +19,4 @@ rm -rf man doc
 LIBDIR="`echo lib/squeak/[0-9.-]*`"
 test -f $LIBDIR/squeak && mv $LIBDIR/squeak $LIBDIR/pharo
 test -d lib/squeak && mv lib/squeak lib/pharo
-LIBDIR="`echo lib/pharo/[0-9.-]*`"
-if [ "$1" = -copysource ]; then
-	cp $SOURCE $LIBDIR
-elif [ -h $SOURCE ]; then
-	ln "`readlink $SOURCE`" $LIBDIR
-elif [ -f $SOURCE ]; then
-	ln $SOURCE $LIBDIR
-else
-	echo "can't find `basename $SOURCE`" 1>&2
-fi
+


### PR DESCRIPTION
Pharo linux builds are still including PharoV50.sources, which isn't
used in any currently supported versions.  For Pharo7 and later sources
are generated for each build, so there's no need to ever include
sources.