### PR TITLE
Fix shift-tab on unix

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -2417,7 +2417,10 @@ static int xkeysym2ucs4(KeySym keysym)
  	return keysym & 0x007f;
   if (keysym == XK_KP_Equal)
     return XK_equal;
-
+# if defined(XK_ISO_Left_Tab)
+  if (keysym == XK_ISO_Left_Tab) /* make shift-tab work */
+    return 9;
+#endif
 
   /* explicitly mapped */
 #define map(lo, hi) if (keysym >= 0x##lo && keysym <= 0x##hi) return ucs4_##lo##_##hi[keysym - 0x##lo];


### PR DESCRIPTION
Shift-tab didn't generate a "key char event" on unix, because
XK_ISO_Left_Tab was not mapped in xkeysym2ucs4, so its unicode code
point was mapped to 0. Map it to tab (9).

On behalf of Levente