### PR TITLE
Bump minimal supported Windows version to Windows Vista (0x0600).

### DIFF
--- a/build.win32x86/common/Makefile.msvc.tools
+++ b/build.win32x86/common/Makefile.msvc.tools
@@ -53,8 +53,8 @@ ifdef MSVC
 MEMACCESS:=-DUSE_INLINE_MEMORY_ACCESSORS=1
 endif
 
-# Set minimum version to WindowsXP (see /cygwin/usr/include/w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0501 -DWINVER=0x0501
+# Set minimum version to Windows 8 (see /cygwin/usr/include/w32api/w32api.h)
+WINVER:=-D_WIN32_WINNT=0x0602 -DWINVER=0x0602
 
 # define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
 #NOBUILTIN:= -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
@@ -62,7 +62,8 @@ NOBUILTIN:=-D_MT
 MACHINE:=x86
 
 DEFS:=	$(COGDEFS) $(MEMACCESS) $(WINVER) \
-	-DWIN32=1 -DUNICODE=1 -DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE \
+	-DWIN32=1 -D_WIN32=1 -DUNICODE=1 \
+	-DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE \
 	$(NDEBUG) -DLSB_FIRST -D'VM_NAME="$(VM_NAME)"' $(XDEFS) $(CROQUET)
 
 #############################################################################

--- a/build.win32x86/common/Makefile.tools
+++ b/build.win32x86/common/Makefile.tools
@@ -42,8 +42,8 @@ else
 COGDEFS:= $(COGDEFS) -DCOGMTVM=0 -DDEBUGVM=$(DEBUGVM)
 endif
 
-# Set minimum version to Windows 8 (see /cygwin/usr/include/w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0602 -DWINVER=0x0602
+# Set minimum version to Windows Vista (see /cygwin/usr/include/w32api/w32api.h)
+WINVER:=-D_WIN32_WINNT=0x0600 -DWINVER=0x0600
 
 # define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
 NOBUILTIN:= -D_MT -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf

--- a/build.win32x86/common/Makefile.tools
+++ b/build.win32x86/common/Makefile.tools
@@ -42,8 +42,8 @@ else
 COGDEFS:= $(COGDEFS) -DCOGMTVM=0 -DDEBUGVM=$(DEBUGVM)
 endif
 
-# Set minimum version to WindowsXP (see /cygwin/usr/include/w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0501 -DWINVER=0x0501
+# Set minimum version to Windows 8 (see /cygwin/usr/include/w32api/w32api.h)
+WINVER:=-D_WIN32_WINNT=0x0602 -DWINVER=0x0602
 
 # define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
 NOBUILTIN:= -D_MT -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
@@ -51,8 +51,9 @@ CFLAGS:= -msse2 -ggdb2 -m32 \
 	-mno-rtd -mms-bitfields $(OFLAGS) $(NOBUILTIN) $(WARNINGS)
 
 TZ:=$(shell date +%Z)
-DEFS:=	$(COGDEFS) $(WINVER) -DWIN32=1 -DWIN32_FILE_SUPPORT -DNO_ISNAN \
-		-DNO_SERVICE -D'TZ="$(TZ)"' \
+DEFS:=	$(COGDEFS) $(WINVER) \
+		-DWIN32=1 -D_WIN32=1 \
+		-DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE -D'TZ="$(TZ)"' \
 		$(NDEBUG) -DLSB_FIRST -D'VM_NAME="$(VM_NAME)"' $(XDEFS) $(CROQUET)
 
 #############################################################################

--- a/build.win64x64/common/Makefile.msvc.tools
+++ b/build.win64x64/common/Makefile.msvc.tools
@@ -59,10 +59,7 @@ MEMACCESS:=-DUSE_INLINE_MEMORY_ACCESSORS=1
 endif
 
 # Set minimum version to Windows 8 (see /cygwin/usr/include/w32api/w32api.h)
-#but if so, sqWin32AEC.cpp includes DeviceTopology.h & barfs
-#WINVER:=-D_WIN32_WINNT=0x0801 -DWINVER=0x0801
-# Set minimum version to Windows 10
-WINVER:=-D_WIN64=1 -D_WIN32_WINNT=0x1001 -DWINVER=0x1001
+WINVER:=-D_WIN32_WINNT=0x0602 -DWINVER=0x0602
 
 # define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
 #NOBUILTIN:= -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
@@ -70,7 +67,8 @@ NOBUILTIN:=-D_MT
 MACHINE:=x64
 
 DEFS:=	-D$(VM)VM=1 $(COGDEFS) $(MEMACCESS) $(WINVER) \
-		-DWIN32=1 -DUNICODE=1 -DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE \
+		-DWIN32=1 -DWIN64=1 -D_WIN32=1 -D_WIN64=1 -DUNICODE=1 \
+		-DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE \
 		$(NDEBUG) -DLSB_FIRST -DVM_NAME='"$(VM_NAME)"' $(XDEFS) $(CROQUET)
 
 #############################################################################

--- a/build.win64x64/common/Makefile.tools
+++ b/build.win64x64/common/Makefile.tools
@@ -49,8 +49,8 @@ ifeq ($(COMPILER_TO_USE),clang)
 COGDEFS:=$(COGDEFS) -mno-stack-arg-probe
 endif
 
-# Set minimum version to Windows 8 (see /cygwin/usr/include/w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0602 -DWINVER=0x0602
+# Set minimum version to Windows Vista (see /cygwin/usr/include/w32api/w32api.h)
+WINVER:=-D_WIN32_WINNT=0x0600 -DWINVER=0x0600
 
 # define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
 NOBUILTIN:= -D_MT -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf

--- a/build.win64x64/common/Makefile.tools
+++ b/build.win64x64/common/Makefile.tools
@@ -49,8 +49,8 @@ ifeq ($(COMPILER_TO_USE),clang)
 COGDEFS:=$(COGDEFS) -mno-stack-arg-probe
 endif
 
-# Set minimum version to WindowsXP (see /cygwin/usr/include/w32api/w32api.h)
-WINVER:=-D_WIN32_WINNT=0x0501 -DWINVER=0x0501
+# Set minimum version to Windows 8 (see /cygwin/usr/include/w32api/w32api.h)
+WINVER:=-D_WIN32_WINNT=0x0602 -DWINVER=0x0602
 
 # define _MT to eliminate the inline versions of printf et al in mingw/stdio.h
 NOBUILTIN:= -D_MT -fno-builtin-printf -fno-builtin-putchar -fno-builtin-fprintf
@@ -59,7 +59,8 @@ CFLAGS:= -fdeclspec -msse2 -ggdb2 -m64 \
 
 TZ:=$(shell date +%Z)
 DEFS:=	-D$(VM)VM=1 $(COGDEFS) $(WINVER) \
-		-DWIN64=1 -DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE \
+		-DWIN32=1 -DWIN64=1 -D_WIN32=1 -D_WIN64=1 \
+		-DWIN32_FILE_SUPPORT -DNO_ISNAN -DNO_SERVICE \
 		$(NDEBUG) -DLSB_FIRST -D'VM_NAME="$(VM_NAME)"' $(XDEFS) $(CROQUET)
 
 #############################################################################

--- a/platforms/win32/vm/sqWin32.h
+++ b/platforms/win32/vm/sqWin32.h
@@ -398,47 +398,6 @@ void pluginHandleEvent(MSG* msg);
 int recordDragDropEvent(HWND wnd, int dragType, int x, int y, int numFiles);
 #endif
 
-/****************************************************************************/
-/* few addtional definitions for those having older include files           */
-/****************************************************************************/
-#if (WINVER < 0x0400) && !defined(_GNU_H_WINDOWS_H)
-/* CreateWindowEx params since Win95/NT4 */
-#define WS_EX_WINDOWEDGE        0x00000100L
-#define WS_EX_CLIENTEDGE        0x00000200L
-#define WS_EX_OVERLAPPEDWINDOW  (WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE)
-#define WS_EX_APPWINDOW         0x00040000L
-#define WS_EX_TOOLWINDOW        0x00000080L
-#define WS_EX_CONTEXTHELP       0x00000400L
-
-/* WM_USERCHANGED since Win95/NT4 */
-#define WM_USERCHANGED                  0x0054
-
-/* Shell_NoifiyIcon() for the system tray on Win95/NT4 */
-typedef struct _NOTIFYICONDATAA {
-        DWORD cbSize;
-        HWND hWnd;
-        UINT uID;
-        UINT uFlags;
-        UINT uCallbackMessage;
-        HICON hIcon;
-        CHAR   szTip[64];
-} NOTIFYICONDATA, *PNOTIFYICONDATA;
-
-#define NIM_ADD         0x00000000
-#define NIM_MODIFY      0x00000001
-#define NIM_DELETE      0x00000002
-
-#define NIF_MESSAGE     0x00000001
-#define NIF_ICON        0x00000002
-#define NIF_TIP         0x00000004
-
-#endif /* WINVER < 0x0400 */
-
-/* WM_MOUSEWHEEL since Win98/NT4 */
-#ifndef WM_MOUSEWHEEL
-#define WM_MOUSEWHEEL 0x020A
-#endif
-
 /******************************************************/
 /* Profiling support                                  */
 /******************************************************/

--- a/platforms/win32/vm/sqWin32Main.c
+++ b/platforms/win32/vm/sqWin32Main.c
@@ -879,7 +879,11 @@ sqInt  fileHandleType(HANDLE fdHandle) {
 	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * MAX_PATH;
 	FILE_NAME_INFO *nameinfo;
 	WCHAR *p = NULL;
-	nameinfo = alloca(size);
+
+	nameinfo = malloc(size);
+	if (nameinfo == NULL) {
+		return -1;
+	}
 	/* Check the name of the pipe: '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
 	if (GetFileInformationByHandleEx(fdHandle, FileNameInfo, nameinfo, size)) {
 		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
@@ -888,11 +892,15 @@ sqInt  fileHandleType(HANDLE fdHandle) {
 		if ((((wcsstr(p, L"msys-") || wcsstr(p, L"cygwin-"))) &&
 			(wcsstr(p, L"-pty") && wcsstr(p, L"-master")))) {
 			//The openned pipe is a msys xor cygwin pipe to pty
+			free(nameinfo);
 			return 4;
 		}
-		else
+		else {
+			free(nameinfo);
 			return 2; //else it is just a standard pipe
+		}
 	}
+	free(nameinfo);
 	return -1;
 }
 


### PR DESCRIPTION
Also fixes a minor issue in MSVC Makefile for 64x64, which tried 0x0801 for Windows 8 and 0x1001 for Windows 10. The latter would actually be 0x0A00. See https://docs.microsoft.com/de-de/cpp/porting/modifying-winver-and-win32-winnt

Also in the Makefile for 64x64, define both _WIN32 and _WIN64. See https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros

Also in the Makefile for 64x64, define both WIN32 and WIN64 because those can be used to identify the Windows platform in application code such as in processors/IA32/bochs. I am not aware of any #ifdef WIN64 at the moment. Most code uses #ifdef _WIN64 to check for that.

Note that, having defined both _WIN32 and _WIN64, code for 32-bit and 64-bit must always begin with #ifdef _WIN64 and only then #elif _WIN32.

I think that the MSVC compiler defines _WIN32 and _WIN64 automatically. Yet, now it is documented in the Makefile.