### PR TITLE
Fix 32 bits CI builds because of the Metal integration

### DIFF
--- a/platforms/iOS/plugins/B3DAcceleratorPlugin/Makefile
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin/Makefile
@@ -6,15 +6,9 @@ INCDIRS:=$(PLATDIR)/Cross/plugins/FilePlugin \
          $(PLATDIR)/unix/vm
 INCDIRS:=$(PLATDIR)/unix/vm
 
-EXTRADYFLAGS=-Wl,-U,_getImageName,-U,_getSTWindow,-U,_setWindowChangedHook,-U,_warning
-#EXTRALIBS:= -framework OpenGL -framework AGL
+EXTRADYFLAGS=-Wl,-U,_getImageName,-U,_getSTWindow,-U,_setWindowChangedHook,-U,_warning \
+	-Wl,-U,_getMainWindowOpenGLContext,-U,_createOpenGLTextureLayerHandle,-U,_destroyOpenGLTextureLayerHandle,-U,_setOpenGLTextureLayerContent \
+	-Wl,-U,_getMainWindowMetalDevice,-U,_getMainWindowMetalCommandQueue,-U,_createMetalTextureLayerHandle,-U,_destroyMetalTextureLayerHandle,-U,_setMetalTextureLayerContent
+EXTRALIBS:= -framework CoreFoundation -framework OpenGL -framework Metal -framework Cocoa
 
 include ../common/Makefile.plugin
-
-ifeq ($(TARGET_ARCH), i386)
-EXTRADYFLAGS=-Wl,-U,_getMainWindowOpenGLContext,-U,_createOpenGLTextureLayerHandle,-U,_destroyOpenGLTextureLayerHandle,-U,_setOpenGLTextureLayerContent
-EXTRALIBS:= -framework CoreFoundation -framework OpenGL -framework Cocoa
-else
-EXTRADYFLAGS=-Wl,-U,_getMainWindowMetalDevice,-U,_getMainWindowMetalCommandQueue,-U,_createMetalTextureLayerHandle,-U,_destroyMetalTextureLayerHandle,-U,_setMetalTextureLayerContent
-EXTRALIBS:= -framework CoreFoundation -framework Metal -framework Cocoa
-endif


### PR DESCRIPTION
This should fix this issue: https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/385#issue-426205672

On 32 bits it is possible to link with the Metal libraries, but the MTLCreateSystemDefaultDevice() function always returns nil, at least on my machines.