### PR TITLE
Declare the shared library depedencies for vm-sound-pulse. Fixes #360

### DIFF
--- a/platforms/unix/vm-sound-pulse/Makefile.inc
+++ b/platforms/unix/vm-sound-pulse/Makefile.inc
@@ -1,0 +1,1 @@
+PLIBS=-lpulse-simple


### PR DESCRIPTION
On my system, pulse was not picked as default driver. I had to manually add add -vm-sound-pulse as a startup parameter. After adding this line it worked without any LD hacks though and ldd reports a correctly linked so file.