### PR TITLE
Fix image opening on unix

### DIFF
--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -1977,13 +1977,13 @@ void imgInit(void)
 	  dpy->winImageNotFound();
 	  imageNotFound(shortImageName);
 	}
-      {
-	int fd= open(imageName, O_RDONLY);
+
+	int fd = fileno(f);
 	if (fd < 0) abort();
 #      ifdef DEBUG_IMAGE
 	printf("fstat(%d) => %d\n", fd, fstat(fd, &sb));
 #      endif
-      }
+
       recordFullPathForImageName(shortImageName); /* full image path */
       if (extraMemory)
 	useMmap= 0;
@@ -1993,12 +1993,12 @@ void imgInit(void)
       printf("image size %ld + heap size %ld (useMmap = %d)\n", (long)sb.st_size, extraMemory, useMmap);
 #    endif
 #if SPURVM
-	  readImageFromFileHeapSizeStartingAt(f, 0, 0);
+	  readImageFromFileHeapSizeStartingAt(fd, 0, 0);
 #else
       extraMemory += (long)sb.st_size;
-      readImageFromFileHeapSizeStartingAt(f, extraMemory, 0);
+      readImageFromFileHeapSizeStartingAt(fd, extraMemory, 0);
 #endif
-      sqImageFileClose(f);
+      sqImageFileClose(fd);
       break;
     }
 }


### PR DESCRIPTION
In imgInit() of sqUnixMain.c
- preserve fd instead of throwing it away
- use fileno() to get the file descriptor (fd) created by fopen() instead of
  opening the file again with open() (which leaked a file descriptor due to
  lack of close())
- pass the file descriptor fd instead of the FILE* f to the recently changed
  methods expecting a file descriptor, e.g. readImageFromFileHeapSizeStartingAt()