### PR TITLE
cli: pollpip consumes an argument, document it

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
@@ -509,7 +509,7 @@ static char *getVersionInfo(int verbose);
 	printf("  "VMOPTION("stackpages")" num       use n stack pages\n");
 	printf("  "VMOPTION("numextsems")" num       make the external semaphore table num in size\n");
 	printf("  "VMOPTION("noheartbeat")"          disable the heartbeat for VM debugging. disables input\n");
-	printf("  "VMOPTION("pollpip")"              output . on each poll for input\n");
+	printf("  "VMOPTION("pollpip")" (0|1)        output on each poll for input\n");
 	printf("  "VMOPTION("checkpluginwrites")"    check for writes past end of object in plugins\n");
 #endif
 #if STACKVM || NewspeakVM

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -1682,7 +1682,7 @@ static void vm_printUsage(void)
 #endif
   printf("  "VMOPTION("noevents")"             disable event-driven input support\n");
   printf("  "VMOPTION("nohandlers")"           disable sigsegv & sigusr1 handlers\n");
-  printf("  "VMOPTION("pollpip")"              output . on each poll for input\n");
+  printf("  "VMOPTION("pollpip")" (0|1)        output on each poll for input\n");
   printf("  "VMOPTION("checkpluginwrites")"    check for writes past end of object in plugins\n");
   printf("  "VMOPTION("pathenc")" <enc>        set encoding for pathnames (default: UTF-8)\n");
   printf("  "VMOPTION("plugins")" <path>       specify alternative plugin location (see manpage)\n");


### PR DESCRIPTION
* pollpip consumes an argument that was not documented
* It specifies to print a '.' while it prints one of '|/-\'