### PR TITLE
Fix #484 [Win64]Cannot save and load image files with a heap whose size is more than 0xff ff ff ff (~4.1GB)

### DIFF
--- a/platforms/win32/plugins/FilePlugin/sqWin32FilePrims.c
+++ b/platforms/win32/plugins/FilePlugin/sqWin32FilePrims.c
@@ -512,32 +512,26 @@ squeakFileOffsetType sqImageFilePosition(sqImageFile h)
 size_t sqImageFileRead(void *ptr, size_t sz, size_t count, sqImageFile h)
 {
   DWORD dwReallyRead;
-
   size_t reallyRead = 0;
-
   size_t totalToRead = count * sz;
-
   squeakFileOffsetType position;
 
-  if (totalToRead > (size_t)MAX_DWORD - 1) {
-    while (reallyRead != totalToRead) {
-      DWORD toRead = (totalToRead - reallyRead) > (size_t)MAX_DWORD ? MAX_DWORD : totalToRead - reallyRead;
-      ReadFile((HANDLE)(h - 1), (LPVOID)((sqInt)ptr + (sqInt)reallyRead), toRead, &dwReallyRead, NULL);
-      reallyRead += dwReallyRead;
-    }
-    return (reallyRead / sz);
-  }
-
   position = sqImageFilePosition(h);
-  ReadFile((HANDLE)(h - 1), (LPVOID)ptr, count * sz, &dwReallyRead, NULL);
-  while(dwReallyRead != (DWORD)(count*sz)) {
-    DWORD err = GetLastError();
-    if(sqMessageBox(MB_ABORTRETRYIGNORE, TEXT("Squeak Warning"),TEXT("Image file read problem (%d out of %d bytes read)"), dwReallyRead, count*sz)
-       == IDABORT) return (dwReallyRead / sz);
-    sqImageFileSeek(h, position);
-    ReadFile((HANDLE)(h-1), (LPVOID) ptr, count*sz, &dwReallyRead, NULL);
+  while (reallyRead != totalToRead) {
+    DWORD toRead = (totalToRead - reallyRead) > (size_t)MAX_DWORD ? MAX_DWORD : totalToRead - reallyRead;
+    BOOL ret = ReadFile((HANDLE)(h - 1), (LPVOID)((sqInt)ptr + (sqInt)reallyRead), toRead, &dwReallyRead, NULL);
+    reallyRead += dwReallyRead;
+
+    if (!ret | dwReallyRead != toRead) {
+      DWORD err = GetLastError();
+      if (sqMessageBox(MB_ABORTRETRYIGNORE, TEXT("VM Warning"), TEXT("Image file read problem (%d out of %d bytes read)"), dwReallyRead, toRead)
+        == IDABORT) return (size_t)(reallyRead / sz);
+      sqImageFileSeek(h, position);
+      reallyRead = 0;
+    }
+
   }
-  return (size_t)(dwReallyRead / sz);
+  return (reallyRead / sz);
 }
 
 squeakFileOffsetType sqImageFileSeek(sqImageFile h, squeakFileOffsetType pos)
@@ -561,15 +555,21 @@ size_t sqImageFileWrite(const void *ptr, size_t sz, size_t count, sqImageFile h)
   size_t reallyWritten =0;
   DWORD dwReallyWritten;
   size_t totalToWrite = count * sz;
-  if (totalToWrite < (size_t)MAX_DWORD -1) {
-    WriteFile((HANDLE)(h - 1), (LPVOID)ptr, count * sz, &dwReallyWritten, NULL);
-    return (size_t)(dwReallyWritten / sz);
-  }
+  squeakFileOffsetType position;
 
+  position = sqImageFilePosition(h);
   while (reallyWritten != totalToWrite) {
     DWORD toWrite = (totalToWrite - reallyWritten) > (size_t) MAX_DWORD ? MAX_DWORD : totalToWrite - reallyWritten;
-    WriteFile((HANDLE)(h - 1), (LPVOID)((sqInt)ptr + (sqInt) reallyWritten), toWrite, &dwReallyWritten, NULL);
+    BOOL ret = WriteFile((HANDLE)(h - 1), (LPVOID)((sqInt)ptr + (sqInt) reallyWritten), toWrite, &dwReallyWritten, NULL);
     reallyWritten += dwReallyWritten;
+
+    if (!ret | dwReallyWritten != toWrite) {
+      DWORD err = GetLastError();
+      if (sqMessageBox(MB_ABORTRETRYIGNORE, TEXT("VM Warning"), TEXT("Image file read problem (%d out of %d bytes read)"), dwReallyWritten, toWrite)
+        == IDABORT) return (size_t)(reallyWritten / sz);
+      sqImageFileSeek(h, position);
+      reallyWritten = 0;
+    }
   }
   return (size_t) (reallyWritten / sz);
 }


### PR DESCRIPTION
The problem is actually when there is only one segment of memory of more of 0xff ff ff ff to read or to write to disk.

This fix the issue and it is tested with a real case on windows.

I added some checks on function return.

Let me know if changes are to be done to follows some conventions or optimizations. 