### PR TITLE
configure script : check for <ifaddrs.h>

### DIFF
--- a/platforms/Cross/vm/sqCogStackAlignment.h
+++ b/platforms/Cross/vm/sqCogStackAlignment.h
@@ -17,7 +17,7 @@
 /* getReturnAddress optionally defined here rather than in sqPlatformSpecific.h
  * to reduce duplication. The GCC intrinics are provided by other compilers too.
  */
-#if !defined(getReturnAddress)
+#if COGVM && !defined(getReturnAddress)
 # if _MSC_VER
 #	define getReturnAddress() _ReturnAddress()
 #	include <intrin.h>

--- a/platforms/unix/config/config.h.in
+++ b/platforms/unix/config/config.h.in
@@ -114,6 +114,9 @@
 /* Define to 1 if you have the <iconv.h> header file. */
 #undef HAVE_ICONV_H
 
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#undef HAVE_IFADDRS_H
+
 /* Interpreter header file present */
 #undef HAVE_INTERP_H
 

--- a/platforms/unix/config/configure.ac
+++ b/platforms/unix/config/configure.ac
@@ -292,6 +292,7 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS_ONCE([unistd.h string.h fcntl.h sys/file.h sys/param.h])
 AC_CHECK_HEADERS_ONCE([sys/time.h sys/filio.h sys/select.h])
 AC_CHECK_HEADERS_ONCE([features.h])
+AC_CHECK_HEADERS_ONCE([ifaddrs.h]) # sqUnixSocket.c
 AC_CHECK_HEADERS_ONCE([alloca.h]) # SunOS5
 AC_HEADER_TIME
 AC_HEADER_DIRENT

--- a/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
+++ b/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
@@ -92,7 +92,9 @@
 # include <netinet/tcp.h>
 # include <arpa/inet.h>
 # include <netdb.h>
-#include <ifaddrs.h>
+#ifdef HAVE_IFADDRS_H
+# include <ifaddrs.h>
+#endif
 # include <errno.h>
 # include <unistd.h>
   
@@ -1499,7 +1501,7 @@ sqInt sqResolverStatus(void)
 sqInt sqResolverAddrLookupResultSize(void)	{ return strlen(lastName); }
 sqInt sqResolverError(void)			{ return lastError; }
 sqInt sqResolverLocalAddress(void)
-#if 0 
+#ifndef HAVE_IFADDRS_H
 /* old code */
 {	sqInt localaddr = nameToAddr(localHostName);
 	if (!localaddr)

--- a/platforms/unix/plugins/UnicodePlugin/README.UnicodePlugin
+++ b/platforms/unix/plugins/UnicodePlugin/README.UnicodePlugin
@@ -1,1 +1,27 @@
 In order to build the Unicode plugin on Linux, you'll need a collection of Pango, Cairo, and glib header and library files. These can often be found in the GTK+ development package in the package repository for your version of Linux.
+
+NOTE: on Solaris 11.4 there is an issue that the UnicodePlugin is disabled,
+because the XCPPFLAGS are incorrect.
+
+XCPPFLAGS includes -I/usr/lib/glib-2.0/include -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include -I/usr/lib/i386-linux-gnu/glib-2.0/include
+
+The acinclude.m4 macro could be (but this may have other problems):
+
+PKG_CHECK_MODULES(UNICODE_PLUGIN,[glib-2.0 pangocairo],,AC_PLUGIN_DISABLE)
+
+AC_SUBST(UNICODE_PLUGIN_CFLAGS)
+AC_SUBST(UNICODE_PLUGIN_LIBS)
+
+The issue is that in the 32bit case
+
+ # pkg-config --cflags glib-2.0
+ -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include  
+
+and in the 64bit (amd64 case)
+
+ # PKG_CONFIG_PATH=/usr/lib/64/pkgconfig pkg-config --cflags glib-2.0
+ -I/usr/include/glib-2.0 -I/usr/lib/amd64/glib-2.0/include  
+
+There are workarounds such as disabling the Plugin (which is the case now),
+or just patch the include path, and then it builds fine.
+


### PR DESCRIPTION
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA256


A few commits that could be of use:

  1. modify configure.ac to check for the header file <ifaddrs.h>
  2. update README of UnicodePlugin
  3. #if COGVM in the sqCogStackAlignment.h for getReturnAddress

The COGVM compiles and works in 32bit on Solaris 10.
It also works now (thanks to code for getReturnAddress) in 64bit on Solaris 11.

Solaris 10 has no header file <ifaddrs.h> it appears, to in that case,
the configure script can automatically 'activate' the old code in
sqUnixSocket.c.  In the Solaris 11 case, it has <ifaddrs.h>, so activate the
new code on Solaris 11.

David Stes

-----BEGIN PGP SIGNATURE-----
Version: GnuPG v2

iQEcBAEBCAAGBQJfazvaAAoJEAwpOKXMq1MaOBMH/0oAanU940wnZi6UnptEXDzL
H4TGeGlQvX+2939+PP79CxAa0yMNQWe/Ew1f2GsERQruKXZAr76lYQPXaJsY2duI
dUeNaNxvPUuKDlsKnrltUnfDgDazYER8NluCZE3tBV8ZUVxak07u/HLUMs/lXP/9
MO/UctlbDSc8KgZlUkBlaffCzz/DtNV/CrgHZNUlPHb9GyLJD2mctc0H7qYkr1o6
2Y3QoOrC1U//4nK/2JbUV9i4lVVj/g1P9CSjRMe2P1ptZp6GfoWod1XAQMM1TIFP
tjZqhxFDB3PHnhdhyBbLrqEbAXoexi2F6nET3xGXEUPYJr6QL6w9rXf3wdhJGVM=
=tynH
-----END PGP SIGNATURE-----
