### PR TITLE
Fix osx linux mouse wheel

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -270,12 +270,19 @@ static int buttonState=0;
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
 	CGFloat x = [theEvent scrollingDeltaX];
 	CGFloat y = [theEvent scrollingDeltaY];
+	/* Convert event units into scrolling units
+	   Assume that 1 event unit corresponds to a single wheel mouse notch
+	   A single notch evaluates to 120 scrolling units */
 	float xDelta = x * 120;
 	float yDelta = y * 120;
 	if ([theEvent respondsToSelector:@selector(hasPreciseScrollingDeltas)]) {
 		if ([theEvent hasPreciseScrollingDeltas]) {
-			xDelta = x;
-			yDelta = y;
+			/* Note: in case of precise scrolling x,y are given in points
+			   Assume that 120 scrolling units corresponds to 3 lines delta 
+			   that is 40 points for a 13.3 point line grid
+			   hence the factor 3 */
+			xDelta = x * 3;
+			yDelta = y * 3;
 		}
 	}
 #else
@@ -295,7 +302,7 @@ static int buttonState=0;
 		prevYTime = now;
 	}
 	if (sendWheelEvents) {
-		float limit = 10;
+		float limit = 20;
 		if (-limit < prevXDelta && prevXDelta < limit && -limit < prevYDelta && prevYDelta < limit ) return;
 		sqMouseEvent evt;
 		memset(&evt,0,sizeof(evt));

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -279,7 +279,8 @@ static int buttonState=0;
 		//printf("x:%f y:%f ex:%ld ey:%ld\n", x, y, evt.x, evt.y);
 
 		int buttonAndModifiers = [self mapMouseAndModifierStateToSqueakBits: theEvent];
-		evt.buttons = buttonAndModifiers >> 3;
+		evt.buttons = buttonAndModifiers & 7;
+		evt.modifiers = buttonAndModifiers >> 3;
 		evt.windowIndex =  aView.windowLogic.windowIndex;
 		[self pushEventToQueue:(sqInputEvent *) &evt];
 	}

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -263,8 +263,23 @@ static int buttonState=0;
 - (void) recordWheelEvent:(NSEvent *) theEvent fromView: (NSView <sqSqueakOSXView> *) aView{
 
 	[self recordMouseEvent: theEvent fromView: aView];
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
+	CGFloat x = [theEvent scrollingDeltaX];
+	CGFloat y = [theEvent scrollingDeltaY];
+	int xDelta = x * 120;
+	int yDelta = y * 120;
+	if ([theEvent respondsToSelector:@selector(hasPreciseScrollingDeltas)]) {
+		if ([theEvent hasPreciseScrollingDeltas]) {
+			xDelta = x;
+			yDelta = y;
+		}
+	}
+#else
 	CGFloat x = [theEvent deltaX];
 	CGFloat y = [theEvent deltaY];
+	int xDelta = x * 120;
+	int yDelta = y * 120;
+#endif
 
 	if (sendWheelEvents) {
 		sqMouseEvent evt;
@@ -273,8 +288,8 @@ static int buttonState=0;
 		evt.type = EventTypeMouseWheel;
 		evt.timeStamp = ioMSecs();
 
-		evt.x =  x * 32;
-		evt.y =  y * 32;
+		evt.x =  xDelta;
+		evt.y =  yDelta;
 
 		//printf("x:%f y:%f ex:%ld ey:%ld\n", x, y, evt.x, evt.y);
 
@@ -285,11 +300,11 @@ static int buttonState=0;
 		[self pushEventToQueue:(sqInputEvent *) &evt];
 	}
 	else {
-		if (x != 0.0f) {
-			[self fakeMouseWheelKeyboardEventsKeyCode: (x < 0 ? 124 : 123) ascii: (x < 0 ? 29 : 28) windowIndex:   aView.windowLogic.windowIndex];
+		if (xDelta != 0) {
+			[self fakeMouseWheelKeyboardEventsKeyCode: (xDelta < 0 ? 124 : 123) ascii: (xDelta < 0 ? 29 : 28) windowIndex: aView.windowLogic.windowIndex];
 		}
-		if (y != 0.0f) {
-			[self fakeMouseWheelKeyboardEventsKeyCode: (y < 0 ? 125 : 126) ascii: (y < 0 ? 31 : 30) windowIndex:  aView.windowLogic.windowIndex];
+		if (yDelta != 0) {
+			[self fakeMouseWheelKeyboardEventsKeyCode: (yDelta < 0 ? 125 : 126) ascii: (yDelta < 0 ? 31 : 30) windowIndex: aView.windowLogic.windowIndex];
 		}
 	}
 }

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -263,11 +263,15 @@ static int buttonState=0;
 - (void) recordWheelEvent:(NSEvent *) theEvent fromView: (NSView <sqSqueakOSXView> *) aView{
 
 	[self recordMouseEvent: theEvent fromView: aView];
+	static float prevXDelta = 0;
+	static float prevYDelta = 0;
+	static int prevXTime = 0;
+	static int prevYTime = 0;
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
 	CGFloat x = [theEvent scrollingDeltaX];
 	CGFloat y = [theEvent scrollingDeltaY];
-	int xDelta = x * 120;
-	int yDelta = y * 120;
+	float xDelta = x * 120;
+	float yDelta = y * 120;
 	if ([theEvent respondsToSelector:@selector(hasPreciseScrollingDeltas)]) {
 		if ([theEvent hasPreciseScrollingDeltas]) {
 			xDelta = x;
@@ -277,21 +281,33 @@ static int buttonState=0;
 #else
 	CGFloat x = [theEvent deltaX];
 	CGFloat y = [theEvent deltaY];
-	int xDelta = x * 120;
-	int yDelta = y * 120;
+	float xDelta = x * 120;
+	float yDelta = y * 120;
 #endif
-
+	/* accumulate enough delta before sending the event to the image */
+	int now = ioMSecs();
+	if( xDelta != 0 ) {
+		prevXDelta = ( now - prevXTime < 500) ? prevXDelta + xDelta : xDelta;
+		prevXTime = now;
+	}
+	if( yDelta != 0 ) {
+		prevYDelta = ( now - prevYTime < 500) ? prevYDelta + yDelta : yDelta;
+		prevYTime = now;
+	}
 	if (sendWheelEvents) {
+		float limit = 10;
+		if (-limit < prevXDelta && prevXDelta < limit && -limit < prevYDelta && prevYDelta < limit ) return;
 		sqMouseEvent evt;
 		memset(&evt,0,sizeof(evt));
 
 		evt.type = EventTypeMouseWheel;
 		evt.timeStamp = ioMSecs();
 
-		evt.x =  xDelta;
-		evt.y =  yDelta;
+		evt.x = prevXDelta;
+		evt.y = prevYDelta;
 
-		//printf("x:%f y:%f ex:%ld ey:%ld\n", x, y, evt.x, evt.y);
+		prevXDelta = 0;
+		prevYDelta = 0;
 
 		int buttonAndModifiers = [self mapMouseAndModifierStateToSqueakBits: theEvent];
 		evt.buttons = buttonAndModifiers & 7;
@@ -300,11 +316,14 @@ static int buttonState=0;
 		[self pushEventToQueue:(sqInputEvent *) &evt];
 	}
 	else {
-		if (xDelta != 0) {
-			[self fakeMouseWheelKeyboardEventsKeyCode: (xDelta < 0 ? 124 : 123) ascii: (xDelta < 0 ? 29 : 28) windowIndex: aView.windowLogic.windowIndex];
+		float limit = 120;
+		if (prevXDelta <= -limit || limit <= prevXDelta) {
+			[self fakeMouseWheelKeyboardEventsKeyCode: (prevXDelta < 0 ? 124 : 123) ascii: (prevXDelta < 0 ? 29 : 28) windowIndex: aView.windowLogic.windowIndex];
+			prevXDelta = 0;
 		}
-		if (yDelta != 0) {
-			[self fakeMouseWheelKeyboardEventsKeyCode: (yDelta < 0 ? 125 : 126) ascii: (yDelta < 0 ? 31 : 30) windowIndex: aView.windowLogic.windowIndex];
+		if (prevYDelta <= -limit || limit <= prevYDelta) {
+			[self fakeMouseWheelKeyboardEventsKeyCode: (prevYDelta < 0 ? 125 : 126) ascii: (prevYDelta < 0 ? 31 : 30) windowIndex: aView.windowLogic.windowIndex];
+			prevYDelta = 0;
 		}
 	}
 }

--- a/platforms/unix/vm/sqUnixEvent.c
+++ b/platforms/unix/vm/sqUnixEvent.c
@@ -183,11 +183,14 @@ static void recordMouseEvent(void)
 
 static void recordMouseWheelEvent(int dx, int dy)
 {
+  int state= getButtonState();
   sqMouseEvent *evt= allocateMouseWheelEvent();
   evt->x= dx;
   evt->y= dy;
-  // VM reads fifth (4th 0-based) field for event's modifiers
-  evt->buttons= (getButtonState() >> 3);
+  evt->buttons= (state & 0x7);
+  evt->modifiers= (state >> 3);
+  evt->nrClicks=
+    evt->windowIndex= 0;
   signalInputEvent();
 #if DEBUG_MOUSE_EVENTS
   printf("EVENT (recordMouseWheelEvent): time: %d  mouse dx %d dy %d", evt->timeStamp, dx, dy);


### PR DESCRIPTION
This provides a fix for Issue #41 

Both unix (X11) and OSX will now deliver the buttons and modifiers states like any other mouse event in fifth and sixth position in event structure (the so called eventBuffer at image side).

Note: OSX VM will now provide smooth wheel scroll events if possible, with a resolution of 20 scroll units (1/6th of wheel notch), like I did for Windows.
This threshold will avoid burst of wheel events with small deltas which where freezing Morphic interactivity.

Note: I did not accumulate small wheel events on linux yet, this remains a TODO.
**EDIT** but I propose accumulating at image side in order to mitigate the problem
See http://source.squeak.org/inbox/Morphic-nice.1613.diff