### PR TITLE
Add --quiet option to allow an app to own stdout and stderr

### DIFF
--- a/build.macos32x86/common/Makefile.vm
+++ b/build.macos32x86/common/Makefile.vm
@@ -60,7 +60,7 @@ OSXSRC=$(wildcard $(OSXDIR)/*.c) $(wildcard $(OSXDIR)/*.m) \
 		$(wildcard $(OSXCLASSESDIR)/*.c) $(wildcard $(OSXCLASSESDIR)/*.m)
 OSXSRC:=$(filter-out $(XEX),$(OSXSRC))
 UNIXSRC:=$(addprefix $(UNIXVMDIR)/,aio.c sqUnixHeartbeat.c sqUnixSpurMemory.c \
-                     sqUnixThreads.c sqUnixVMProfile.c)
+                     sqUnixThreads.c sqUnixVMProfile.c debug.c)
 VMSRC:= $(MAKERSRC) $(CROSSSRC) $(OSXSRC) $(UNIXSRC)
 VMOBJ:=	$(notdir $(VMSRC))
 VMOBJ:=	$(VMOBJ:.c=.o)

--- a/build.macos64x64/common/Makefile.vm
+++ b/build.macos64x64/common/Makefile.vm
@@ -60,7 +60,7 @@ OSXSRC=$(wildcard $(OSXDIR)/*.c) $(wildcard $(OSXDIR)/*.m) \
 		$(wildcard $(OSXCLASSESDIR)/*.c) $(wildcard $(OSXCLASSESDIR)/*.m)
 OSXSRC:=$(filter-out $(XEX),$(OSXSRC))
 UNIXSRC:=$(addprefix $(UNIXVMDIR)/,aio.c sqUnixHeartbeat.c sqUnixSpurMemory.c \
-                     sqUnixThreads.c sqUnixVMProfile.c)
+                     sqUnixThreads.c sqUnixVMProfile.c debug.c)
 VMSRC:= $(MAKERSRC) $(CROSSSRC) $(OSXSRC) $(UNIXSRC)
 VMOBJ:=	$(notdir $(VMSRC))
 VMOBJ:=	$(VMOBJ:.c=.o)

--- a/platforms/Cross/vm/sq.h
+++ b/platforms/Cross/vm/sq.h
@@ -651,4 +651,11 @@ sqInt ioFreeModule(void *moduleHandle);
 /* The Squeak version from which this interpreter was generated. */
 extern const char *interpreterVersion;
 
+/* Debug helper - don't print to the user console directly */
+
+/*
+ * FILE pointing to the error output of the VM.
+ */
+extern FILE *VM_ERR(void);
+
 #endif /* _SQ_H */

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
@@ -298,6 +298,10 @@ static char *getVersionInfo(int verbose);
 		return 1;
 	}
 #endif
+	if ([argData isEqualToString: VMOPTIONOBJ("quiet")]) {
+		sqSetVmErrFile(fopen("/dev/null", "w"));
+		return 1;
+	}
 
 	/* Options with arguments */
 	if (!peek)
@@ -495,6 +499,7 @@ static char *getVersionInfo(int verbose);
 
 - (void) printUsage {
 	printf("\nCommon <option>s:\n");
+	printf("  "VMOPTION("quiet")"                don't print debugging messages from the VM\n");
 	printf("  "VMOPTION("help")"                 print this help message, then exit\n");
 	printf("  "VMOPTION("memory")" <size>[mk]    use fixed heap size (added to image size)\n");
     printf("  "VMOPTION("nohandlers")"           disable sigsegv & sigusr1 handlers\n");

--- a/platforms/unix/misc/threadValidate/sqUnixHeartbeat.c
+++ b/platforms/unix/misc/threadValidate/sqUnixHeartbeat.c
@@ -275,17 +275,17 @@ yieldToHighPriorityTickerThread()
 
 	if ((err = pthread_mutex_lock(&yield_mutex))) {
 		if (err != EDEADLK)
-			fprintf(stderr,"pthread_mutex_lock yield_mutex %s\n", strerror(err));
+			fprintf(VM_ERR(),"pthread_mutex_lock yield_mutex %s\n", strerror(err));
 	}
 	/* If lock fails then unblockVMThreadAfterYieldToHighPriorityTickerThread
 	 * has locked and we should not block.
 	 */
 	if ((err = pthread_mutex_lock(&yield_sync))) {
 		if (err != EDEADLK)
-			fprintf(stderr,"pthread_mutex_lock yield_sync %s\n", strerror(err));
+			fprintf(VM_ERR(),"pthread_mutex_lock yield_sync %s\n", strerror(err));
 	}
 	else if ((err = pthread_cond_wait(&yield_cond, &yield_mutex)))
-		fprintf(stderr,"pthread_cond_wait %s\n", strerror(err));
+		fprintf(VM_ERR(),"pthread_cond_wait %s\n", strerror(err));
 }
 
 /* Private to sqTicker.c checkHighPriorityTickees */

--- a/platforms/unix/misc/threadValidate/threadValidate.c
+++ b/platforms/unix/misc/threadValidate/threadValidate.c
@@ -79,7 +79,7 @@ printAndQuit()
 void
 lockedup(int arg)
 {
-	fprintf(stderr,"system locked %s, time not advancing (yield method %s)\n",
+	fprintf(VM_ERR(),"system locked %s, time not advancing (yield method %s)\n",
 			arg == SIGINT ? "" : (char *)arg, method);
 	printf("vm %10lld hp %9lld hp+vm %10lld yields %d (%d,%d,%d) clk hz %ld\n",
 			vmcount, hpcount, vmcount + hpcount,
@@ -143,23 +143,23 @@ maybeYield()
 		case yield_via_wait_signal: { int err;
 			if ((err = pthread_mutex_lock(&yield_mutex))) {
 				if (err != EDEADLK)
-					fprintf(stderr,"pthread_mutex_lock yield_mutex %s\n", strerror(err));
+					fprintf(VM_ERR(),"pthread_mutex_lock yield_mutex %s\n", strerror(err));
 			}
 			else if ((err = pthread_mutex_lock(&yield_sync))) {
 				if (err != EDEADLK)
-					fprintf(stderr,"pthread_mutex_lock yield_sync %s\n", strerror(err));
+					fprintf(VM_ERR(),"pthread_mutex_lock yield_sync %s\n", strerror(err));
 			}
 			else {
 				sqLowLevelMFence();
 				if (yield
 				 && (err = pthread_cond_wait(&yield_cond, &yield_mutex)))
-					fprintf(stderr,"pthread_cond_wait %s\n", strerror(err));
+					fprintf(VM_ERR(),"pthread_cond_wait %s\n", strerror(err));
 			}
 			break;
 		}
 
 		default:
-			fprintf(stderr,"unrecognized yield method\n");
+			fprintf(VM_ERR(),"unrecognized yield method\n");
 			exit(5);
 	}
 }
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
 		else if (!strcmp(argv[1],"wait_signal"))
 			yieldMethod = yield_via_wait_signal;
 		else {
-			fprintf(stderr,
+			fprintf(VM_ERR(),
 					"usage: %s [none] [sched_yield] [nanosleep] [cond_timedwait] [wait_signal] [yield usecs]\n",
 					argv[0]);
 			return 3;
@@ -281,4 +281,4 @@ ioNumProcessors(void)
 }
 
 void
-warning(char *msg) { fprintf(stderr,"%s\n", msg); }
+warning(char *msg) { fprintf(VM_ERR(),"%s\n", msg); }

--- a/platforms/unix/vm/aio.c
+++ b/platforms/unix/vm/aio.c
@@ -31,6 +31,7 @@
  */
 
 #include "sqaio.h"
+#include "sq.h"
 
 #ifdef HAVE_CONFIG_H
 
@@ -99,7 +100,7 @@
 #endif /* !HAVE_CONFIG_H */
 
 /* function to inform the VM about idle time */
-extern void addIdleUsecs(long idleUsecs);
+extern void addIdleUsecs(sqInt idleUsecs);
 
 #if defined(AIO_DEBUG)
 long	aioLastTick = 0;
@@ -126,7 +127,7 @@ static fd_set xdMask;		/* external descriptor	 */
 static void 
 undefinedHandler(int fd, void *clientData, int flags)
 {
-	fprintf(stderr, "undefined handler called (fd %d, flags %x)\n", fd, flags);
+	fprintf(VM_ERR(), "undefined handler called (fd %d, flags %x)\n", fd, flags);
 }
 
 #ifdef AIO_DEBUG
@@ -221,7 +222,7 @@ static int tickCount = 0;
 #define TICKS_PER_CHAR 10
 #define DO_TICK(bool)				\
 do if ((bool) && !(++tickCount % TICKS_PER_CHAR)) {		\
-	fprintf(stderr, "\r%c\r", *ticker);		\
+	fprintf(VM_ERR(), "\r%c\r", *ticker);		\
 	if (!*ticker++) ticker= ticks;			\
 } while (0)
 
@@ -232,7 +233,7 @@ aioPoll(long microSeconds)
 	fd_set	rd, wr, ex;
 	unsigned long long us;
 
-	FPRINTF((stderr, "aioPoll(%ld)\n", microSeconds));
+	FPRINTF((VM_ERR(), "aioPoll(%ld)\n", microSeconds));
 	DO_TICK(SHOULD_TICK());
 
 	/*
@@ -269,7 +270,7 @@ aioPoll(long microSeconds)
 			return 0;
 		}
 		if (errno && (EINTR != errno)) {
-			fprintf(stderr, "errno %d\n", errno);
+			fprintf(VM_ERR(), "errno %d\n", errno);
 			perror("select");
 			return 0;
 		}
@@ -332,13 +333,13 @@ aioSleepForUsecs(long microSeconds)
 void 
 aioEnable(int fd, void *data, int flags)
 {
-	FPRINTF((stderr, "aioEnable(%d)\n", fd));
+	FPRINTF((VM_ERR(), "aioEnable(%d)\n", fd));
 	if (fd < 0) {
-		FPRINTF((stderr, "aioEnable(%d): IGNORED\n", fd));
+		FPRINTF((VM_ERR(), "aioEnable(%d): IGNORED\n", fd));
 		return;
 	}
 	if (FD_ISSET(fd, &fdMask)) {
-		fprintf(stderr, "aioEnable: descriptor %d already enabled\n", fd);
+		fprintf(VM_ERR(), "aioEnable: descriptor %d already enabled\n", fd);
 		return;
 	}
 	clientData[fd] = data;
@@ -395,9 +396,9 @@ aioEnable(int fd, void *data, int flags)
 void 
 aioHandle(int fd, aioHandler handlerFn, int mask)
 {
-	FPRINTF((stderr, "aioHandle(%d, %s, %d)\n", fd, handlerName(handlerFn), mask));
+	FPRINTF((VM_ERR(), "aioHandle(%d, %s, %d)\n", fd, handlerName(handlerFn), mask));
 	if (fd < 0) {
-		FPRINTF((stderr, "aioHandle(%d): IGNORED\n", fd));
+		FPRINTF((VM_ERR(), "aioHandle(%d): IGNORED\n", fd));
 		return;
 	}
 #undef _DO
@@ -416,10 +417,10 @@ void
 aioSuspend(int fd, int mask)
 {
 	if (fd < 0) {
-		FPRINTF((stderr, "aioSuspend(%d): IGNORED\n", fd));
+		FPRINTF((VM_ERR(), "aioSuspend(%d): IGNORED\n", fd));
 		return;
 	}
-	FPRINTF((stderr, "aioSuspend(%d)\n", fd));
+	FPRINTF((VM_ERR(), "aioSuspend(%d)\n", fd));
 #undef _DO
 #define _DO(FLAG, TYPE)							\
 	if (mask & FLAG) {							\
@@ -436,10 +437,10 @@ void
 aioDisable(int fd)
 {
 	if (fd < 0) {
-		FPRINTF((stderr, "aioDisable(%d): IGNORED\n", fd));
+		FPRINTF((VM_ERR(), "aioDisable(%d): IGNORED\n", fd));
 		return;
 	}
-	FPRINTF((stderr, "aioDisable(%d)\n", fd));
+	FPRINTF((VM_ERR(), "aioDisable(%d)\n", fd));
 	aioSuspend(fd, AIO_RWX);
 	FD_CLR(fd, &xdMask);
 	FD_CLR(fd, &fdMask);

--- a/platforms/unix/vm/debug.c
+++ b/platforms/unix/vm/debug.c
@@ -53,3 +53,8 @@ FILE *VM_ERR(void)
 	}
 	return VM_ERR_FILE;
 }
+
+void sqSetVmErrFile(FILE *file)
+{
+	VM_ERR_FILE = file;
+}

--- a/platforms/unix/vm/debug.c
+++ b/platforms/unix/vm/debug.c
@@ -1,4 +1,5 @@
 #include "debug.h"
+#include "sq.h"
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -32,13 +33,23 @@ void __sq_eprintf(const char *fmt, ...)
   char *file= strrchr(__sq_errfile, '/');
   file= file ? file + 1 : __sq_errfile;
   va_start(ap, fmt);
-  fprintf(stderr, "%s(%d): %s:\n", file, __sq_errline, __sq_errfunc);
-  fprintf(stderr, "%s(%d): ", file, __sq_errline);
-  vfprintf(stderr, fmt, ap);
+  fprintf(VM_ERR(), "%s(%d): %s:\n", file, __sq_errline, __sq_errfunc);
+  fprintf(VM_ERR(), "%s(%d): ", file, __sq_errline);
+  vfprintf(VM_ERR(), fmt, ap);
   va_end(ap);
 }
 
 
 void sqDebugAnchor(void)
 {
+}
+
+static FILE *VM_ERR_FILE = NULL;
+
+FILE *VM_ERR(void)
+{
+	if (!VM_ERR_FILE) {
+		VM_ERR_FILE = stderr;
+	}
+	return VM_ERR_FILE;
 }

--- a/platforms/unix/vm/debug.h
+++ b/platforms/unix/vm/debug.h
@@ -1,6 +1,7 @@
 #ifndef __sq_debug_h
 #define __sq_debug_h
 
+#include <stdio.h>
 
 #ifndef  DEBUG
 # define DEBUG	0
@@ -43,5 +44,7 @@ extern void __sq_eprintf(const char *fmt, ...);
     __sq_eprintf )
 
 extern void sqDebugAnchor(void);
+
+extern void sqSetVmErrFile(FILE* file);
 
 #endif /* __sq_debug_h */

--- a/platforms/unix/vm/dlfcn-dyld.c
+++ b/platforms/unix/vm/dlfcn-dyld.c
@@ -63,12 +63,12 @@ static const char *dlerror(void)
 
 static void dlUndefined(const char *symbol)
 {
-  fprintf(stderr, "dyld: undefined symbol: %s\n", symbol);
+  fprintf(VM_ERR(), "dyld: undefined symbol: %s\n", symbol);
 }
 
 static NSModule dlMultiple(NSSymbol s, NSModule oldModule, NSModule newModule)
 {
-  DPRINTF((stderr, "dyld: %s: %s previously defined in %s, new definition in %s\n",
+  DPRINTF((VM_ERR(), "dyld: %s: %s previously defined in %s, new definition in %s\n",
 	   NSNameOfSymbol(s), NSNameOfModule(oldModule), NSNameOfModule(newModule)));
   return newModule;
 }
@@ -77,7 +77,7 @@ static void dlLinkEdit(NSLinkEditErrors errorClass, int errorNumber,
 		       const char *fileName, const char *errorString)
 
 {
-  fprintf(stderr, "dyld: %s: %s\n", fileName, errorString);
+  fprintf(VM_ERR(), "dyld: %s: %s\n", fileName, errorString);
 }
 
 static NSLinkEditErrorHandlers errorHandlers=
@@ -126,7 +126,7 @@ static void *dlopen(const char *path, int mode)
   if (!handle)
     dlSetError("could not load shared object: %s", path);
 
-  DPRINTF((stderr, "dlopen: %s => %d\n", path, (int)handle));
+  DPRINTF((VM_ERR(), "dlopen: %s => %d\n", path, (int)handle));
 
   return handle;
 }
@@ -139,17 +139,17 @@ static void *dlsym(void *handle, const char *symbol)
 
   snprintf(_symbol, sizeof(_symbol), "_%s", symbol);
 
-  DPRINTF((stderr, "dlsym: looking for %s (%s) in %d\n", symbol, _symbol, (int)handle));
+  DPRINTF((VM_ERR(), "dlsym: looking for %s (%s) in %d\n", symbol, _symbol, (int)handle));
 
   if (!handle)
     {
-      DPRINTF((stderr, "dlsym: setting app context for this handle\n"));
+      DPRINTF((VM_ERR(), "dlsym: setting app context for this handle\n"));
       handle= DL_APP_CONTEXT;
     }
 
   if (DL_APP_CONTEXT == handle)
     {
-      DPRINTF((stderr, "dlsym: looking in app context\n"));
+      DPRINTF((VM_ERR(), "dlsym: looking in app context\n"));
       if (NSIsSymbolNameDefined(_symbol))
 	nsSymbol= NSLookupAndBindSymbol(_symbol);
     }
@@ -165,15 +165,15 @@ static void *dlsym(void *handle, const char *symbol)
 		 _symbol,
 		 NSLOOKUPSYMBOLINIMAGE_OPTION_BIND
 		 /*| NSLOOKUPSYMBOLINIMAGE_OPTION_RETURN_ON_ERROR*/);
-	      DPRINTF((stderr, "dlsym: bundle (image) lookup returned %p\n", nsSymbol));
+	      DPRINTF((VM_ERR(), "dlsym: bundle (image) lookup returned %p\n", nsSymbol));
 	    }
 	  else
-	    DPRINTF((stderr, "dlsym: bundle (image) symbol not defined\n"));
+	    DPRINTF((VM_ERR(), "dlsym: bundle (image) symbol not defined\n"));
 	}
       else
 	{
 	  nsSymbol= NSLookupSymbolInModule(handle, _symbol);
-	  DPRINTF((stderr, "dlsym: dylib (module) lookup returned %p\n", nsSymbol));
+	  DPRINTF((VM_ERR(), "dlsym: dylib (module) lookup returned %p\n", nsSymbol));
 	}
     }
 

--- a/platforms/unix/vm/sqUnixCharConv.c
+++ b/platforms/unix/vm/sqUnixCharConv.c
@@ -33,6 +33,7 @@
 # include "sqMemoryAccess.h"
 #endif
 #include "sqUnixCharConv.h"
+#include "sq.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -115,7 +116,7 @@ void setEncoding(void **encoding, char *rawName)
       }
     else
       ++ap;
-  fprintf(stderr, "setEncoding: could not set encoding '%s'\n", name);
+  fprintf(VM_ERR(), "setEncoding: could not set encoding '%s'\n", name);
  done:
   free(name);
 }

--- a/platforms/unix/vm/sqUnixHeartbeat.c
+++ b/platforms/unix/vm/sqUnixHeartbeat.c
@@ -324,7 +324,7 @@ beatStateMachine(void *careLess)
 		 */
 		extern char *revisionAsString();
 		errno = er;
-		perror("pthread_setschedparam failed");
+		fprintf(VM_ERR(), "pthread_setschedparam failed: %s", strerror(errno));
 #if PharoVM
 # define VMNAME "pharo"
 #elif NewspeakVM
@@ -332,20 +332,20 @@ beatStateMachine(void *careLess)
 #else
 # define VMNAME "squeak"
 #endif
-        fprintf(stderr, "This VM uses a separate heartbeat thread to update its internal clock\n");
-        fprintf(stderr, "and handle events.  For best operation, this thread should run at a\n");
-        fprintf(stderr, "higher priority, however the VM was unable to change the priority.  The\n");
-        fprintf(stderr, "effect is that heavily loaded systems may experience some latency\n");
-        fprintf(stderr, "issues.  If this occurs, please create the appropriate configuration\n");
-        fprintf(stderr, "file in /etc/security/limits.d/ as shown below:\n\n");
-        fprintf(stderr, "cat <<END | sudo tee /etc/security/limits.d/%s.conf\n", VMNAME);
-        fprintf(stderr, "*      hard    rtprio  2\n");
-        fprintf(stderr, "*      soft    rtprio  2\n");
-        fprintf(stderr, "END\n");
-        fprintf(stderr, "\nand report to the %s mailing list whether this improves behaviour.\n", VMNAME);
-        fprintf(stderr, "\nYou will need to log out and log back in for the limits to take effect.\n");
-        fprintf(stderr, "For more information please see\n");
-        fprintf(stderr, "https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/tag/r3732#linux\n");
+        fprintf(VM_ERR(), "This VM uses a separate heartbeat thread to update its internal clock\n");
+        fprintf(VM_ERR(), "and handle events.  For best operation, this thread should run at a\n");
+        fprintf(VM_ERR(), "higher priority, however the VM was unable to change the priority.  The\n");
+        fprintf(VM_ERR(), "effect is that heavily loaded systems may experience some latency\n");
+        fprintf(VM_ERR(), "issues.  If this occurs, please create the appropriate configuration\n");
+        fprintf(VM_ERR(), "file in /etc/security/limits.d/ as shown below:\n\n");
+        fprintf(VM_ERR(), "cat <<END | sudo tee /etc/security/limits.d/%s.conf\n", VMNAME);
+        fprintf(VM_ERR(), "*      hard    rtprio  2\n");
+        fprintf(VM_ERR(), "*      soft    rtprio  2\n");
+        fprintf(VM_ERR(), "END\n");
+        fprintf(VM_ERR(), "\nand report to the %s mailing list whether this improves behaviour.\n", VMNAME);
+        fprintf(VM_ERR(), "\nYou will need to log out and log back in for the limits to take effect.\n");
+        fprintf(VM_ERR(), "For more information please see\n");
+        fprintf(VM_ERR(), "https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/tag/r3732#linux\n");
         // exit(errno);
 		// The VM may have issues with clock jitter due to the heartbeat thread
 		// not running at elevated priority. An exit may be appropriate in some

--- a/platforms/unix/vm/sqUnixITimerTickerHeartbeat.c
+++ b/platforms/unix/vm/sqUnixITimerTickerHeartbeat.c
@@ -382,17 +382,17 @@ yieldToHighPriorityTickerThread()
 
 	if ((err = pthread_mutex_lock(&yield_mutex))) {
 		if (err != EDEADLK)
-			fprintf(stderr,"pthread_mutex_lock yield_mutex %s\n", strerror(err));
+			fprintf(VM_ERR(),"pthread_mutex_lock yield_mutex %s\n", strerror(err));
 	}
 	/* If lock fails then unblockVMThreadAfterYieldToHighPriorityTickerThread
 	 * has locked and we should not block.
 	 */
 	if ((err = pthread_mutex_lock(&yield_sync))) {
 		if (err != EDEADLK)
-			fprintf(stderr,"pthread_mutex_lock yield_sync %s\n", strerror(err));
+			fprintf(VM_ERR(),"pthread_mutex_lock yield_sync %s\n", strerror(err));
 	}
 	else if ((err = pthread_cond_wait(&yield_cond, &yield_mutex)))
-		fprintf(stderr,"pthread_cond_wait %s\n", strerror(err));
+		fprintf(VM_ERR(),"pthread_cond_wait %s\n", strerror(err));
 }
 
 /* Private to sqTicker.c checkHighPriorityTickees */

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -643,13 +643,13 @@ static void emergencyDump(int quit)
   printf("\nMost recent primitives\n");
   dumpPrimTraceLog();
 #endif
-  fprintf(stderr, "\n");
+  fprintf(VM_ERR(), "\n");
   printCallStack();
-  fprintf(stderr, "\nTo recover valuable content from this image:\n");
-  fprintf(stderr, "    %s %s\n", exeName, imageName);
-  fprintf(stderr, "and then evaluate\n");
-  fprintf(stderr, "    Smalltalk processStartUpList: true\n");
-  fprintf(stderr, "in a workspace.  DESTROY the dumped image after recovering content!");
+  fprintf(VM_ERR(), "\nTo recover valuable content from this image:\n");
+  fprintf(VM_ERR(), "    %s %s\n", exeName, imageName);
+  fprintf(VM_ERR(), "and then evaluate\n");
+  fprintf(VM_ERR(), "    Smalltalk processStartUpList: true\n");
+  fprintf(VM_ERR(), "in a workspace.  DESTROY the dumped image after recovering content!");
 
   if (quit) abort();
   strncpy(imageName, savedName, sizeof(imageName));
@@ -863,13 +863,13 @@ sqInt  primitivePluginRequestState(void)	{ return dpy->primitivePluginRequestSta
 
 static void outOfMemory(void)
 {
-  /* pushing stderr outputs the error report on stderr instead of stdout */
+  /* pushing VM_ERR() outputs the error report on VM_ERR() instead of stdout */
   pushOutputFile((char *)STDERR_FILENO);
   error("out of memory\n");
 }
 
 /* Print an error message, possibly a stack trace, do /not/ exit.
- * Allows e.g. writing to a log file and stderr.
+ * Allows e.g. writing to a log file and VM_ERR().
  */
 static void *printRegisterState(ucontext_t *uap);
 
@@ -1202,7 +1202,7 @@ struct SqModule *queryLoadModule(char *type, char *name, int query)
       else
 	if (!query)
 	  {
-	    fprintf(stderr, "could not find module %s\n", modName);
+	    fprintf(VM_ERR(), "could not find module %s\n", modName);
 	    return 0;
 	  }
     }
@@ -1211,7 +1211,7 @@ struct SqModule *queryLoadModule(char *type, char *name, int query)
       module= (struct SqModule *)itf;
       if (SqModuleVersion != module->version)
 	{
-	  fprintf(stderr, "module %s version %x does not have required version %x\n",
+	  fprintf(VM_ERR(), "module %s version %x does not have required version %x\n",
 		  modName, module->version, SqModuleVersion);
 	  abort();
 	}
@@ -1222,7 +1222,7 @@ struct SqModule *queryLoadModule(char *type, char *name, int query)
       return module;
     }
   if (!query)
-    fprintf(stderr, "could not find interface %s in module %s\n", itfName, modName);
+    fprintf(VM_ERR(), "could not find interface %s in module %s\n", itfName, modName);
   return 0;
 }
 
@@ -1283,7 +1283,7 @@ static void requireModuleNamed(char *type)	/*** NOTE: MODIFIES THE ARGUMENT! ***
       module= requireModule(type, name);
       if (!addr)
 	{
-	  fprintf(stderr, "this cannot happen\n");
+	  fprintf(VM_ERR(), "this cannot happen\n");
 	  abort();
 	}
       *addr= module;
@@ -1313,7 +1313,7 @@ static void checkModuleVersion(struct SqModule *module, int required, int actual
 {
   if (required != actual)
     {
-      fprintf(stderr, "module %s interface version %x does not have required version %x\n",
+      fprintf(VM_ERR(), "module %s interface version %x does not have required version %x\n",
 	      module->name, actual, required);
       abort();
     }
@@ -1324,10 +1324,10 @@ static void loadImplicit(struct SqModule **addr, char *evar, char *type, char *n
 {
   if ((!*addr) && getenv(evar) && !(*addr= queryModule(type, name)))
     {
-      fprintf(stderr, "could not find %s driver vm-%s-%s; either:\n", type, type, name);
-      fprintf(stderr, "  - check that %s/vm-%s-%s.so exists, or\n", vmPath, type, name);
-      fprintf(stderr, "  - use the '-plugins <path>' option to tell me where it is, or\n");
-      fprintf(stderr, "  - remove %s from your environment.\n", evar);
+      fprintf(VM_ERR(), "could not find %s driver vm-%s-%s; either:\n", type, type, name);
+      fprintf(VM_ERR(), "  - check that %s/vm-%s-%s.so exists, or\n", vmPath, type, name);
+      fprintf(VM_ERR(), "  - use the '-plugins <path>' option to tell me where it is, or\n");
+      fprintf(VM_ERR(), "  - remove %s from your environment.\n", evar);
       abort();
     }
 }
@@ -1343,19 +1343,19 @@ static void loadModules(void)
       if (!*md->addr)
 	if ((*md->addr= queryModule(md->type, md->name)))
 #	 if defined(DEBUG_MODULES)
-	  fprintf(stderr, "%s: %s driver defaulting to vm-%s-%s\n", exeName, md->type, md->type, md->name)
+	  fprintf(VM_ERR(), "%s: %s driver defaulting to vm-%s-%s\n", exeName, md->type, md->type, md->name)
 #	 endif
 	    ;
   }
 
   if (!displayModule)
     {
-      fprintf(stderr, "%s: could not find any display driver\n", exeName);
+      fprintf(VM_ERR(), "%s: could not find any display driver\n", exeName);
       abort();
     }
   if (!soundModule)
     {
-      fprintf(stderr, "%s: could not find any sound driver\n", exeName);
+      fprintf(VM_ERR(), "%s: could not find any sound driver\n", exeName);
       abort();
     }
 
@@ -1407,7 +1407,7 @@ static void vm_parseEnvironment(void)
   if (ev)
     setLocaleEncoding(ev);
   else
-    fprintf(stderr, "setlocale() failed (check values of LC_CTYPE, LANG and LC_ALL)\n");
+    fprintf(VM_ERR(), "setlocale() failed (check values of LC_CTYPE, LANG and LC_ALL)\n");
 
   if (documentName)
     strcpy(shortImageName, documentName);
@@ -1442,7 +1442,7 @@ static int parseModuleArgument(int argc, char **argv, struct SqModule **addr, ch
 {
   if (*addr)
     {
-      fprintf(stderr, "option '%s' conflicts with previously-loaded module '%s'\n", *argv, (*addr)->name);
+      fprintf(VM_ERR(), "option '%s' conflicts with previously-loaded module '%s'\n", *argv, (*addr)->name);
       exit(1);
     }
   *addr= requireModule(type, name);
@@ -1742,7 +1742,7 @@ static void vm_printUsageNotes(void)
 
 static void *vm_makeInterface(void)
 {
-  fprintf(stderr, "this cannot happen\n");
+  fprintf(VM_ERR(), "this cannot happen\n");
   abort();
 }
 
@@ -1885,7 +1885,7 @@ static void parseArguments(int argc, char **argv)
 #    endif
       if (n == 0)			/* option not recognised */
 	{
-	  fprintf(stderr, "unknown option: %s\n", argv[0]);
+	  fprintf(VM_ERR(), "unknown option: %s\n", argv[0]);
 	  usage();
 	  exit(1);
 	}
@@ -1919,7 +1919,7 @@ static void
 imageNotFound(char *imageName)
 {
   /* image file is not found */
-  fprintf(stderr,
+  fprintf(VM_ERR(),
 	  "Could not open the " IMAGE_DIALECT_NAME " image file `%s'.\n"
 	  "\n"
 	  "There are three ways to open a " IMAGE_DIALECT_NAME " image file.  You can:\n"
@@ -2115,7 +2115,7 @@ main(int argc, char **argv, char **envp)
       if (comp)
 	{
 	  ((void (*)(void))comp)();
-	  fprintf(stderr, "handing control back to interpret() -- have a nice day\n");
+	  fprintf(VM_ERR(), "handing control back to interpret() -- have a nice day\n");
 	}
       else
 	printf("could not find j_interpret\n");

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -1659,6 +1659,10 @@ static int vm_parseArgument(int argc, char **argv)
     }
     return 2;
   }
+  else if (!strcmp(argv[0], VMOPTION("quiet"))) {
+    sqSetVmErrFile(fopen("/dev/null", "w"));
+    return 1;
+  }
   return 0; /* option not recognised */
 }
 
@@ -1666,6 +1670,7 @@ static int vm_parseArgument(int argc, char **argv)
 static void vm_printUsage(void)
 {
   printf("\nCommon <option>s:\n");
+  printf("  "VMOPTION("quiet")"                don't print debugging messages from the VM\n");
   printf("  "VMOPTION("encoding")" <enc>       set the internal character encoding (default: MacRoman)\n");
   printf("  "VMOPTION("help")"                 print this help message, then exit\n");
   printf("  "VMOPTION("memory")" <size>[mk]    use fixed heap size (added to image size)\n");

--- a/platforms/unix/vm/sqUnixMemory.c
+++ b/platforms/unix/vm/sqUnixMemory.c
@@ -116,7 +116,7 @@ void *
 uxAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
 {
 	if (heap) {
-		fprintf(stderr, "uxAllocateMemory: already called\n");
+		fprintf(VM_ERR(), "uxAllocateMemory: already called\n");
 		exit(1);
 	}
 	pageSize= getpagesize();
@@ -130,7 +130,7 @@ void *uxAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
 # endif
 
   if (heap) {
-      fprintf(stderr, "uxAllocateMemory: already called\n");
+      fprintf(VM_ERR(), "uxAllocateMemory: already called\n");
       exit(1);
   }
   pageSize= getpagesize();
@@ -159,7 +159,7 @@ void *uxAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
   }
 
   if (!heap) {
-      fprintf(stderr, "uxAllocateMemory: failed to allocate at least %lld bytes)\n", (long long)minHeapSize);
+      fprintf(VM_ERR(), "uxAllocateMemory: failed to allocate at least %lld bytes)\n", (long long)minHeapSize);
       useMmap= 0;
       return malloc(desiredHeapSize);
   }
@@ -262,7 +262,7 @@ void *
 uxAllocateMemory(sqInt minHeapSize, sqInt desiredHeapSize)
 {
 	if (pageMask) {
-		fprintf(stderr, "uxAllocateMemory: already called\n");
+		fprintf(VM_ERR(), "uxAllocateMemory: already called\n");
 		exit(1);
 	}
 	pageSize = getpagesize();

--- a/platforms/unix/vm/sqUnixSpurMemory.c
+++ b/platforms/unix/vm/sqUnixSpurMemory.c
@@ -94,7 +94,7 @@ sqAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
     sqInt allocBytes;
 
 	if (pageSize) {
-		fprintf(stderr, "sqAllocateMemory: already called\n");
+		fprintf(VM_ERR(), "sqAllocateMemory: already called\n");
 		exit(1);
 	}
 	pageSize = getpagesize();
@@ -108,7 +108,7 @@ sqAllocateMemory(usqInt minHeapSize, usqInt desiredHeapSize)
 	alloc = sqAllocateMemorySegmentOfSizeAboveAllocatedSizeInto
 				(roundUpToPage(desiredHeapSize), address, &allocBytes);
 	if (!alloc) {
-		fprintf(stderr, "sqAllocateMemory: initial alloc failed!\n");
+		fprintf(VM_ERR(), "sqAllocateMemory: initial alloc failed!\n");
 		exit(errno);
 	}
 	return (usqInt)alloc;

--- a/platforms/unix/vm/sqaio.h
+++ b/platforms/unix/vm/sqaio.h
@@ -113,7 +113,7 @@ extern unsigned volatile long long ioUTCMicrosecondsNow(void);
 	extern const char *__shortFileName(const char *);
 #   define FPRINTF(X) do { \
 	aioThisTick = ioMSecs(); \
-	fprintf(stderr, "%8ld %4ld %s:%d ", aioThisTick, aioThisTick - aioLastTick,\
+	fprintf(VM_ERR(), "%8ld %4ld %s:%d ", aioThisTick, aioThisTick - aioLastTick,\
 			__shortFileName(__FILE__),__LINE__); \
 	aioLastTick = aioThisTick; \
 	fprintf X; } while (0)


### PR DESCRIPTION
I envison to have --quiet and --debugoutput FILENAME as options in the future. For an end-user it is difficult to separate application output/error from VM one (e.g. the infamous thread priority warning).