### PR TITLE
fix issue #405: path to checkSCCSversion was wrong in linux mvm scripts

### DIFF
--- a/build.linux32ARMv6/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv6/newspeak.cog.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv6/newspeak.cog.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/newspeak.cog.spur/build/mvm
+++ b/build.linux32ARMv6/newspeak.cog.spur/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARMv6/newspeak.stack.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARMv6/newspeak.stack.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/newspeak.stack.spur/build/mvm
+++ b/build.linux32ARMv6/newspeak.stack.spur/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/pharo.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/pharo.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/pharo.cog.spur/build/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.cog.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.cog.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.cog.spur/build/mvm
+++ b/build.linux32ARMv6/squeak.cog.spur/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.stack.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.stack.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.stack.spur/build/mvm
+++ b/build.linux32ARMv6/squeak.stack.spur/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.stack.v3/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.stack.v3/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.stack.v3/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.stack.v3/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv6/squeak.stack.v3/build/mvm
+++ b/build.linux32ARMv6/squeak.stack.v3/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv7/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv7/newspeak.cog.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv7/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv7/newspeak.cog.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv7/newspeak.cog.spur/build/mvm
+++ b/build.linux32ARMv7/newspeak.cog.spur/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv7/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARMv7/newspeak.stack.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv7/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARMv7/newspeak.stack.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32ARMv7/newspeak.stack.spur/build/mvm
+++ b/build.linux32ARMv7/newspeak.stack.spur/build/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.assert/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.debug/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.itimerheartbeat/mvm
@@ -22,7 +22,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.cog.spur/build/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build/mvm
@@ -22,7 +22,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32x86/newspeak.stack.spur/build.assert/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32x86/newspeak.stack.spur/build.debug/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/newspeak.stack.spur/build/mvm
+++ b/build.linux32x86/newspeak.stack.spur/build/mvm
@@ -22,7 +22,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/nsnac.cog.spur/build.assert/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.assert/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/nsnac.cog.spur/build.debug/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.debug/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/nsnac.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.itimerheartbeat/mvm
@@ -22,7 +22,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/nsnac.cog.spur/build/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build/mvm
@@ -22,7 +22,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.assert/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.assert/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.debug/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.debug/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.itimerheartbeat/mvm
@@ -24,7 +24,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.lowcode/build/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build/mvm
@@ -23,7 +23,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
@@ -14,7 +14,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.assert/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.assert/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
@@ -14,7 +14,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
@@ -23,7 +23,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur.minheadless/build/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build/mvm
@@ -17,7 +17,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur/build.assert/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.assert/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur/build.debug/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.debug/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.itimerheartbeat/mvm
@@ -24,7 +24,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.cog.spur/build/mvm
+++ b/build.linux32x86/pharo.cog.spur/build/mvm
@@ -23,7 +23,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.sista.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.sista.spur/build.assert/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.sista.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.sista.spur/build.debug/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.sista.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.itimerheartbeat/mvm
@@ -20,7 +20,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.sista.spur/build/mvm
+++ b/build.linux32x86/pharo.sista.spur/build/mvm
@@ -20,7 +20,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.assert/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.assert/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.debug/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.debug/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.itimerheartbeat/mvm
@@ -24,7 +24,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/pharo.stack.spur.lowcode/build/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build/mvm
@@ -23,7 +23,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur.immutability/build.assert/mvm
+++ b/build.linux32x86/squeak.cog.spur.immutability/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur.immutability/build.debug/mvm
+++ b/build.linux32x86/squeak.cog.spur.immutability/build.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur.immutability/build/mvm
+++ b/build.linux32x86/squeak.cog.spur.immutability/build/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur/build.assert/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur/build.debug/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.debug/mvm
@@ -16,7 +16,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.itimerheartbeat/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.spur/build/mvm
+++ b/build.linux32x86/squeak.cog.spur/build/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.assert/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.debug/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.itimerheartbeat/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.multithreaded.assert/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.multithreaded.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.multithreaded.debug/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.multithreaded.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build.multithreaded/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.multithreaded/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.cog.v3/build/mvm
+++ b/build.linux32x86/squeak.cog.v3/build/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.sista.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.assert.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.sista.spur/build.assert/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.sista.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.debug.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.sista.spur/build.debug/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.sista.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.itimerheartbeat/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.sista.spur/build/mvm
+++ b/build.linux32x86/squeak.sista.spur/build/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.stack.spur/build.assert/mvm
+++ b/build.linux32x86/squeak.stack.spur/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.stack.spur/build.debug/mvm
+++ b/build.linux32x86/squeak.stack.spur/build.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.stack.spur/build/mvm
+++ b/build.linux32x86/squeak.stack.spur/build/mvm
@@ -18,7 +18,7 @@ esac
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.stack.v3/build.assert/mvm
+++ b/build.linux32x86/squeak.stack.v3/build.assert/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.stack.v3/build.debug/mvm
+++ b/build.linux32x86/squeak.stack.v3/build.debug/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux32x86/squeak.stack.v3/build/mvm
+++ b/build.linux32x86/squeak.stack.v3/build/mvm
@@ -19,7 +19,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64ARMv8/pharo.cog.spur/build/mvm
+++ b/build.linux64ARMv8/pharo.cog.spur/build/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64ARMv8/pharo.stack.spur/build.debug/mvm
+++ b/build.linux64ARMv8/pharo.stack.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64ARMv8/pharo.stack.spur/build/mvm
+++ b/build.linux64ARMv8/pharo.stack.spur/build/mvm
@@ -18,7 +18,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64ARMv8/squeak.stack.spur/build.assert/mvm
+++ b/build.linux64ARMv8/squeak.stack.spur/build.assert/mvm
@@ -7,7 +7,7 @@ OPT="-g3 -O1 -fwrapv -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DDEBU
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64ARMv8/squeak.stack.spur/build.debug/mvm
+++ b/build.linux64ARMv8/squeak.stack.spur/build.debug/mvm
@@ -7,7 +7,7 @@ OPT="-g3 -O0 -fwrapv -DDEBUGVM=1"
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64ARMv8/squeak.stack.spur/build/mvm
+++ b/build.linux64ARMv8/squeak.stack.spur/build/mvm
@@ -7,7 +7,7 @@ OPT="-g -O2 -fwrapv -DNDEBUG -DDEBUGVM=0"
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.assert/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.debug/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.cog.spur/build/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux64x64/newspeak.stack.spur/build.assert/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux64x64/newspeak.stack.spur/build.debug/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/newspeak.stack.spur/build/mvm
+++ b/build.linux64x64/newspeak.stack.spur/build/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/nsnac.cog.spur/build.assert/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.assert/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/nsnac.cog.spur/build.debug/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.debug/mvm
@@ -11,7 +11,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/nsnac.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.itimerheartbeat/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/nsnac.cog.spur/build/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	esac
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
@@ -14,7 +14,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.assert/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.assert/mvm
@@ -7,7 +7,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
@@ -14,7 +14,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.debug/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.debug/mvm
@@ -7,7 +7,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
@@ -23,7 +23,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur.minheadless/build/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build/mvm
@@ -7,7 +7,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.assert.itimerheartbeat/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur/build.assert/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.debug.itimerheartbeat/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur/build.debug/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.itimerheartbeat/mvm
@@ -14,7 +14,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/pharo.cog.spur/build/mvm
+++ b/build.linux64x64/pharo.cog.spur/build/mvm
@@ -15,7 +15,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur.immutability/build.assert/mvm
+++ b/build.linux64x64/squeak.cog.spur.immutability/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur.immutability/build.debug/mvm
+++ b/build.linux64x64/squeak.cog.spur.immutability/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur.immutability/build/mvm
+++ b/build.linux64x64/squeak.cog.spur.immutability/build/mvm
@@ -12,7 +12,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur/build.assert/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur/build.debug/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.itimerheartbeat/mvm
@@ -12,7 +12,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.cog.spur/build/mvm
+++ b/build.linux64x64/squeak.cog.spur/build/mvm
@@ -23,7 +23,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.stack.spur/build.assert/mvm
+++ b/build.linux64x64/squeak.stack.spur/build.assert/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.stack.spur/build.debug/mvm
+++ b/build.linux64x64/squeak.stack.spur/build.debug/mvm
@@ -8,7 +8,7 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in

--- a/build.linux64x64/squeak.stack.spur/build/mvm
+++ b/build.linux64x64/squeak.stack.spur/build/mvm
@@ -7,7 +7,7 @@ OPT="-g -O1 -fwrapv -DNDEBUG -DDEBUGVM=0"
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
-if ../../scripts/checkSCCSversion ; then exit 1; fi
+if ../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
 case $a in


### PR DESCRIPTION
for Linux `mvm` build scripts, changed path to `checkSCCSversion` to reflect its being three nestings away rather than two