### PR TITLE
Do not convert keyboard event charCode to mac-roman encoding

### DIFF
--- a/platforms/win32/vm/sqWin32.h
+++ b/platforms/win32/vm/sqWin32.h
@@ -173,7 +173,6 @@ typedef int (*messageHook)(void *, unsigned int, unsigned int, long);
 /* Several setup functions                              */
 /********************************************************/
 void SetupFilesAndPath();
-void SetupKeymap();
 void SetupWindows();
 void SetupPixmaps();
 void SetupPrinter();

--- a/platforms/win32/vm/sqWin32Main.c
+++ b/platforms/win32/vm/sqWin32Main.c
@@ -1616,7 +1616,6 @@ sqMain(int argc, char *argv[])
 #endif
 
   /* initialisation */
-  SetupKeymap();
   SetupWindows();
   SetupPixmaps();
   { extern void ioInitTime(void);

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -1097,41 +1097,7 @@ void SetWindowSize(void) {
 /*              Keyboard and Mouse                                          */
 /****************************************************************************/
 
-/* The following is a mapping to Mac Roman glyphs.
-   It is not entirely correct since a number of glyphs are
-   different but should be good enough for Squeak.
-   More significantly, we can now map in both directions. */
-static unsigned char keymap[256] =
-{
-  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
- 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
- 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
- 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
- 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
- 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
- 96, 97, 98, 99,100,101,102,103,104,105,106,107,108,109,110,111,
-112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,
-173,176,226,196,227,201,160,224,246,228,178,220,206,179,182,183,
-184,212,213,210,211,165,208,209,247,170,185,221,207,186,189,217,
-202,193,162,163,219,180,195,164,172,169,187,199,194,197,168,248,
-161,177,198,215,171,181,166,225,252,218,188,200,222,223,240,192,
-203,231,229,204,128,129,174,130,233,131,230,232,237,234,235,236,
-245,132,241,238,239,205,133,249,175,244,242,243,134,250,251,167,
-136,135,137,139,138,140,190,141,143,142,144,145,147,146,148,149,
-253,150,152,151,153,155,154,214,191,157,156,158,159,254,255,216
-};
-
-/* The following is the inverse keymap */
-static unsigned char iKeymap[256];
-
-void SetupKeymap()
-{ int i;
-  for(i=0;i<256;i++)
-    iKeymap[keymap[i]] = i;
-}
-
-
-/* Map a virtual key into something the Mac understands */
+/* Map a virtual key into some encoding shared by all platforms and known at image side */
 static int mapVirtualKey(int virtKey)
 {
   switch (virtKey) {
@@ -1334,7 +1300,7 @@ int recordKeyboardEvent(MSG *msg) {
   evt = (sqKeyboardEvent*) sqNextEventPut();
   evt->type = EventTypeKeyboard;
   evt->timeStamp = msg->time;
-  evt->charCode = keymap[keyCode & 0xff];
+  evt->charCode = keyCode & 0xff;
   evt->pressCode = pressCode;
   evt->modifiers = 0;
   evt->modifiers |= alt ? CommandKeyBit : 0;
@@ -1495,8 +1461,8 @@ int recordKeystroke(UINT msg, WPARAM wParam, LPARAM lParam)
   /* Special case: VK_RETURN is handled as virtual key *only* */
   if(wParam == 13) return 1;
 
-  /* Map from Win32 to Mac */
-  keystate = keymap[wParam];
+  /* Set low 8 bits to the key code - this is internationalization unfriendly, but we cannot compact key code and modifier state into single sqInt without such sacrifice */
+  keystate = wParam & 0xff;
   /* add the modifiers */
   keystate = keystate | ((buttonState >> 3) << 8);
   /* check for interrupt key */


### PR DESCRIPTION
Fix issue 401

Image do not use such mac-roman encoding for ages.
On the contrary, images have to undo this translation by sending `macToSqueak` here and there which makes no sense.
We do not need this opensmalltalk VM to be compatible with 15-years old images. Let's clean-up.