### PR TITLE
Add missing code signing command for MacOS Travis

### DIFF
--- a/deploy/pack-vm.sh
+++ b/deploy/pack-vm.sh
@@ -27,6 +27,7 @@ macos_codesign() {
   security set-keychain-settings -t 3600 -u "${KEY_CHAIN}"
   security import "${path_cer}" -k ~/Library/Keychains/"${KEY_CHAIN}" -T /usr/bin/codesign
   security import "${path_p12}" -k ~/Library/Keychains/"${KEY_CHAIN}" -P "${cert_pass}" -T /usr/bin/codesign
+  security set-key-partition-list -S apple-tool:,apple: -s -k travis "${KEY_CHAIN}"
   # Invoke codesign
   if [[ -d "${app_dir}/Contents/MacOS/Plugins" ]]; then # Pharo.app does not (yet) have its plugins in Resources dir
     codesign -s "${sign_identity}" --force --deep "${app_dir}/Contents/MacOS/Plugins/"*


### PR DESCRIPTION
I am adding a missing command that is now required for code signing in Travis. Otherwise, it seem that the build is hanging because it is expecting manual password input.

See https://docs.travis-ci.com/user/common-build-problems/#mac-macos-sierra-1012-code-signing-errors