### PR TITLE
Always call XInitThreads, not only on the Pharo VM. 

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -4280,11 +4280,10 @@ void initWindow(char *displayName)
   XRectangle windowBounds= { 0, 0, 640, 480 };  /* default window bounds */
   int right, bottom;
 
-#ifdef PharoVM
-  // Some libraries require Xlib multi-threading support. When using
-  // multi-threading XInitThreads() has to be first Xlib function called.
+  // Some libraries such as OpenGL and Vulkan drivers, require Xlib
+  // multi-threading support. When using multi-threading XInitThreads() has to
+  // be first Xlib function called.
   XInitThreads();
-#endif
 
   XSetErrorHandler(xError);
 


### PR DESCRIPTION
Otherwise, a segmentation fault on quit time is produced when using third party libraries such as Vulkan drivers that depend on it.

Here is the stack trace that I obtain:

C stack backtrace & registers:
	rax 0x7f9521972810 rbx 0x00000000 rcx 0x013df6a0 rdx 0x7f9522cf3ca0
	rdi 0x00000000 rsi 0x00000000 rbp 0x013cd090 rsp 0x7ffd0cf3f3d8
	r8  0x00000001 r9  0x00000007 r10 0x00000016 r11 0x00000000
	r12 0x013ddfe8 r13 0x00000000 r14 0x00000000 r15 0x00000000
	rip 0x7f9522d03960
*/lib/x86_64-linux-gnu/libpthread.so.0(__pthread_mutex_lock+0x0)[0x7f9522d03960]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak[0x41b7c3]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak[0x41d24e]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x12dd0)[0x7f9522d0bdd0]
/lib/x86_64-linux-gnu/libpthread.so.0(__pthread_mutex_lock+0x0)[0x7f9522d03960]
/usr/lib/x86_64-linux-gnu/libX11.so.6(XrmDestroyDatabase+0x27)[0x7f952198d287]
/usr/lib/x86_64-linux-gnu/libX11.so.6(_XFreeDisplayStructure+0x39b)[0x7f95219747ab]
/usr/lib/x86_64-linux-gnu/libX11.so.6(XCloseDisplay+0xdf)[0x7f9521961c4f]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/vm-display-X11.so(disconnectXDisplay+0xa6)[0x7f9521b28456]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak(ioExitWithErrorCode+0x21)[0x41dfe1]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak(interpret+0xa1f5)[0x467fd5]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak[0x469216]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak(interpret+0x246)[0x45e026]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak(main+0x2fa)[0x41acfa]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xeb)[0x7f9522b3309b]
sqcogspur64linuxht/lib/squeak/5.0-201906220205/squeak[0x41b024]
[0x0]
