### PR TITLE
x11: emulate only up/down scroll events via keyboard, not left/right

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -3718,7 +3718,8 @@ handleEvent(XEvent *evt)
 		if (sendWheelEvents)
 			recordMouseWheelEvent(mouseWheelXDelta[evt->xbutton.button - 3],
 								  mouseWheelYDelta[evt->xbutton.button - 3]);
-		else {
+		else if (evt->xbutton.button <= 5) { /* only emulate up/down, as left/right
+												is used for text editing */
 		  int keyCode = mouseWheel2Squeak[evt->xbutton.button - 4];
 		  /* Set every meta bit to distinguish the fake event from a real
 		   * right/left arrow.


### PR DESCRIPTION
This restores the behavior to what we previously had and fixes an
annoying side effect, where vertical scrolling on a touchpad causing
occassional horizontal scrolling events would move the cursor in a text
editor, since we generate ctrl+left/right.