### PR TITLE
fix calculation of x11 scroll distances

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -3583,7 +3583,7 @@ extern sqInt sendWheelEvents; /* If true deliver EventTypeMouseWheel else kybd *
 static int mouseWheel2Squeak[4] = {30, 31, 28, 29};
 /* if sendWheelEvents is true this determines how much x & y are incremented */
 static int mouseWheelXDelta[4] = {0, 0, -120, 120};
-static int mouseWheelYDelta[4] = {-120, 120, 0, 0};
+static int mouseWheelYDelta[4] = {120, -120, 0, 0};
 
 static void
 handleEvent(XEvent *evt)
@@ -3716,8 +3716,8 @@ handleEvent(XEvent *evt)
 	  }
 	  else if (evt->xbutton.button <= 7) { /* mouse wheel */
 		if (sendWheelEvents)
-			recordMouseWheelEvent(mouseWheelXDelta[evt->xbutton.button - 3],
-								  mouseWheelYDelta[evt->xbutton.button - 3]);
+			recordMouseWheelEvent(mouseWheelXDelta[evt->xbutton.button - 4],
+								  mouseWheelYDelta[evt->xbutton.button - 4]);
 		else if (evt->xbutton.button <= 5) { /* only emulate up/down, as left/right
 												is used for text editing */
 		  int keyCode = mouseWheel2Squeak[evt->xbutton.button - 4];


### PR DESCRIPTION
I believe these values should be like the below.

Refer to for example here: http://xahlee.info/linux/linux_x11_mouse_button_number.html (the first scroll event is button 4). And the up-direction should be negative for Squeak. After these adjustments the behavior was correct on my machine.

To try out, ensure that you have `Smalltalk sendMouseWheelEvents: true`