### PR TITLE
Allow newspeak spur linux & macos x64 failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ jobs:
   - env: FLAVOR="squeak.cog.spur.lowcode"
   - env: FLAVOR="pharo.cog.spur.lowcode"
   - env: ARCH="linux64x64" FLAVOR="newspeak.cog.spur"
+  - env: ARCH="macos64x64" FLAVOR="newspeak.cog.spur"
 
 install: ./scripts/ci/travis_install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,7 @@ jobs:
   - env: FLAVOR="pharo.sista.spur"
   - env: FLAVOR="squeak.cog.spur.lowcode"
   - env: FLAVOR="pharo.cog.spur.lowcode"
+  - env: ARCH="linux64x64" FLAVOR="newspeak.cog.spur"
 
 install: ./scripts/ci/travis_install.sh
 


### PR DESCRIPTION
These architectures and flavours are failing for a long time
Such failures make the CI status useless
and obstruct integration of unrelated features

It is vital to have a green CI, and these are provisional measures to restore a useful status.
This should not prevent us to investigate the problem further and hopefully resolve it.

It seems that all recent builds triggered the same crash dump on macos and linux while bootstrapping Newspeak, following stage:

    "$NSVM" $HEADLESS $COG_FLAGS $IMAGE NewspeakBootstrap.st

The error did not happen in x64 stack version, neither on linux nor macos.
This means that this might well be a bug related to Cog JIT on x64 SysV,
rather than a bug specific to Newspeak 64bits image.
It might be that Newspeak bootstrap process is testing the VM more thoroughly...