### PR TITLE
Fix issue #472

### DIFF
--- a/platforms/Cross/plugins/Squeak3D/b3dInit.c
+++ b/platforms/Cross/plugins/Squeak3D/b3dInit.c
@@ -315,6 +315,8 @@ int b3dQuickSortInitialFaces(B3DPrimitiveObject *obj, int i, int j)
   int ij, k, l, n;
   B3DPrimitiveVertex *di, *dj, *dij, *tt, *vtx = obj->vertices;
 
+  if( i >= j ) return B3D_NO_ERROR;
+
   /* Keep us enough headroom */
   INIT((j-i)*2);
   PUSH(i,j);
@@ -378,7 +380,9 @@ int b3dQuickSortObjects(B3DPrimitiveObject **array, int i, int j)
 {
   int ij, k, l, n;
   B3DPrimitiveObject *di, *dj, *dij, *tmp;
-	
+
+  if( i >= j ) return B3D_NO_ERROR;
+
   /* Keep us enough headroom */
   INIT((j-i)*2);
   PUSH(i,j);


### PR DESCRIPTION
when `i == j`, there is nothing to sort.
If we call this for the first time, there is no stack allocated by `INIT(0)`, but stack is accessed nonetheless thru `PUSH(i,j)`.
The best thing todo IMO is to return early.