### PR TITLE
Update OpenSSL download to v1.1.1d as v1.0.2q EOLed 1 Jan 2020.

### DIFF
--- a/third-party/openssl.spec
+++ b/third-party/openssl.spec
@@ -1,10 +1,10 @@
-openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.0.2q.tar.gz
-openssl_spec_archive_name:=openssl-1.0.2q.tar.gz
-openssl_spec_unpack_dir_name:=openssl-1.0.2q
-openssl_spec_product1_name_macOS:=libssl.1.0.0.dylib
-openssl_spec_product2_name_macOS:=libcrypto.1.0.0.dylib
-openssl_spec_product1_name_linux:=libssl.so.1.0.0
-openssl_spec_product2_name_linux:=libcrypto.so.1.0.0
+openssl_spec_download_url:=https://www.openssl.org/source/openssl-1.1.1d.tar.gz
+openssl_spec_archive_name:=openssl-1.1.1d.tar.gz
+openssl_spec_unpack_dir_name:=openssl-1.1.1d
+openssl_spec_product1_name_macOS:=libssl.1.1.dylib
+openssl_spec_product2_name_macOS:=libcrypto.1.1.dylib
+openssl_spec_product1_name_linux:=libssl.so.1.1
+openssl_spec_product2_name_linux:=libcrypto.so.1.1
 openssl_spec_product1_name_windows:=ssleay32.dll
 openssl_spec_product2_name_windows:=libeay32.dll
 openssl_spec_symlinks_macOS:=libssl*.dylib libcrypto*.dylib


### PR DESCRIPTION
Fixes #455 