### PR TITLE
Restore support for large cursor on linux X11 VM

### DIFF
--- a/platforms/unix/config/aclocal.m4
+++ b/platforms/unix/config/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.15 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/platforms/unix/config/config.h.in
+++ b/platforms/unix/config/config.h.in
@@ -119,6 +119,9 @@
 /* Define to 1 if you have the <libutil.h> header file. */
 #undef HAVE_LIBUTIL_H
 
+/* Have Xrender library */
+#undef HAVE_LIBXRENDER
+
 /* Define to 1 if you have the <linux/fb.h> header file. */
 #undef HAVE_LINUX_FB_H
 

--- a/platforms/unix/config/configure
+++ b/platforms/unix/config/configure
@@ -16603,6 +16603,73 @@ done
 $as_echo "#define USE_X11_GLX 0" >>confdefs.h
 
     fi
+    ac_fn_c_check_header_mongrel "$LINENO" "X11/extensions/Xrender.h" "ac_cv_header_X11_extensions_Xrender_h" "$ac_includes_default"
+if test "x$ac_cv_header_X11_extensions_Xrender_h" = xyes; then :
+
+
+$as_echo "#define HAVE_LIBXRENDER 1" >>confdefs.h
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing XRenderCreateCursor" >&5
+$as_echo_n "checking for library containing XRenderCreateCursor... " >&6; }
+if ${ac_cv_search_XRenderCreateCursor+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char XRenderCreateCursor ();
+int
+main ()
+{
+return XRenderCreateCursor ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' Xrender; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_XRenderCreateCursor=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_XRenderCreateCursor+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_XRenderCreateCursor+:} false; then :
+
+else
+  ac_cv_search_XRenderCreateCursor=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_XRenderCreateCursor" >&5
+$as_echo "$ac_cv_search_XRenderCreateCursor" >&6; }
+ac_res=$ac_cv_search_XRenderCreateCursor
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+          break
+
+fi
+
+
 
 else
 

--- a/platforms/unix/vm-display-X11/acinclude.m4
+++ b/platforms/unix/vm-display-X11/acinclude.m4
@@ -60,6 +60,11 @@ if test "$have_x" = "yes"; then
     else
         AC_DEFINE([USE_X11_GLX], [0], [Use X11 GLX])
     fi
+    AC_CHECK_HEADER([X11/extensions/Xrender.h], [
+          AC_DEFINE([HAVE_LIBXRENDER], [1], [Have Xrender library])
+          AC_SEARCH_LIBS([XRenderCreateCursor],[Xrender])
+          break
+        ])
   ],[
     AC_PLUGIN_DISABLE
   ])

--- a/scripts/ci/travis_install.sh
+++ b/scripts/ci/travis_install.sh
@@ -11,6 +11,7 @@ if [[ "${ARCH}" = "linux64x64" ]]; then
             libfreetype6-dev \
             libx11-dev \
             libxext-dev \
+            libxrender-dev \
             libpango1.0-dev \
             libpulse-dev \
             libaudio-dev \
@@ -34,6 +35,7 @@ elif [[ "${ARCH}" = "linux32x86" ]]; then
             libgl1-mesa-glx:i386 \
             libgl1-mesa-dev:i386 \
             libxext-dev:i386 \
+            libxrender-dev:i386 \
             libglapi-mesa:i386 \
             libpango1.0-dev:i386 \
               libxft-dev:i386 \
@@ -115,7 +117,7 @@ if [ ! -e "$ARMCHROOT/etc/debian_chroot" ]; then
     schroot -c rpi -u root -- apt-get update
     schroot -c rpi -u root -- apt-get --allow-unauthenticated install -y \
 	    build-essential libcairo2-dev libpango1.0-dev libssl-dev uuid-dev uuid-runtime libasound2-dev \
-	    debhelper devscripts libssl-dev libfreetype6-dev libx11-dev libxext-dev \
+	    debhelper devscripts libssl-dev libfreetype6-dev libx11-dev libxext-dev libxrender-dev \
 	    libx11-dev libsm-dev libice-dev libgl1-mesa-dev libgl1-mesa-glx git \
 	    libtool automake autoconf
     #needed for third-party libraries


### PR DESCRIPTION
Large cursor support is present but optional on X11
It is triggered by compiler define HAVE_LIBXRENDER
It depends on availability of Xrender library which is an optional X extension
Try to test presence of header and library in configure macro
Note that it is also necessary to install the proper package
e.g. on debian flavours

	sudo apt-get install libxrender-dev