### PR TITLE
Handle spaces in VM path name

### DIFF
--- a/platforms/unix/config/bin.squeak.sh.in
+++ b/platforms/unix/config/bin.squeak.sh.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Run the VM, setting SQUEAK_PLUGINS if unset to the VM's containing directory
 # if unset, and ensuring LD_LIBRARY_PATH includes the VM's containing directory.
-BIN=`/usr/bin/dirname $0`/../@expanded_relative_imgdir@
+BIN=`/usr/bin/dirname "$0"`/../@expanded_relative_imgdir@
 GDB=
 if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
 	export SQUEAK_PLUGINS="$BIN"

--- a/platforms/unix/config/squeak.sh.in
+++ b/platforms/unix/config/squeak.sh.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Run the VM, setting SQUEAK_PLUGINS if unset to the VM's containing directory
 # if unset, and ensuring LD_LIBRARY_PATH includes the VM's containing directory.
-BIN=`/usr/bin/dirname $0`/@expanded_relative_imgdir@
+BIN=`/usr/bin/dirname "$0"`/@expanded_relative_imgdir@
 GDB=
 if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
 	export SQUEAK_PLUGINS="$BIN"


### PR DESCRIPTION
Modify the launch script templates to handle spaces in the VM path name.

dirname takes one or more paths, so if the path has spaces and isn't
quoted it is treated as two paths... not what we want.