### PR TITLE
update url to always use current stable release

### DIFF
--- a/image/getlatesttrunkimage.sh
+++ b/image/getlatesttrunkimage.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 . ./envvars.sh
-# curl clags -s silent -o output to
-URL=http://files.squeak.org/5.2/
-LATEST=`curl -s $URL | tr "=" "\\012" | grep Squeak5.2.*32bit | tail -1 | sed 's/"\(.*\)\/">.*$/\1/'`
-echo curl -o $LATEST.zip $URL/$LATEST/$LATEST.zip
-curl -o $LATEST.zip $URL/$LATEST/$LATEST.zip
+# curl flags -s silent -L follow redirects -o output
+URL=http://files.squeak.org/current_stable
+LATEST=`curl -s -L $URL | tr "=" "\\012" | grep 'Squeak.*-32bit' | tail -1 | sed 's/"\(.*\)\/">.*$/\1/'`
+echo curl -L -o $LATEST.zip $URL/$LATEST/$LATEST.zip
+curl -L -o $LATEST.zip $URL/$LATEST/$LATEST.zip
 unzip $LATEST.zip
 mv $LATEST.image $BASE.image
 mv $LATEST.changes $BASE.changes


### PR DESCRIPTION
Building spurreader.image was taking a long time because getlatesttrunkimage.sh was still using 5.2. I changed the URL to use current_stable so that the script doesn't have to change with each release.

The curl also needed a -L option to follow any redirects.