### PR TITLE
Add  -DAIO_DEBUG to mvm files for SunOS

### DIFF
--- a/build.sunos32x86/squeak.cog.spur/build/mvm
+++ b/build.sunos32x86/squeak.cog.spur/build/mvm
@@ -11,7 +11,7 @@ esac
 MAKE=gmake
 INSTALLDIR=sqcogspursunosht/usr
 # Some gcc versions create a broken VM using -O2
-OPT="-g -DNDEBUG -DDEBUGVM=0"
+OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0"
 
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift

--- a/build.sunos32x86/squeak.cog.spur/build/mvm
+++ b/build.sunos32x86/squeak.cog.spur/build/mvm
@@ -8,7 +8,7 @@ i86pc) ;; # we're good
 fi ;;
 esac
 # Spur VM with VM profiler and threaded heartbeat
-MAKE=/usr/bin/gmake
+MAKE=gmake
 INSTALLDIR=sqcogspursunosht/usr
 # Some gcc versions create a broken VM using -O2
 OPT="-g -DNDEBUG -DDEBUGVM=0"

--- a/build.sunos32x86/squeak.stack.spur/build/mvm
+++ b/build.sunos32x86/squeak.stack.spur/build/mvm
@@ -11,7 +11,7 @@ esac
 INSTALLDIR=sqstkspursunosht/usr
 # Some gcc versions create a broken VM using -O2
 OPT="-g -DNDEBUG -DDEBUGVM=0"
-MAKE=/usr/bin/gmake
+MAKE=gmake
 
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift

--- a/build.sunos32x86/squeak.stack.spur/build/mvm
+++ b/build.sunos32x86/squeak.stack.spur/build/mvm
@@ -10,7 +10,7 @@ esac
 # Stack Spur VM with VM profiler and threaded heartbeat
 INSTALLDIR=sqstkspursunosht/usr
 # Some gcc versions create a broken VM using -O2
-OPT="-g -DNDEBUG -DDEBUGVM=0"
+OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0"
 MAKE=gmake
 
 if [ $# -ge 1 ]; then

--- a/build.sunos64x64/squeak.cog.spur/build/mvm
+++ b/build.sunos64x64/squeak.cog.spur/build/mvm
@@ -3,7 +3,7 @@ set -e
 # Spur VM with VM profiler and threaded heartbeat
 INSTALLDIR=sqcogspur64sunosht/usr
 # Some gcc versions create a broken VM using -O2
-OPT="-g -DNDEBUG -DDEBUGVM=0"
+OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0"
 MAKE=gmake
 
 CFLAGS="$OPT -DCOGMTVM=0"

--- a/build.sunos64x64/squeak.cog.spur/build/mvm
+++ b/build.sunos64x64/squeak.cog.spur/build/mvm
@@ -4,7 +4,7 @@ set -e
 INSTALLDIR=sqcogspur64sunosht/usr
 # Some gcc versions create a broken VM using -O2
 OPT="-g -DNDEBUG -DDEBUGVM=0"
-MAKE=/usr/bin/gmake
+MAKE=gmake
 
 CFLAGS="$OPT -DCOGMTVM=0"
 LIBS=""

--- a/build.sunos64x64/squeak.stack.spur/build/mvm
+++ b/build.sunos64x64/squeak.stack.spur/build/mvm
@@ -3,7 +3,7 @@ set -e
 # Stack Spur VM with VM profiler and threaded heartbeat
 INSTALLDIR=sqstkspur64sunosht/usr
 # Some gcc versions create a broken VM using -O2
-OPT="-g -DNDEBUG -DDEBUGVM=0"
+OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0"
 MAKE=gmake
 
 if [ $# -ge 1 ]; then

--- a/build.sunos64x64/squeak.stack.spur/build/mvm
+++ b/build.sunos64x64/squeak.stack.spur/build/mvm
@@ -4,7 +4,7 @@ set -e
 INSTALLDIR=sqstkspur64sunosht/usr
 # Some gcc versions create a broken VM using -O2
 OPT="-g -DNDEBUG -DDEBUGVM=0"
-MAKE=/usr/bin/gmake
+MAKE=gmake
 
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift


### PR DESCRIPTION
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA256


Hi,

The following patch adds -DAIO_DEBUG to the SunOS mvm scripts.

It should be safe as this only impacts the build.sunos* directories.

Note on the other hand that I think the -aiolog option is interesting,
because probably the UNIX AT&T derived kernel specifics are different
in a subtle way from BSD UNIX or Linux derived kernels.

Remember that a few months ago I actually submitted a patch

platforms/unix/vm/aio.c:

# include <sys/file.h> /* FASYNC or ioctl FIOASYNC will be issued  */

I suspect this is a very complicated matter ... (unfortunately).

But it may help to have the -aiolog.

Regards,
David Stes

-----BEGIN PGP SIGNATURE-----
Version: GnuPG v2

iQEcBAEBCAAGBQJfhEZkAAoJEAwpOKXMq1MaOhwIAJco0jGEz7qR1mOliCcFuMaw
hx94K/xZdFZ/VITM6Za2ZINq+sfDOnBiFyOYkRd3ZpCbdp3s0/TzhVmRLRGk+Das
qeevFJ4Oa/R6boyrwCx1OK02Ps8WHCHMN+YWpzXU1lyJmARgGy4bUHkZes4I1wtd
yQGRWLSRjyQCCyl1PPiCazwtKUH6Vd/Kax79yVU51zPwTtKnz4Y0uX2Z7yOwqZ3x
K+YRXdUaKkTqsldfj37oAjAdHW1bCUSbMP2UUfFZyS533Q7UYkzcwxnsbXC5uAl4
Xl7MXlhtnFnlQwA4lYf7fcz+s6J9hBWzQY6aBQTM4Mq8rcXA8WKf+YIwTCEaA6s=
=K1T7
-----END PGP SIGNATURE-----
