### PR TITLE
Minheadless SqueakSSL plugin compilation bug fix

### DIFF
--- a/cmake/PluginsCommon.cmake
+++ b/cmake/PluginsCommon.cmake
@@ -96,6 +96,10 @@ if(DARWIN)
 endif()
 
 # Squeak SSL plugin
+# In the case of the minheadless VM for OS X, we are treating the VM as it were
+# an unix since we are removing all of the platform specific windowing code in
+# this VM variant. For this reason, in the cases where OS X is different than
+# another unix, the plugin code has to be added manually.
 if (APPLE)
 	set(SqueakSSL_Sources
 	    "platforms/iOS/plugins/SqueakSSL/sqMacSSL.c"

--- a/cmake/PluginsCommon.cmake
+++ b/cmake/PluginsCommon.cmake
@@ -100,7 +100,7 @@ if (APPLE)
 	set(SqueakSSL_Sources
 	    "platforms/iOS/plugins/SqueakSSL/sqMacSSL.c"
 	)
-	add_vm_plugin_sources(SqueakSSL EXTERNAL ${SqueakSSL_Sources})
+	add_vm_plugin_auto(SqueakSSL EXTERNAL ${SqueakSSL_Sources})
 	vm_plugin_link_libraries(SqueakSSL ${CoreFoundation_LIBRARY} ${Security_LIBRARY})
 else()
 	add_vm_plugin_auto(SqueakSSL EXTERNAL)


### PR DESCRIPTION
I fixed a mistake in the compilation of the SqueakSSL plugin in the minheadless VM for Mac.