### PR TITLE
Fix compilation problem with ARC in some compilers.

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
@@ -83,6 +83,9 @@
 	id<MTLRenderPipelineState> screenQuadPipelineState;
 	id<MTLRenderPipelineState> layerScreenQuadPipelineState;
 	id<MTLBuffer> screenQuadVertexBuffer;
+    
+    NSArray *extraDrawingLayers;
+    unsigned int allocatedExtraDrawingLayers;
 }
 
 + (BOOL) isMetalViewSupported;

--- a/platforms/iOS/vm/SqueakPureObjc_Prefix.pch
+++ b/platforms/iOS/vm/SqueakPureObjc_Prefix.pch
@@ -10,7 +10,7 @@
 #endif
 
 #if __has_feature(objc_arc)
-# define RELEASEOBJ(o) o
+# define RELEASEOBJ(o) (void)o
 # define RETAINOBJ(o) o
 # define AUTORELEASEOBJ(o) o
 # define SUPERDEALLOC


### PR DESCRIPTION
This fixes a compilation error that is produced by some versions of clang. No ARC pointers in structs are allowed.