### PR TITLE
hack to restore B3DAcceleratorPlugin on macos32x86

### DIFF
--- a/build.macos32x86/common/Makefile.plugin
+++ b/build.macos32x86/common/Makefile.plugin
@@ -63,7 +63,12 @@ endif
 
 CROSSDIR:=	$(PLATDIR)/Cross/plugins/$(LIBDIR)
 OSXDIR:=	$(PLATDIR)/iOS/vm/OSX
+#quick hack for B3DAcceleratorPlugin: no 32 bit METAL FRAMEWORK
+ifeq ($(LIBDIR),B3DAcceleratorPlugin)
+OSXPLGDIR:=	$(PLATDIR)/iOS/plugins/$(LIBDIR)32
+else
 OSXPLGDIR:=	$(PLATDIR)/iOS/plugins/$(LIBDIR)
+endif
 UNIXDIR:=	$(PLATDIR)/unix/vm
 MAKERDIR:=	$(PLUGINSRCDIR)/$(LIBDIR)
 BUILDDIR:=	$(BUILD)/$(LIBDIR)

--- a/build.macos32x86/common/Makefile.vm
+++ b/build.macos32x86/common/Makefile.vm
@@ -216,10 +216,12 @@ endif
 #
 .PHONY: $(OBJDIR)/%.lib $(OBJDIR)/%.bundle $(OBJDIR)/%.dylib
 
+hack-b3d = $(subst B3DAcceleratorPlugin,B3DAcceleratorPlugin32,$(1))
+
 ifeq ($(USEPLUGINASDYLIB),TRUE)
-plugin-makefile = $(firstword $(realpath $(OSXPLUGINSDIR)/$(subst lib,,$(1))/Makefile ../common/Makefile.plugin))
+plugin-makefile = $(firstword $(realpath $(OSXPLUGINSDIR)/$(subst lib,,$(call hack-b3d,$(1)))/Makefile ../common/Makefile.plugin))
 else
-plugin-makefile = $(firstword $(realpath $(OSXPLUGINSDIR)/$(1)/Makefile ../common/Makefile.plugin))
+plugin-makefile = $(firstword $(realpath $(OSXPLUGINSDIR)/$(call hack-b3d,$(1))/Makefile ../common/Makefile.plugin))
 endif
 
 # Internal plugin.  Build as lib then link in lib
@@ -241,7 +243,7 @@ prereqs/%.lib:
 	@-ls -rlt	$(call plugin-makefile,$(*F)) $(wildcard $(*F).ignore) \
 				$(wildcard $(PLUGINSRCDIR)/$(*F)/*.c) \
 				$(wildcard $(PLATDIR)/Cross/plugins/$(*F)/*.*) \
-				$(wildcard $(OSXPLUGINSDIR)/$(*F)/*.*)
+				$(wildcard $(OSXPLUGINSDIR)/$(call hack-b3d,$(*F))/*.*)
 
 # It would be nice to have this abbreviation but it creates havoc eem 2/2016
 #%.lib: $(OBJDIR)/%.lib

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/Makefile
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/Makefile
@@ -1,0 +1,14 @@
+# The current version of B3DAcceleratorPlugin (the OpenGL interface) uses lots
+# of Carbon code & is hence 32-bit only.  So include the Carbon frameworks.
+# Until this can be rewritten this implies no 64-bit OpenGL on Mac OS X :-(.
+
+INCDIRS:=$(PLATDIR)/Cross/plugins/FilePlugin \
+         $(PLATDIR)/unix/vm
+INCDIRS:=$(PLATDIR)/unix/vm
+
+EXTRADYFLAGS=-Wl,-U,_getImageName,-U,_getSTWindow,-U,_setWindowChangedHook,-U,_warning \
+	-Wl,-U,_getMainWindowOpenGLContext,-U,_createOpenGLTextureLayerHandle,-U,_destroyOpenGLTextureLayerHandle,-U,_setOpenGLTextureLayerContent
+EXTRALIBS:= -framework CoreFoundation -framework OpenGL -framework Cocoa
+#EXTRALIBS:= -framework OpenGL -framework AGL
+
+include ../common/Makefile.plugin

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/sqMacOpenGL.h
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/sqMacOpenGL.h
@@ -1,0 +1,47 @@
+#ifndef SQ_MAC_OPENGL_H
+#define SQ_MAC_OPENGL_H
+
+#define MAX_RENDERER 16
+	
+# import <OpenGL/gl.h>
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+# import <OpenGL/OpenGL.h>
+#else
+# import <OpenGL/Opengl.h>
+#endif
+
+typedef struct glRendererFramebuffer {
+	GLuint handle;
+	GLuint texture;
+	GLuint depthStencilBuffer;
+	
+	GLuint resolveFramebuffer;
+	GLuint multisampleColorbuffer;
+} glRendererFramebuffer;
+
+typedef struct glRenderer {
+    /* Required by the common implementation */
+	GLint bufferRect[4];
+	GLint viewport[4];
+    
+    int used;
+
+    void* theOpenGLContext;
+    unsigned int layerHandle;
+    
+	// Multi sampling
+	int hasMultisampling;
+	int sampleCount;
+	
+	// Depth and stencil buffer
+	int hasStencilBuffer;
+	GLenum depthStencilFormat;
+	
+	glRendererFramebuffer framebuffers[2];
+	unsigned int backBufferIndex;
+    
+} glRenderer;
+
+#define GL_RENDERER_DEFINED 1
+
+#endif /* SQ_MAC_OPENGL_H */

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/sqMacOpenGL.m
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/sqMacOpenGL.m
@@ -1,0 +1,403 @@
+/**
+ * Author: Ronie Salgado <roniesalg@gmail.com>
+ * License: MIT
+ * Based loosely on the previous implementation by Andreas Raab.
+ *
+ * Offscreen based glRenderer for the B3DAcceleratorPlugin. This uses the OpenGL
+ * framebuffer object facility to render into a offscreen texture that is
+ * shared with the OpenGL context of the main window. This is implemented in
+ * this way with the objective to cooperate with the OpenGL context of the main
+ * window by using a custom layering system.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Do not include the entire sq.h file but just those parts needed. */
+/*  The virtual machine proxy definition */
+#include "sqVirtualMachine.h"
+#include "sqAssert.h"
+/* Configuration options */
+#include "sqConfig.h"
+/* Platform specific definitions */
+#include "sqPlatformSpecific.h"
+#include "B3DAcceleratorPlugin.h"
+#include "sqMacOpenGL.h"
+#include "sqOpenGLRenderer.h"
+
+static glRenderer *currentGLRenderer = NULL;
+static glRenderer allRenderer[MAX_RENDERER];
+
+extern NSOpenGLContext *getMainWindowOpenGLContext(void);
+extern unsigned int createOpenGLTextureLayerHandle(void);
+extern void destroyOpenGLTextureLayerHandle(unsigned int handle);
+extern void setOpenGLTextureLayerContent(unsigned int handle, GLuint texture, int x, int y, int w, int h);
+
+static float blackLight[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    
+int
+glIsOverlayRenderer(int handle)
+{
+  return 0;
+}
+
+glRenderer *
+glRendererFromHandle(int handle) {
+    if(handle < 0 || handle >= MAX_RENDERER) return NULL;
+    if(allRenderer[handle].used) return &allRenderer[handle];
+    return NULL;
+}
+
+/*****************************************************************************/
+/*****************************************************************************/
+/*                      Renderer creation primitives                         */
+/*****************************************************************************/
+/*****************************************************************************/
+
+static int
+hasExtension(const char *extensionName) {
+    return strstr((const char*)glGetString(GL_EXTENSIONS), extensionName) != NULL;
+}
+
+static NSOpenGLPixelFormat *
+createPixelFormat(int flags)
+{
+    NSOpenGLPixelFormatAttribute attrs[] =
+    {
+        NSOpenGLPFAAccelerated,
+        NSOpenGLPFANoRecovery,
+        NSOpenGLPFAAllowOfflineRenderers, // Enables automatic graphics card switching
+        NSOpenGLPFADepthSize, 0,
+        NSOpenGLPFAStencilSize, 0,
+        0
+    };
+    return [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
+};
+
+static void
+createTextureStorage(glRenderer *renderer, GLuint texture, int w, int h)
+{
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+}
+
+static void
+createRenderbuffersStorage(glRenderer *renderer, glRendererFramebuffer *framebuffer, int w, int h)
+{
+    if(renderer->hasMultisampling) {
+        glBindRenderbufferEXT(GL_RENDERBUFFER, framebuffer->multisampleColorbuffer);
+        glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, renderer->sampleCount, GL_RGBA, w, h);
+
+        glBindRenderbufferEXT(GL_RENDERBUFFER, framebuffer->depthStencilBuffer);
+        glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, renderer->sampleCount, renderer->depthStencilFormat, w, h);
+    } else {
+        glBindRenderbufferEXT(GL_RENDERBUFFER, framebuffer->depthStencilBuffer);
+        glRenderbufferStorageEXT(GL_RENDERBUFFER, renderer->depthStencilFormat, w, h);
+    }
+}
+
+static void
+createRendererFramebuffer(glRenderer *renderer, glRendererFramebuffer *framebuffer, int w, int h)
+{
+    if(!framebuffer->handle) {
+        // Create the handles
+        glGenFramebuffersEXT(1, &framebuffer->handle);
+        glGenTextures(1, &framebuffer->texture);
+        glGenRenderbuffers(1, &framebuffer->depthStencilBuffer);
+        if(renderer->hasMultisampling) {
+            glGenFramebuffersEXT(1, &framebuffer->resolveFramebuffer);
+            glGenRenderbuffers(1, &framebuffer->multisampleColorbuffer);
+        }
+        
+        // Create the texture storage
+        createTextureStorage(renderer, framebuffer->texture, w, h);
+        
+        // Create the render buffer storage
+        createRenderbuffersStorage(renderer, framebuffer, w, h);
+        
+        if(renderer->hasMultisampling) {
+            // Link the texture with the resolve framebuffer
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebuffer->resolveFramebuffer);
+            glFramebufferTexture2D(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, framebuffer->texture, 0);
+            
+            // Link the framebuffer with the multi-sample render buffers.
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebuffer->handle);
+            glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, framebuffer->multisampleColorbuffer);
+        } else {
+            // Link the texture with the framebuffer
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebuffer->handle);
+            glFramebufferTexture2D(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, framebuffer->texture, 0);
+        }
+
+        // Link the depth stencil buffer
+        if(renderer->hasStencilBuffer)
+            glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_STENCIL_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, framebuffer->depthStencilBuffer);
+        glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, framebuffer->depthStencilBuffer);
+    } else {
+        // Recreate the sizes
+        createTextureStorage(renderer, framebuffer->texture, w, h);
+        createRenderbuffersStorage(renderer, framebuffer, w, h);
+    }
+    
+    if(renderer->hasMultisampling) {
+        // Check the framebuffer status.
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebuffer->resolveFramebuffer);
+        GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+        if(status != GL_FRAMEBUFFER_COMPLETE_EXT) {
+            fprintf(stderr, "OpenGL resolve FBO is not complete: %04x\n", status);
+        }
+    }
+    
+    // Check the framebuffer status.
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebuffer->handle);
+    GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+    if(status != GL_FRAMEBUFFER_COMPLETE_EXT) {
+        fprintf(stderr, "OpenGL FBO is not complete: %04x\n", status);
+    }
+}
+
+static void
+destroyRendererFramebuffer(glRenderer *renderer, glRendererFramebuffer *framebuffer)
+{
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+    glBindRenderbuffer(GL_RENDERBUFFER_EXT, 0);
+    glDeleteFramebuffersEXT(1, &framebuffer->handle);
+    if(renderer->hasMultisampling)
+        glDeleteFramebuffersEXT(1, &framebuffer->resolveFramebuffer);
+
+    glDeleteTextures(1, &framebuffer->texture);
+    glDeleteRenderbuffers(1, &framebuffer->depthStencilBuffer);
+    if(renderer->hasMultisampling)
+        glDeleteRenderbuffers(1, &framebuffer->multisampleColorbuffer);
+}
+
+static void
+createRendererFramebuffers(glRenderer *renderer, int w, int h)
+{
+    glBindFramebufferEXT(GL_FRAMEBUFFER, 0);
+    createRendererFramebuffer(renderer, &renderer->framebuffers[0], w, h);
+    createRendererFramebuffer(renderer, &renderer->framebuffers[1], w, h);
+    
+    glBindFramebufferEXT(GL_FRAMEBUFFER, renderer->framebuffers[renderer->backBufferIndex].handle);
+}
+
+int
+glCreateRendererFlags(int x, int y, int w, int h, int flags)
+{    
+    // Get the main opengl context
+    NSOpenGLContext *mainOpenGLContext = getMainWindowOpenGLContext();
+    if(!mainOpenGLContext)
+        return -1;
+        
+    // Find a free renderer slot.
+    int handle;
+    for(handle=0; handle < MAX_RENDERER; handle++) {
+        if(allRenderer[handle].used == 0)
+            break;
+    }
+    if(handle >= MAX_RENDERER)
+        return -1;
+    
+    // Allocate the layer, for compositing.    
+    glRenderer *renderer = &allRenderer[handle];
+    memset(renderer, 0, sizeof(glRenderer));
+    renderer->layerHandle = createOpenGLTextureLayerHandle();
+    if(!renderer->layerHandle)
+        return -1;
+    
+    // Create the OpenGL context.
+    NSOpenGLPixelFormat *pixelFormat = createPixelFormat(flags);
+    
+    NSOpenGLContext *theContext = [[NSOpenGLContext alloc] initWithFormat: pixelFormat shareContext: mainOpenGLContext];
+    DEALLOCOBJ(pixelFormat);
+    
+    // Make sure that the context is created successfully.
+    if(!theContext) {
+        destroyOpenGLTextureLayerHandle(renderer->layerHandle);
+        return -1;
+    }
+    
+    renderer->theOpenGLContext = (__bridge void *)theContext;
+    renderer->used = 1;
+    renderer->bufferRect[0] = x;
+    renderer->bufferRect[1] = y;
+    renderer->bufferRect[2] = w;
+    renderer->bufferRect[3] = h;
+    
+    // Activate the context
+    [theContext makeCurrentContext];
+
+    renderer->hasMultisampling = (flags & B3D_ANTIALIASING) && hasExtension("GL_ARB_multisample") && hasExtension("GL_EXT_framebuffer_multisample"); 
+    renderer->sampleCount = 4;
+    renderer->hasStencilBuffer = (flags & B3D_STENCIL_BUFFER) != 0;
+    renderer->depthStencilFormat = renderer->hasStencilBuffer ? GL_DEPTH24_STENCIL8_EXT : GL_DEPTH_COMPONENT16;
+    
+    // Print some information about the context
+    DPRINTF3D(3,("\nOpenGL vendor: %s\n", (const char*)glGetString(GL_VENDOR)));
+    DPRINTF3D(3,("OpenGL renderer: %s\n", (const char*)glGetString(GL_RENDERER)));
+    DPRINTF3D(3,("OpenGL version: %s\n", (const char*)glGetString(GL_VERSION)));
+    DPRINTF3D(3,("OpenGL extensions: %s\n", (const char*)glGetString(GL_EXTENSIONS)));
+    
+    createRendererFramebuffers(renderer, w, h);
+    
+    // Setup the context
+    glViewport(0, 0, w, h);
+    glDisable(GL_LIGHTING);
+    glDisable(GL_COLOR_MATERIAL);
+    glDisable(GL_BLEND);
+    glDisable(GL_ALPHA_TEST);
+    glEnable(GL_DITHER);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_NORMALIZE);
+    glDepthFunc(GL_LEQUAL);
+    glClearDepth(1.0);
+    glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+    ERROR_CHECK;
+    glShadeModel(GL_SMOOTH);
+    ERROR_CHECK_1("glShadeModel");
+    glLightModelfv(GL_LIGHT_MODEL_AMBIENT, blackLight);
+    ERROR_CHECK_1("glLightModelfv");
+    if(renderer->hasMultisampling)
+        glEnable(GL_MULTISAMPLE_ARB);
+
+    return handle;
+}
+
+void
+deleteRendererResources(glRenderer *renderer)
+{
+    destroyOpenGLTextureLayerHandle(renderer->layerHandle);
+    destroyRendererFramebuffer(renderer, &renderer->framebuffers[0]);
+    destroyRendererFramebuffer(renderer, &renderer->framebuffers[1]);
+}
+
+int
+glDestroyRenderer(int handle)
+{
+    glRenderer *renderer = glRendererFromHandle(handle);
+
+    if(!renderer) {
+        return 1; /* already destroyed */
+    }
+    
+    NSOpenGLContext *context = (__bridge NSOpenGLContext *)renderer->theOpenGLContext;
+    
+    // Delete the potentially shared resources
+    [context makeCurrentContext];
+    deleteRendererResources(renderer);
+    
+    // Destroy the context.
+    [NSOpenGLContext clearCurrentContext];
+    RELEASEOBJ(context);
+    
+    currentGLRenderer = NULL;
+    renderer->used = 0;
+    return 1;
+}
+
+int
+glMakeCurrentRenderer(glRenderer *renderer) {
+    if(currentGLRenderer == renderer)
+        return 1;
+        
+    if(renderer) {
+        if(!renderer->used || !renderer->theOpenGLContext)
+            return 0;
+    }
+    
+    NSOpenGLContext *context = (__bridge NSOpenGLContext *)renderer->theOpenGLContext;
+    [context makeCurrentContext];
+    currentGLRenderer = renderer;
+    
+    return 1;
+}
+
+int
+glSetBufferRect(int handle, int x, int y, int w, int h)
+{
+	glRenderer *renderer = glRendererFromHandle(handle);
+	if(!renderer || !glMakeCurrentRenderer(renderer))
+        return 0;
+    
+    // Do we need to resize the framebuffers?
+    if(renderer->bufferRect[2] != w || renderer->bufferRect[3] != h) {
+        createRendererFramebuffers(renderer, w, h);
+    }
+    
+    renderer->bufferRect[0] = x;
+    renderer->bufferRect[1] = y;
+    renderer->bufferRect[2] = w;
+    renderer->bufferRect[3] = h;
+    return 1;
+}
+
+int
+glGetIntPropertyOS(int handle, int prop)
+{
+    //TODO: Retrieve the swap interval
+    return 0;
+}
+
+int
+glSetIntPropertyOS(int handle, int prop, int value)
+{
+    //TODO: Set the swap interval
+	return 0;
+}
+
+int glSwapBuffers(glRenderer *renderer)
+{
+	if(!renderer || !glMakeCurrentRenderer(renderer))
+        return 0;
+        
+    // Resolve the multi-sampling.
+    if(renderer->hasMultisampling) {
+        int w = renderer->bufferRect[2];
+        int h = renderer->bufferRect[3];
+        glRendererFramebuffer *framebuffer = &renderer->framebuffers[renderer->backBufferIndex];
+        glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, framebuffer->handle);
+        glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, framebuffer->resolveFramebuffer);
+        glBlitFramebufferEXT(0, 0, w, h, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    }
+        
+    // Swap the buffer.
+    int frontBuffer = renderer->backBufferIndex;
+    renderer->backBufferIndex = (renderer->backBufferIndex + 1) % 2;
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, renderer->framebuffers[renderer->backBufferIndex].handle);
+    glFlush();
+    
+    // Flush the new front buffer.
+    setOpenGLTextureLayerContent(renderer->layerHandle, renderer->framebuffers[frontBuffer].texture,
+        renderer->bufferRect[0], renderer->bufferRect[1], renderer->bufferRect[2], renderer->bufferRect[3]);
+    return 1;
+}
+
+/***************************************************************************
+ ***************************************************************************
+					Module initializers
+ ***************************************************************************
+ ***************************************************************************/
+
+int
+glInitialize(void)
+{
+    memset(allRenderer, 0, sizeof(allRenderer));
+    glVerbosityLevel = 5;
+    return 1;
+}
+
+int
+glShutdown(void)
+{
+	int i;
+	for (i = 0; i < MAX_RENDERER; i++) {
+		if (allRenderer[i].used) {
+			glDestroyRenderer(i);
+        }
+    }
+    return 1;
+}

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacOpenGL.c
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacOpenGL.c
@@ -1,0 +1,690 @@
+/****************************************************************************
+*   PROJECT: Squeak 3D accelerator
+*   FILE:    sqMacOpenGL.c
+*   CONTENT: MacOS specific bindings for OpenGL
+*
+*   AUTHOR:  Andreas Raab (ar)
+*   ADDRESS: Walt Disney Imagineering, Glendale, CA
+*   EMAIL:   Andreas.Raab@disney.com
+*   RCSID:   $Id: sqMacOpenGL.c 1367 2006-03-21 06:49:10Z johnmci $
+*
+*   NOTES:
+*
+*	Changes May 14th 2001 John M McIntosh Carbon support
+*   Changes Jun 2001 JMM browser internal plugin support
+* 	Changes Jan 2002 JMM carbon cleanup
+*  Feb 26th, 2002, JMM - use carbon get dominate device
+*  Apr 3rd, 2003, JMM - use BROWSERPLUGIN
+*
+*****************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <Carbon/Carbon.h>
+//#include <QuickTime/QTML.h> /* unavailable in 64-bit apps :-( */
+//#include <QuickTime/QuickTimeComponents.h> /* unavailable in 64-bit apps :-( */
+#include <unistd.h>
+#include <AGL/agl.h>
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+# include <OpenGL/gl.h>
+# define useTempMem (1L << 2) //This declaration is taken from old sdk definition.
+#else
+# include <AGL/gl.h>
+#endif
+#include <OpenGL/OpenGL.h>
+/* Do not include the entire sq.h file but just those parts needed. */
+/*  The virtual machine proxy definition */
+#include "sqVirtualMachine.h"
+#include "sqAssert.h"
+/* Configuration options */
+#include "sqConfig.h"
+/* Platform specific definitions */
+#include "sqPlatformSpecific.h"
+#include "sqMacUIConstants.h"
+#include "B3DAcceleratorPlugin.h"
+#include "sqMacOpenGL.h"
+#include "sqOpenGLRenderer.h"
+
+#ifdef BROWSERPLUGIN
+#include "npapi.h"
+#endif
+
+int printRendererInfo(void);
+int printFormatInfo(AGLPixelFormat info);
+
+static glRenderer *current = NULL;
+static glRenderer allRenderer[MAX_RENDERER];
+
+#ifdef BROWSERPLUGIN
+int gPortX,gPortY;
+extern NP_Port *getNP_Port(void);
+void StartDraw(void);
+void EndDraw(void);
+#endif
+/* N.B. Whether this is built as an internal (SQUEAK_BUILTIN_PLUGIN) or
+ * external plugin, we still directly access symbols from the VM.  See the
+ * Makefile in this directory and its use of -bundle_loader to check for
+ * available exports from the main VM.
+ */
+typedef void (*windowChangedHook)();
+extern windowChangedHook setWindowChangedHook(windowChangedHook hook);
+windowChangedHook existingHook = 0;
+
+
+static float blackLight[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+/*****************************************************************************/
+/*****************************************************************************/
+/*                      Mac window changed hook                              */
+/*****************************************************************************/
+/*****************************************************************************/
+
+static void
+windowChangedProc(void)
+{
+	int i;
+	AGLDrawable win;
+	static WindowPtr oldWindow = NULL;
+#ifdef BROWSERPLUGIN
+	NP_Port	*anNPPort;
+#endif
+
+	if (existingHook)
+		existingHook();
+	if (!(win = (AGLDrawable) getSTWindow()))
+		return;
+	if (!oldWindow)
+		oldWindow = win;
+	for (i = 0; i < MAX_RENDERER; i++) {
+		glRenderer *renderer = allRenderer+i;
+		if (renderer->used
+		 && (renderer->drawable == win
+		  || (WindowPtr)(renderer->drawable) == oldWindow)) {
+			int		x,y,w,h;
+			Rect	portRect;
+			GLint 	bufferRect[4];
+			CGrafPtr	windowPort;
+
+#ifdef BROWSERPLUGIN
+			StartDraw();
+			anNPPort = getNP_Port();
+			gPortX = anNPPort->portx;
+			gPortY = anNPPort->porty;
+			x = renderer->bufferRect[0] - gPortX;
+			y = renderer->bufferRect[1] - gPortY;
+#else
+			x = renderer->bufferRect[0];
+			y = renderer->bufferRect[1];
+#endif
+			w = renderer->bufferRect[2];
+			h = renderer->bufferRect[3];
+
+			windowPort = GetWindowPort((WindowPtr)win);
+			GetPortBounds(windowPort,&portRect);
+
+			bufferRect[0] = x;
+			bufferRect[1] = portRect.bottom - portRect.top - (y+h);
+			bufferRect[2] = w;
+			bufferRect[3] = h;
+
+			// aglSetDrawable(renderer->context,nil);
+			renderer->drawable = (AGLDrawable) win;
+			aglSetDrawable(renderer->context,windowPort);
+			aglSetInteger(renderer->context, AGL_BUFFER_RECT, bufferRect);
+			aglUpdateContext(renderer->context);
+#ifdef BROWSERPLUGIN
+			EndDraw();
+#endif
+		}
+	}
+	oldWindow = win;
+}
+
+/*****************************************************************************/
+/*****************************************************************************/
+/*                      Renderer creation primitives                         */
+/*****************************************************************************/
+/*****************************************************************************/
+
+int glDestroyRenderer(int handle)
+{
+	glRenderer *renderer = glRendererFromHandle(handle);
+
+	if(!renderer) return 1; /* already destroyed */
+
+	/* Now really destroy the renderer */
+	if(renderer->drawable) {
+		/* was a direct drawable */
+		aglSetDrawable(renderer->context, NULL);
+	}
+	if(renderer == current)
+		glMakeCurrentRenderer(NULL);
+	aglDestroyContext(renderer->context);
+	if(renderer->gWorld) {
+		UnlockPixels(renderer->pixMap);
+		DisposeGWorld(renderer->gWorld);
+	}
+	renderer->context = (AGLContext) NULL;
+	renderer->drawable = (AGLDrawable) NULL;
+	renderer->gWorld = NULL;
+	renderer->used = 0;
+	return 1;
+}
+
+/*
+ * Is ARB_Multisample supported?
+ */
+static int glHasARBMultisampling () {
+
+	/* We need an open gl connection in which to test for extensions,
+	 * so we setup a throwaway context.
+	 */
+	GLint attrib[] = { AGL_RGBA, AGL_NONE};
+	AGLContext ctx;
+	AGLPixelFormat fmt = aglChoosePixelFormat(NULL, 0, attrib);
+
+	if (! fmt) { return 0; }
+	ctx = aglCreateContext(fmt, NULL);
+	aglDestroyPixelFormat(fmt);
+	if (! ctx) {
+		return 0;
+	}
+	aglSetCurrentContext(ctx);
+	int result = gluCheckExtension((const GLubyte*) "GL_ARB_multisample", glGetString(GL_EXTENSIONS));
+	aglDestroyContext(ctx);
+
+	return result;
+}
+
+
+#if !defined(SQUEAK_BUILTIN_PLUGIN)
+/* This beauty is taken from the sqMacSSL plugin.
+ * It should be a platform-wide facility.
+ */
+static int
+printf_status(OSStatus status, const char* restrict format, ...)
+{
+    int ret = 0;
+    va_list args;
+    va_start(args, format);
+    CFErrorRef _e = CFErrorCreate(NULL, kCFErrorDomainOSStatus, status, NULL);
+    CFStringRef _sdesc = CFErrorCopyDescription(_e);
+    CFStringRef _sreas = CFErrorCopyFailureReason(_e);
+    CFStringRef _sreco = CFErrorCopyRecoverySuggestion(_e);
+    ret += vprintf(format, args);
+    ret += printf("Status (%d): %s (%s): %s\n",
+                  (int)status,
+                  CFStringGetCStringPtr(_sdesc, kCFStringEncodingUTF8),
+                  CFStringGetCStringPtr(_sreas, kCFStringEncodingUTF8),
+                  CFStringGetCStringPtr(_sreco, kCFStringEncodingUTF8));
+    CFRelease(_sreco);
+    CFRelease(_sreas);
+    CFRelease(_sdesc);
+    CFRelease(_e);
+    va_end(args);
+    return ret;
+}
+
+/* See https://lists.apple.com/archives/mac-opengl/2006/Jun/msg00021.html */
+static GDHandle
+GetMainDevice()
+{	CGDirectDisplayID mainID = CGMainDisplayID();
+	GDHandle mainDevice;
+
+	OSErr err = DMGetGDeviceByDisplayID (mainID, &mainDevice, true);
+
+	if (err != noErr) {
+		printf_status(err, "DMGetGDeviceByDisplayID(...)\n");
+		exit(0);
+	}
+	return mainDevice;
+}
+#endif /* SQUEAK_BUILTIN_PLUGIN */
+
+
+int
+glCreateRendererFlags(int x, int y, int w, int h, int flags)
+{
+ 	int index, i, allowSoftware, allowHardware;
+ 	GLint          hwAttrib[] = { AGL_STENCIL_SIZE, 0, AGL_RGBA, AGL_DOUBLEBUFFER, AGL_ACCELERATED, AGL_DEPTH_SIZE, 16,
+				      AGL_SAMPLE_BUFFERS_ARB, 1, AGL_SAMPLES_ARB, 4, AGL_MULTISAMPLE, AGL_NO_RECOVERY, AGL_NONE};
+				      /* Note - we honor antialiasing requests only for hardware renderers. */
+ 	GLint          swAttrib[] = { AGL_STENCIL_SIZE, 0, AGL_RGBA, AGL_PIXEL_SIZE, 0, AGL_OFFSCREEN, AGL_DEPTH_SIZE, 16, AGL_NONE };
+	AGLPixelFormat fmt;
+	AGLContext     ctx;
+	GLboolean      ok;
+	GLenum         err;
+	AGLDrawable    win;
+	glRenderer     *renderer;
+	char *string;
+ 	long swapInterval = 0;
+#ifdef SQUEAK_BUILTIN_PLUGIN
+	Rect ignore;
+	GDHandle tempGDH;
+#endif
+
+#define SUPPORTED_FLAGS (B3D_HARDWARE_RENDERER | B3D_SOFTWARE_RENDERER | B3D_STENCIL_BUFFER | B3D_ANTIALIASING | B3D_STEREO | B3D_SYNCVBL)
+	if(flags & ~SUPPORTED_FLAGS) {
+		DPRINTF3D(1, ("ERROR: Unsupported renderer flags (%d)\n", flags));
+		return -1;
+	}
+#undef SUPPORTED_FLAGS
+
+	/* interpret renderer flags */
+	allowSoftware = (flags & B3D_SOFTWARE_RENDERER) != 0;
+	allowHardware = (flags & B3D_HARDWARE_RENDERER) != 0;
+	if(flags & B3D_STENCIL_BUFFER) {
+		hwAttrib[1] = 1;
+		swAttrib[1] = 1;
+	}
+
+	/* enable/disable stereo requests */
+	if(flags & B3D_STEREO) {
+		return -1; /* not supported for now */
+	}
+
+	/* Suppress the multisampling flags if antialiasing is not requested (or not supported.) */
+	if (! ((flags & B3D_ANTIALIASING) && glHasARBMultisampling())) {
+		hwAttrib[7] = AGL_NONE;
+	}
+
+	for(index=0; index < MAX_RENDERER; index++) {
+		if(allRenderer[index].used == 0) break;
+	}
+	if(index >= MAX_RENDERER) {
+		DPRINTF3D(1, ("ERROR: Maximum number of renderers (%d) exceeded\n", MAX_RENDERER));
+		return 0;
+	}
+	renderer = allRenderer+index;
+	renderer->used = 0;
+	renderer->finished = 0;
+	renderer->context = NULL;
+	renderer->drawable = NULL;
+	renderer->gWorld = NULL;
+
+#ifdef SQUEAK_BUILTIN_PLUGIN
+	if (! getSTWindow())
+		return 0;
+	GetWindowGreatestAreaDevice(getSTWindow(),kWindowContentRgn,&tempGDH,&ignore);
+	if (tempGDH == nil)
+		return -1;
+	swAttrib[2] = (*(*tempGDH)->gdPMap)->pixelSize;
+#else
+	swAttrib[2] = (*(*GetMainDevice())->gdPMap)->pixelSize;
+#endif
+	if(swAttrib[2] < 16) swAttrib[2] = 16;
+
+	/* Choose an rgb pixel format */
+	for(i = 0; i<2; i++) {
+		if( (i == 0) && !allowHardware) continue;
+		if( (i == 1) && !allowSoftware) continue;
+		ctx = 0;
+		if(i == 0) {
+			DPRINTF3D(3, ("### Attempting to find hardware renderer\n"));
+			win = (AGLDrawable) getSTWindow();
+			if(!win) {
+				DPRINTF3D(1, ("ERROR: stWindow is invalid (NULL)\n"));
+				goto FAILED;
+			}
+			fmt = aglChoosePixelFormat(NULL, 0, hwAttrib);
+		} else {
+			DPRINTF3D(3, ("### Attempting to find software renderer\n"));
+			win = NULL;
+			fmt = aglChoosePixelFormat(NULL, 0, swAttrib);
+		}
+		DPRINTF3D(3, ("\tx: %d\n\ty: %d\n\tw: %d\n\th: %d\n", x, y, w, h));
+
+		if((err = aglGetError()) != AGL_NO_ERROR) DPRINTF3D(3,("aglGetError - %s\n", aglErrorString(err)));
+		if(fmt == NULL) {
+			DPRINTF3D(1, ("ERROR: aglChoosePixelFormat failed\n"));
+			goto FAILED;
+		}
+
+		printFormatInfo(fmt);
+
+		/* Create an AGL context */
+		ctx = aglCreateContext(fmt, NULL);
+		if((err = aglGetError()) != AGL_NO_ERROR) DPRINTF3D(3,("aglGetError - %s\n", aglErrorString(err)));
+		/* The pixel format is no longer needed */
+		aglDestroyPixelFormat(fmt);
+		if(ctx == NULL) {
+			DPRINTF3D(1, ("ERROR: aglCreateContext failed\n"));
+			goto FAILED;
+		}
+
+		if(i == 0) {
+			GLint bufferRect[4];
+			Rect	portRect;
+
+#ifdef BROWSERPLUGIN
+			NP_Port	*anNPPort;
+
+			StartDraw();
+ 			win = (AGLDrawable) getSTWindow();
+ 			anNPPort = getNP_Port();
+
+			GetPortBounds(GetWindowPort((WindowPtr)win),&portRect);
+			bufferRect[0] = x - anNPPort->portx;
+			bufferRect[1] = portRect.bottom - portRect.top - (y+h)  + anNPPort->porty;
+			bufferRect[2] = w;
+			bufferRect[3] = h;
+			EndDraw();
+#else
+			GetPortBounds(GetWindowPort((WindowPtr)win),&portRect);
+			bufferRect[0] = x;
+			bufferRect[1] = portRect.bottom - portRect.top - (y+h);
+			bufferRect[2] = w;
+			bufferRect[3] = h;
+#endif
+
+			/* hardware renderer; attach buffer rect and window */
+			ok = aglEnable(ctx, AGL_BUFFER_RECT);
+			if((err = aglGetError()) != AGL_NO_ERROR)
+				DPRINTF3D(3,("aglEnable(AGL_BUFFER_RECT) failed: aglGetError - %s\n", aglErrorString(err)));
+			if(!ok) goto FAILED;
+			ok = aglSetInteger(ctx, AGL_BUFFER_RECT, bufferRect);
+			if((err = aglGetError()) != AGL_NO_ERROR)
+				DPRINTF3D(3,("aglSetInteger(AGL_BUFFER_RECT) failed: aglGetError - %s\n", aglErrorString(err)));
+			if(!ok) goto FAILED;
+			/* Attach the context to the target */
+			ok = aglSetDrawable(ctx,GetWindowPort( (WindowPtr)win));
+			if((err = aglGetError()) != AGL_NO_ERROR)
+				DPRINTF3D(3,("aglSetDrawable() failed: aglGetError - %s\n", aglErrorString(err)));
+			if(!ok) goto FAILED;
+			renderer->drawable = (AGLDrawable) win;
+
+			/* Set VBL SYNC if requested */
+			if(flags & B3D_SYNCVBL) swapInterval = 1;
+			aglSetInteger(ctx, AGL_SWAP_INTERVAL, &swapInterval);
+
+		} else {
+			/* software renderer; attach offscreen buffer to context */
+			Rect rect;
+			QDErr qdErr;
+
+			renderer->depth = swAttrib[2];
+			/* Create the offscreen gworld */
+			SetRect(&rect, 0, 0, w, h);
+			qdErr = NewGWorld(&renderer->gWorld, (short) renderer->depth, &rect, NULL, NULL, useTempMem);
+			if(qdErr || !renderer->gWorld) {
+				DPRINTF3D(1,("ERROR: Failed to create new GWorld\n"));
+				renderer->gWorld = NULL;
+				goto FAILED;
+			}
+			renderer->pixMap = GetGWorldPixMap(renderer->gWorld);
+			LockPixels(renderer->pixMap);
+			renderer->pitch = (**(renderer->pixMap)).rowBytes & 0x7FFF;
+			renderer->bits = (unsigned char*) GetPixBaseAddr(renderer->pixMap);
+			ok = aglSetOffScreen(ctx, w, h, renderer->pitch, renderer->bits);
+			if((err = aglGetError()) != AGL_NO_ERROR) DPRINTF3D(3,("aglGetError - %s\n", aglErrorString(err)));
+			if(!ok) {
+				DPRINTF3D(1, ("ERROR: aglSetOffScreen failed\n"));
+				goto FAILED;
+			}
+		}
+		renderer->context = ctx;
+		renderer->used = 1;
+		renderer->finished = 0;
+		renderer->bufferRect[0] = x;
+		renderer->bufferRect[1] = y;
+		renderer->bufferRect[2] = w;
+		renderer->bufferRect[3] = h;
+
+		/* Make the context the current context */
+		glMakeCurrentRenderer(renderer);
+
+		/* finally, try to enable multithreaded OpenGL */
+		if (0) /* disable it, because it's broken */
+		{
+			CGLContextObj cglContext = CGLGetCurrentContext();
+			CGLError cglErr =  CGLEnable( cglContext, kCGLCEMPEngine);
+			if (cglErr != kCGLNoError ) {
+				DPRINTF3D(3,("CGLEnable(kCGLCEMPEngine) failed: cannot set multithreaded OpenGL\n"));
+				exit(0);
+			}
+		}
+
+		/* print some information about the context */
+		string = (char*) glGetString(GL_VENDOR);
+		DPRINTF3D(3,("\nOpenGL vendor: %s\n", string));
+		string = (char*) glGetString(GL_RENDERER);
+		DPRINTF3D(3,("OpenGL renderer: %s\n", string));
+		string = (char*) glGetString(GL_VERSION);
+		DPRINTF3D(3,("OpenGL version: %s\n", string));
+		string = (char*) glGetString(GL_EXTENSIONS);
+		DPRINTF3D(3,("OpenGL extensions: %s\n", string));
+		ERROR_CHECK;
+
+		DPRINTF3D(3, ("### Renderer created! (id = %d)\n", index));
+		/* setup user context */
+		glDisable(GL_LIGHTING);
+		glDisable(GL_COLOR_MATERIAL);
+		glDisable(GL_BLEND);
+		glDisable(GL_ALPHA_TEST);
+		glEnable(GL_DITHER);
+		glEnable(GL_DEPTH_TEST);
+		glEnable(GL_NORMALIZE);
+		glDepthFunc(GL_LEQUAL);
+		glClearDepth(1.0);
+		glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+		ERROR_CHECK;
+		glShadeModel(GL_SMOOTH);
+		ERROR_CHECK_1("glShadeModel");
+		glLightModelfv(GL_LIGHT_MODEL_AMBIENT, blackLight);
+		ERROR_CHECK_1("glLightModelfv");
+
+		return index;
+FAILED:
+		if(ctx) aglDestroyContext(ctx);
+		if(renderer->gWorld) DisposeGWorld(renderer->gWorld);
+	}
+	return -1;
+}
+
+/*****************************************************************************/
+/*****************************************************************************/
+
+int glGetIntPropertyOS(int handle, int prop)
+{
+	GLint v;
+	glRenderer *renderer = glRendererFromHandle(handle);
+	if(!renderer || !glMakeCurrentRenderer(renderer)) return 0;
+
+	switch(prop) {
+		case -1: /* vertical blank synchronization */
+			aglGetInteger(renderer->context, AGL_SWAP_INTERVAL, &v);
+			return v;
+	}
+	return 0;
+}
+
+int glSetIntPropertyOS(int handle, int prop, int value)
+{
+	glRenderer *renderer = glRendererFromHandle(handle);
+	if(!renderer || !glMakeCurrentRenderer(renderer)) return 0;
+
+	switch(prop) {
+		case -1: /* vertical blank synchronization */
+			aglSetInteger(renderer->context, AGL_SWAP_INTERVAL, (GLint*) &value);
+			return 1;
+	}
+	return 0;
+}
+
+
+glRenderer *glRendererFromHandle(int handle) {
+	DPRINTF3D(7, ("Looking for renderer id: %d\n", handle));
+	if(handle < 0 || handle >= MAX_RENDERER) return NULL;
+	if(allRenderer[handle].used) return allRenderer+handle;
+	return NULL;
+}
+
+int glSwapBuffers(glRenderer *renderer) {
+	GLint err;
+
+	assert(!glErr);
+	ERROR_CHECK_1("glErr already set on calling glSwapBuffers");
+	if(!renderer) return 0;
+	if(!renderer->used || !renderer->context) return 0;
+	if(renderer->drawable) {
+#ifdef BROWSERPLUGIN
+		NP_Port	*anNPPort;
+
+		anNPPort = getNP_Port();
+		if (!(anNPPort->portx == gPortX && anNPPort->porty == gPortY)) {
+			return 0;
+		}
+#endif
+		aglSwapBuffers(renderer->context);
+		if((err = aglGetError()) != AGL_NO_ERROR) DPRINTF3D(3,("ERROR (aglSwapBuffers): aglGetError - %s\n", aglErrorString(err)));
+		ERROR_CHECK_1("aglSwapBuffers");
+	}
+	else {
+#if 0	/* No CopyBits or QDSwapPort in the Mac OS X 10.9 SDK */
+		/* But off screen renderers don't appear to be used.  Fingers crossed. */
+		WindowPtr win;
+		Rect src, dst, portBounds;
+		GrafPtr oldPort,winPort;
+		Boolean portChanged;
+
+		/* ensure execution for offscreen contexts */
+		glFinish();
+		ERROR_CHECK;
+		/* Copy the image to the window */
+
+		win =  getSTWindow();
+		if(!win) return 0;
+
+		winPort = (GrafPtr) GetWindowPort((WindowRef) win);
+# ifdef BROWSERPLUGIN
+		StartDraw();
+# else
+		portChanged = QDSwapPort(winPort, &oldPort);
+		GetPortBounds((CGrafPtr) winPort,&portBounds);
+
+//  Draw into the new port here
+
+# endif
+		SetRect(&src, 0, 0, renderer->bufferRect[2], renderer->bufferRect[3]);
+		SetRect(&dst, renderer->bufferRect[0], renderer->bufferRect[1],
+				renderer->bufferRect[0] + renderer->bufferRect[2],
+				renderer->bufferRect[1] + renderer->bufferRect[3]);
+		CopyBits(GetPortBitMapForCopyBits(renderer->gWorld), GetPortBitMapForCopyBits((CGrafPtr) winPort), &src, &dst, srcCopy, NULL);
+# ifdef BROWSERPLUGIN
+		EndDraw();
+# else
+		if (portChanged)
+			QDSwapPort(oldPort, NULL);
+# endif
+#else /* 0 */
+		DPRINTF3D(1,("ERROR glSwapBuffers: swapping of off-screen renderers UNIMPLEMENTED!\n"));
+#endif
+	}
+	return 1;
+}
+
+int glMakeCurrentRenderer(glRenderer *renderer) {
+	GLboolean ok;
+	GLint err;
+
+	if(current == renderer) return 1;
+	if(renderer)
+		if(!renderer->used || !renderer->context) return 0;
+	// ERROR_CHECK;
+	ok = aglSetCurrentContext(renderer ? renderer->context : NULL);
+	if((err = aglGetError()) != AGL_NO_ERROR) DPRINTF3D(3,("ERROR (glMakeCurrentRenderer): aglGetError - %s\n", aglErrorString(err)));
+	if(!ok) {
+		DPRINTF3D(1, ("ERROR (glMakeCurrentRenderer): aglSetCurrentContext failed\n"));
+		return 0;
+	}
+	// ERROR_CHECK;
+	current = renderer;
+	return 1;
+}
+
+int glSetBufferRect(int handle, int x, int y, int w, int h) {
+	glRenderer *renderer = glRendererFromHandle(handle);
+	if(!renderer || !glMakeCurrentRenderer(renderer)) return 0;
+	if(renderer->drawable) {
+		/* hardware renderer */
+		GLboolean ok;
+		GLenum err;
+		GLint bufferRect[4];
+		Rect	portRect;
+
+#ifdef BROWSERPLUGIN
+		AGLDrawable	win;
+		NP_Port	*anNPPort;
+
+		StartDraw();
+		win = (AGLDrawable) getSTWindow();
+		anNPPort = getNP_Port();
+
+		GetPortBounds(GetWindowPort((WindowPtr)win),&portRect);
+		bufferRect[0] = x - anNPPort->portx;
+		bufferRect[1] = portRect.bottom - portRect.top - (y+h)  + anNPPort->porty;
+		bufferRect[2] = w;
+		bufferRect[3] = h;
+
+		EndDraw();
+#else
+		GetPortBounds(GetWindowPort((WindowPtr) renderer->drawable),&portRect);
+		bufferRect[0] = x;
+		bufferRect[1] = portRect.bottom - portRect.top - (y+h);
+		bufferRect[2] = w;
+		bufferRect[3] = h;
+#endif
+		ok = aglSetInteger(renderer->context, AGL_BUFFER_RECT, bufferRect);
+		if((err = aglGetError()) != AGL_NO_ERROR)
+			DPRINTF3D(3,("aglSetInteger(AGL_BUFFER_RECT) failed: aglGetError - %s\n", aglErrorString(err)));
+		if(!ok) return 0;
+	} else {
+		/* software renderer */
+		if(renderer->bufferRect[2] != w && renderer->bufferRect[3] != h) {
+			/* do not allow resizing the software renderer */
+			return 0;
+		}
+	}
+	renderer->bufferRect[0] = x;
+	renderer->bufferRect[1] = y;
+	renderer->bufferRect[2] = w;
+	renderer->bufferRect[3] = h;
+	return 1;
+}
+
+
+int glIsOverlayRenderer(int handle) {
+#pragma unused(handle)
+  /* we never use overlay renderers */
+  return 0;
+}
+
+/***************************************************************************
+ ***************************************************************************
+					Module initializers
+ ***************************************************************************
+ ***************************************************************************/
+
+int
+glInitialize(void)
+{
+	int i;
+	for (i = 0; i < MAX_RENDERER; i++)
+		allRenderer[i].used = 0;
+
+	glVerbosityLevel = 5;
+
+	existingHook = setWindowChangedHook(windowChangedProc);
+	return 1;
+}
+
+int
+glShutdown(void)
+{
+	int i;
+	for (i = 0; i < MAX_RENDERER; i++)
+		if (allRenderer[i].used)
+			glDestroyRenderer(i);
+	setWindowChangedHook(existingHook);
+	return 1;
+}

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacOpenGL.h
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacOpenGL.h
@@ -1,0 +1,38 @@
+#ifndef SQ_MAC_OPENGL_H
+#define SQ_MAC_OPENGL_H
+
+#define MAX_RENDERER 16
+	
+#if defined(__MWERKS__) 
+#include <agl.h>
+#include <gl.h>
+#else
+#include <AGL/agl.h>
+#ifdef MAC_OS_X_VERSION_10_7
+#include <OpenGL/gl.h>
+#else
+#include <AGL/gl.h>
+#endif
+#endif
+typedef struct glRenderer {
+	GLint bufferRect[4];
+	GLint viewport[4];
+
+	int used;
+	int finished;
+	AGLContext context;
+
+	/* hardware attributes */
+	AGLDrawable drawable;
+
+	/* software attributes */
+	GWorldPtr gWorld;
+	PixMapHandle pixMap;
+	int depth;
+	int pitch;
+	unsigned char *bits;
+} glRenderer;
+
+#define GL_RENDERER_DEFINED 1
+
+#endif /* SQ_MAC_OPENGL_H */

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacOpenGLInfo.c
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacOpenGLInfo.c
@@ -1,0 +1,324 @@
+/****************************************************************************
+*   PROJECT: Squeak 3D accelerator
+*   FILE:    sqMacOpenGLInfo.c
+*   CONTENT: MacOS specific bindings for OpenGL
+*
+*   AUTHOR:  Andreas Raab (ar)
+*   ADDRESS: Walt Disney Imagineering, Glendale, CA
+*   EMAIL:   Andreas.Raab@disney.com
+*   RCSID:   $Id: sqMacOpenGLInfo.c 1708 2007-06-10 00:40:04Z johnmci $
+*
+*   NOTES: eem 2017/04/29 simplified logging for use within Cocoa build.
+*
+*****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <Carbon/Carbon.h>
+//#include <QuickTime/QTML.h> /* unavailable in 64-bit apps :-( */
+//#include <QuickTime/QuickTimeComponents.h> /* unavailable in 64-bit apps :-( */
+#include <OpenGL/gl.h>
+#ifdef MAC_OS_X_VERSION_10_7
+# include <OpenGL/gl.h>
+#else 
+# include <AGL/gl.h>
+#endif
+#include <AGL/agl.h>
+
+#include "sq.h"
+#include "sqVirtualMachine.h"
+#include "sqMacUIConstants.h"
+#include "sqOpenGLRenderer.h"
+
+int printRendererInfo(void);
+int printFormatInfo(AGLPixelFormat info);
+
+/*****************************************************************************/
+/*****************************************************************************/
+/*****************************************************************************/
+/*****************************************************************************/
+
+static void PrintBufferModes(GLint v)
+{
+	if(v & AGL_MONOSCOPIC_BIT)   DPRINTF3D(3,("            AGL_MONOSCOPIC_BIT\n"));
+	if(v & AGL_STEREOSCOPIC_BIT) DPRINTF3D(3,("            AGL_STEREOSCOPIC_BIT\n"));
+	if(v & AGL_SINGLEBUFFER_BIT) DPRINTF3D(3,("            AGL_SINGLEBUFFER_BIT\n"));
+	if(v & AGL_DOUBLEBUFFER_BIT) DPRINTF3D(3,("            AGL_DOUBLEBUFFER_BIT\n"));
+}
+
+static void PrintColorModes(GLint v)
+{
+	if(v & AGL_RGB8_BIT)         DPRINTF3D(3,("            AGL_RGB8_BIT\n"));
+	if(v & AGL_RGB8_A8_BIT)      DPRINTF3D(3,("            AGL_RGB8_A8_BIT\n"));
+	if(v & AGL_BGR233_BIT)       DPRINTF3D(3,("            AGL_BGR233_BIT\n"));
+	if(v & AGL_BGR233_A8_BIT)    DPRINTF3D(3,("            AGL_BGR233_A8_BIT\n"));
+	if(v & AGL_RGB332_BIT)       DPRINTF3D(3,("            AGL_RGB332_BIT\n"));
+	if(v & AGL_RGB332_A8_BIT)    DPRINTF3D(3,("            AGL_RGB332_A8_BIT\n"));
+	if(v & AGL_RGB444_BIT)       DPRINTF3D(3,("            AGL_RGB444_BIT\n"));
+	if(v & AGL_ARGB4444_BIT)     DPRINTF3D(3,("            AGL_ARGB4444_BIT\n"));
+	if(v & AGL_RGB444_A8_BIT)    DPRINTF3D(3,("            AGL_RGB444_A8_BIT\n"));
+	if(v & AGL_RGB555_BIT)       DPRINTF3D(3,("            AGL_RGB555_BIT\n"));
+	if(v & AGL_ARGB1555_BIT)     DPRINTF3D(3,("            AGL_ARGB1555_BIT\n"));
+	if(v & AGL_RGB555_A8_BIT)    DPRINTF3D(3,("            AGL_RGB555_A8_BIT\n"));
+	if(v & AGL_RGB565_BIT)       DPRINTF3D(3,("            AGL_RGB565_BIT\n"));
+	if(v & AGL_RGB565_A8_BIT)    DPRINTF3D(3,("            AGL_RGB565_A8_BIT\n"));
+	if(v & AGL_RGB888_BIT)       DPRINTF3D(3,("            AGL_RGB888_BIT\n"));
+	if(v & AGL_ARGB8888_BIT)     DPRINTF3D(3,("            AGL_ARGB8888_BIT\n"));
+	if(v & AGL_RGB888_A8_BIT)    DPRINTF3D(3,("            AGL_RGB888_A8_BIT\n"));
+	if(v & AGL_RGB101010_BIT)    DPRINTF3D(3,("            AGL_RGB101010_BIT\n"));
+	if(v & AGL_ARGB2101010_BIT)  DPRINTF3D(3,("            AGL_ARGB2101010_BIT\n"));
+	if(v & AGL_RGB101010_A8_BIT) DPRINTF3D(3,("            AGL_RGB101010_A8_BIT\n"));
+	if(v & AGL_RGB121212_BIT)    DPRINTF3D(3,("            AGL_RGB121212_BIT\n"));
+	if(v & AGL_ARGB12121212_BIT) DPRINTF3D(3,("            AGL_ARGB12121212_BIT\n"));
+	if(v & AGL_RGB161616_BIT)    DPRINTF3D(3,("            AGL_RGB161616_BIT\n"));
+	if(v & AGL_ARGB16161616_BIT) DPRINTF3D(3,("            AGL_ARGB16161616_BIT\n"));
+	if(v & AGL_INDEX8_BIT)       DPRINTF3D(3,("            AGL_INDEX8_BIT\n"));
+	if(v & AGL_INDEX16_BIT)      DPRINTF3D(3,("            AGL_INDEX16_BIT\n"));
+}
+
+static void PrintBitModes(GLint v)
+{
+	if(v & AGL_0_BIT)            DPRINTF3D(3,("            AGL_0_BIT\n"));
+	if(v & AGL_1_BIT)            DPRINTF3D(3,("            AGL_1_BIT\n"));
+	if(v & AGL_2_BIT)            DPRINTF3D(3,("            AGL_2_BIT\n"));
+	if(v & AGL_3_BIT)            DPRINTF3D(3,("            AGL_3_BIT\n"));
+	if(v & AGL_4_BIT)            DPRINTF3D(3,("            AGL_4_BIT\n"));
+	if(v & AGL_5_BIT)            DPRINTF3D(3,("            AGL_5_BIT\n"));
+	if(v & AGL_6_BIT)            DPRINTF3D(3,("            AGL_6_BIT\n"));
+	if(v & AGL_8_BIT)            DPRINTF3D(3,("            AGL_8_BIT\n"));
+	if(v & AGL_10_BIT)           DPRINTF3D(3,("            AGL_10_BIT\n"));
+	if(v & AGL_12_BIT)           DPRINTF3D(3,("            AGL_12_BIT\n"));
+	if(v & AGL_16_BIT)           DPRINTF3D(3,("            AGL_16_BIT\n"));
+	if(v & AGL_24_BIT)           DPRINTF3D(3,("            AGL_24_BIT\n"));
+	if(v & AGL_32_BIT)           DPRINTF3D(3,("            AGL_32_BIT\n"));
+	if(v & AGL_48_BIT)           DPRINTF3D(3,("            AGL_48_BIT\n"));
+	if(v & AGL_64_BIT)           DPRINTF3D(3,("            AGL_64_BIT\n"));
+	if(v & AGL_96_BIT)           DPRINTF3D(3,("            AGL_96_BIT\n"));
+	if(v & AGL_128_BIT)          DPRINTF3D(3,("            AGL_128_BIT\n"));
+}
+
+static void PrintInfoStats(AGLRendererInfo info)
+{
+	GLint rv;
+	
+	aglDescribeRenderer(info, AGL_RENDERER_ID, &rv);
+	DPRINTF3D(3,("        AGL_RENDERER_ID     : 0x%X\n", rv));
+	
+	aglDescribeRenderer(info, AGL_OFFSCREEN, &rv);
+	DPRINTF3D(3,("        AGL_OFFSCREEN       : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_FULLSCREEN, &rv);
+	DPRINTF3D(3,("        AGL_FULLSCREEN      : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_WINDOW, &rv);
+	DPRINTF3D(3,("        AGL_WINDOW          : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_ACCELERATED, &rv);
+	DPRINTF3D(3,("        AGL_ACCELERATED     : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_ROBUST, &rv);
+	DPRINTF3D(3,("        AGL_ROBUST          : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_BACKING_STORE, &rv);
+	DPRINTF3D(3,("        AGL_BACKING_STORE   : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_MP_SAFE, &rv);
+	DPRINTF3D(3,("        AGL_MP_SAFE         : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_COMPLIANT, &rv);
+	DPRINTF3D(3,("        AGL_COMPLIANT       : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_MULTISCREEN, &rv);
+	DPRINTF3D(3,("        AGL_MULTISCREEN     : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribeRenderer(info, AGL_BUFFER_MODES, &rv);
+	DPRINTF3D(3,("        AGL_BUFFER_MODES    : 0x%X\n", rv));
+	PrintBufferModes(rv);
+	
+	aglDescribeRenderer(info, AGL_MIN_LEVEL, &rv);
+	DPRINTF3D(3,("        AGL_MIN_LEVEL       : %d\n", rv));
+	
+	aglDescribeRenderer(info, AGL_MAX_LEVEL, &rv);
+	DPRINTF3D(3,("        AGL_MAX_LEVEL       : %d\n", rv));
+	
+	aglDescribeRenderer(info, AGL_COLOR_MODES, &rv);
+	DPRINTF3D(3,("        AGL_COLOR_MODES     : 0x%X\n", rv));
+	PrintColorModes(rv);
+	
+	aglDescribeRenderer(info, AGL_ACCUM_MODES, &rv);
+	DPRINTF3D(3,("        AGL_ACCUM_MODES     : 0x%X\n", rv));
+	PrintColorModes(rv);
+	
+	aglDescribeRenderer(info, AGL_DEPTH_MODES, &rv);
+	DPRINTF3D(3,("        AGL_DEPTH_MODES     : 0x%X\n", rv));
+	PrintBitModes(rv);
+	
+	aglDescribeRenderer(info, AGL_STENCIL_MODES, &rv);
+	DPRINTF3D(3,("        AGL_STENCIL_MODES   : 0x%X\n", rv));
+	PrintBitModes(rv);
+	
+	aglDescribeRenderer(info, AGL_MAX_AUX_BUFFERS, &rv);
+	DPRINTF3D(3,("        AGL_MAX_AUX_BUFFERS : %d\n", rv));
+	
+	aglDescribeRenderer(info, AGL_VIDEO_MEMORY, &rv);
+	DPRINTF3D(3,("        AGL_VIDEO_MEMORY    : %d\n", rv));
+	
+	aglDescribeRenderer(info, AGL_TEXTURE_MEMORY, &rv);
+	DPRINTF3D(3,("        AGL_TEXTURE_MEMORY  : %d\n", rv));
+}
+
+static void CheckGetRendererInfo(GDHandle device)
+{
+	AGLRendererInfo info, head_info;
+	GLint inum;
+
+	head_info =  aglQueryRendererInfo(&device, 1);
+	if(!head_info)
+	{
+		DPRINTF3D(3,("aglQueryRendererInfo : Info Error\n"));
+		return;
+	}
+	
+	info = head_info;
+	inum = 0;
+	while(info)
+	{
+		DPRINTF3D(3,("\n    Renderer : %d\n", inum));
+		PrintInfoStats(info);
+		info = aglNextRendererInfo(info);
+		inum++;
+	}
+	
+	aglDestroyRendererInfo(head_info);
+}
+
+int printRendererInfo(void)
+{
+	GLenum   err;
+	GDHandle device;
+	GLuint   dnum = 0;
+	
+	device = GetDeviceList();
+	while(device)
+	{
+		DPRINTF3D(3,("\nDevice : %d\n", dnum));
+		CheckGetRendererInfo(device);
+		device = GetNextDevice(device);
+		dnum++;
+	}
+		
+	err = aglGetError();
+	if(err != AGL_NO_ERROR) DPRINTF3D(3,("aglGetError - %s\n", aglErrorString(err)));
+
+   return 1;
+}
+
+int printFormatInfo(AGLPixelFormat info)
+{
+	GLint rv;
+
+	DPRINTF3D(3, ("\n\nSelected pixel format:\n"));
+
+	aglDescribePixelFormat(info, AGL_RENDERER_ID, &rv);
+	DPRINTF3D(3,("        AGL_RENDERER_ID     : 0x%X\n", rv));
+	
+	aglDescribePixelFormat(info, AGL_OFFSCREEN, &rv);
+	DPRINTF3D(3,("        AGL_OFFSCREEN       : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_FULLSCREEN, &rv);
+	DPRINTF3D(3,("        AGL_FULLSCREEN      : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_WINDOW, &rv);
+	DPRINTF3D(3,("        AGL_WINDOW          : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_ACCELERATED, &rv);
+	DPRINTF3D(3,("        AGL_ACCELERATED     : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_ROBUST, &rv);
+	DPRINTF3D(3,("        AGL_ROBUST          : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_BACKING_STORE, &rv);
+	DPRINTF3D(3,("        AGL_BACKING_STORE   : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_MP_SAFE, &rv);
+	DPRINTF3D(3,("        AGL_MP_SAFE         : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_COMPLIANT, &rv);
+	DPRINTF3D(3,("        AGL_COMPLIANT       : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_MULTISCREEN, &rv);
+	DPRINTF3D(3,("        AGL_MULTISCREEN     : %s\n", (rv ? "GL_TRUE" : "GL_FALSE")));
+	
+	aglDescribePixelFormat(info, AGL_BUFFER_SIZE, &rv);
+	DPRINTF3D(3,("        AGL_BUFFER_SIZE     : %d\n", rv));
+	
+	aglDescribePixelFormat(info, AGL_LEVEL, &rv);
+	DPRINTF3D(3,("        AGL_LEVEL           : %d\n", rv));
+
+	aglDescribePixelFormat(info, AGL_PIXEL_SIZE, &rv);
+	DPRINTF3D(3,("        AGL_PIXEL_SIZE      : %d\n", rv));
+
+#if 0
+	aglDescribePixelFormat(info, AGL_ACCUM_MODES, &rv);
+	DPRINTF3D(3,("        AGL_ACCUM_MODES     : 0x%X\n", rv));
+	PrintColorModes(rv);
+#endif	
+	aglDescribePixelFormat(info, AGL_DEPTH_SIZE, &rv);
+	DPRINTF3D(3,("        AGL_DEPTH_SIZE      : %d\n", rv));
+	
+	aglDescribePixelFormat(info, AGL_STENCIL_SIZE, &rv);
+	DPRINTF3D(3,("        AGL_STENCIL_SIZE    : %d\n", rv));
+	PrintBitModes(rv);
+	
+	aglDescribePixelFormat(info, AGL_AUX_BUFFERS, &rv);
+	DPRINTF3D(3,("        AGL_AUX_BUFFERS     : %d\n", rv));
+#if 0
+	aglDescribePixelFormat(info, AGL_VIDEO_MEMORY, &rv);
+	DPRINTF3D(3,("        AGL_VIDEO_MEMORY    : %d\n", rv));
+	
+	aglDescribePixelFormat(info, AGL_TEXTURE_MEMORY, &rv);
+	DPRINTF3D(3,("        AGL_TEXTURE_MEMORY  : %d\n", rv));
+#endif
+
+#if 0
+	aglDescribePixelFormat(pix, AGL_BUFFER_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_BUFFER_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_LEVEL, &rv);
+	DPRINTF3D(3, ("\tAGL_LEVEL: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_RGBA, &rv);
+	DPRINTF3D(3, ("\tAGL_RGBA: %s\n", (rv == GL_TRUE ? "GL_TRUE" : "GL_FALSE")));
+	aglDescribePixelFormat(pix, AGL_DOUBLEBUFFER, &rv);
+	DPRINTF3D(3, ("\tAGL_DOUBLEBUFFER: %s\n", (rv == GL_TRUE ? "GL_TRUE" : "GL_FALSE")));
+	aglDescribePixelFormat(pix, AGL_STEREO, &rv);
+	DPRINTF3D(3, ("\tAGL_STEREO: %s\n", (rv == GL_TRUE ? "GL_TRUE" : "GL_FALSE")));
+	aglDescribePixelFormat(pix, AGL_AUX_BUFFERS, &rv);
+	DPRINTF3D(3, ("\tAGL_AUX_BUFFERS: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_PIXEL_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_PIXEL_SIZE: %d\n", rv));
+
+	aglDescribePixelFormat(pix, AGL_RED_SIZE, &rv);
+	DPRINTF3D(3, ("\n\tAGL_RED_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_GREEN_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_GREEN_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_BLUE_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_BLUE_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_ALPHA_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_ALPHA_SIZE: %d\n", rv));
+
+	aglDescribePixelFormat(pix, AGL_DEPTH_SIZE, &rv);
+	DPRINTF3D(3, ("\n\tAGL_DEPTH_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_STENCIL_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_STENCIL_SIZE: %d\n", rv));
+	
+	aglDescribePixelFormat(pix, AGL_ACCUM_RED_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_ACCUM_RED_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_ACCUM_GREEN_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_ACCUM_GREEN_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_ACCUM_BLUE_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_ACCUM_BLUE_SIZE: %d\n", rv));
+	aglDescribePixelFormat(pix, AGL_ACCUM_ALPHA_SIZE, &rv);
+	DPRINTF3D(3, ("\tAGL_ACCUM_ALPHA_SIZE: %d\n", rv));
+#endif
+	return 1;
+}

--- a/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacUIConstants.h
+++ b/platforms/iOS/plugins/B3DAcceleratorPlugin32/zzz/sqMacUIConstants.h
@@ -1,0 +1,24 @@
+/****************************************************************************
+*   PROJECT: mac apple constants
+*   FILE:    sqMacUIConstants.h
+*   CONTENT: 
+*
+*   AUTHOR:   John McIntosh
+*   ADDRESS: 
+*   EMAIL:   johnmci@smalltalkconsulting.com
+*   RCSID:   $Id: sqMacUIConstants.h 1344 2006-03-05 21:07:15Z johnmci $
+*
+*   NOTES: 
+*   2011/04/01  WARNING: I'm usinf this file as is, copying it from platforms/Mac OS/vm because this plugin sources needs to be rewritten, and in the mean time there is 
+*               no good reason to pollute the other code.
+*/
+
+
+#define IMAGE_NAME_SIZE 1000
+#define SHORTIMAGE_NAME_SIZE 255
+#define DOCUMENT_NAME_SIZE 1000
+#define VMPATH_SIZE 1000
+
+  #define DELIMITER "/"
+  #define DELIMITERInt '/'
+


### PR DESCRIPTION
This is a temporary hack because MacOS32 is going away soon anyway
It restore the files from 5a38b3483dc5c82c7ecc85a590fdf1b095377a1f
in platforms/iOS/plugins/B3DAcceleratorPlugin32
and hack the build.macos32x86 makefiles to use that

NOTE: the CI fails with a Newspeak-64 segfault during tests, but it can't be related to macosx32 B3DAcceleratorPlugin fix obviously...