### PR TITLE
Use NSWindow API for changing fullscreen mode

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -48,7 +48,7 @@
 
 extern SqueakOSXAppDelegate *gDelegateApp;
 extern struct VirtualMachine* interpreterProxy;
-extern int getFullScreenFlag();
+extern sqInt getFullScreenFlag();
 
 static sqSqueakOSXMetalView *mainMetalView;
 
@@ -231,7 +231,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 	
 	if (!firstDrawCompleted) {
 		firstDrawCompleted = YES;
-		if (getFullScreenFlag() == 0) {
+		if (!getFullScreenFlag()) {
 			[self.window makeKeyAndOrderFront: self];
         }
 	}
@@ -876,13 +876,13 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 #pragma mark Fullscreen
 
 - (void)  ioSetFullScreen: (sqInt) fullScreen {
-	if (getFullScreenFlag() == (fullScreen == 1))
+	if (getFullScreenFlag() == fullScreen)
 		return; // not changing fullscreen mode
 
 	self.fullScreenInProgress = YES;
 	[self.window toggleFullScreen:self];
 
-	if (getFullScreenFlag() && (fullScreen == 0)) {
+	if (getFullScreenFlag() && !fullScreen) {
 		if ([self.window isKeyWindow] == NO) {
 			[self.window makeKeyAndOrderFront: self];
 		}

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -48,6 +48,7 @@
 
 extern SqueakOSXAppDelegate *gDelegateApp;
 extern struct VirtualMachine* interpreterProxy;
+extern int getFullScreenFlag();
 
 static sqSqueakOSXMetalView *mainMetalView;
 
@@ -230,7 +231,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 	
 	if (!firstDrawCompleted) {
 		firstDrawCompleted = YES;
-        extern sqInt getFullScreenFlag(void);
 		if (getFullScreenFlag() == 0) {
 			[self.window makeKeyAndOrderFront: self];
         }
@@ -876,25 +876,13 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 #pragma mark Fullscreen
 
 - (void)  ioSetFullScreen: (sqInt) fullScreen {
+	if (getFullScreenFlag() == (fullScreen == 1))
+		return; // not changing fullscreen mode
 
-	if ([self isInFullScreenMode] == YES && (fullScreen == 1))
-		return;
-	if ([self isInFullScreenMode] == NO && (fullScreen == 0))
-		return;
+	self.fullScreenInProgress = YES;
+	[self.window toggleFullScreen:self];
 
-	if ([self isInFullScreenMode] == NO && (fullScreen == 1)) {
-       self.fullScreenInProgress = YES;
-		NSDictionary* options = [NSDictionary dictionaryWithObjectsAndKeys:
-			[NSNumber numberWithInt:
-				NSApplicationPresentationHideDock |
-				NSApplicationPresentationHideMenuBar ],
-			NSFullScreenModeApplicationPresentationOptions, nil];
-		[self enterFullScreenMode:[NSScreen mainScreen] withOptions:options];
-	}
-
-	if ([self isInFullScreenMode] == YES && (fullScreen == 0)) {
-        self.fullScreenInProgress = YES;
-		[self exitFullScreenModeWithOptions: NULL];
+	if (getFullScreenFlag() && (fullScreen == 0)) {
 		if ([self.window isKeyWindow] == NO) {
 			[self.window makeKeyAndOrderFront: self];
 		}


### PR DESCRIPTION
instead of going through NSView's API. The latter does offer more options, but messes up the fullscreen mode for some reason ([UI becomes unresponsive because input events are no longer received](http://forum.world.st/ANN-Squeak-5-3-RC1-tp5112435p5112454.html)).

Using `self.window toggleFullScreen:self` also does not mess with additional displays (only the display showing Squeak is put into fullscreen mode).

Please test and review!