### PR TITLE
SunOS change: make sure lseek64 is used (configure in 32bit)

### DIFF
--- a/build.sunos32x86/squeak.cog.spur/build/mvm
+++ b/build.sunos32x86/squeak.cog.spur/build/mvm
@@ -10,8 +10,10 @@ esac
 # Spur VM with VM profiler and threaded heartbeat
 MAKE=gmake
 INSTALLDIR=sqcogspursunosht/usr
+# GNU configure AC_SYS_LARGEFILE is not adding -D_FILE_OFFSET_BITS (config.h)
+# to use lseek64 instead of lseek, must -D it here
 # Some gcc versions create a broken VM using -O2
-OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0"
+OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
 
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift

--- a/build.sunos32x86/squeak.stack.spur/build/mvm
+++ b/build.sunos32x86/squeak.stack.spur/build/mvm
@@ -9,8 +9,10 @@ fi ;;
 esac
 # Stack Spur VM with VM profiler and threaded heartbeat
 INSTALLDIR=sqstkspursunosht/usr
+# GNU configure AC_SYS_LARGEFILE is not adding -D_FILE_OFFSET_BITS (config.h)
+# to use lseek64 instead of lseek, must -D it here
 # Some gcc versions create a broken VM using -O2
-OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0"
+OPT="-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
 MAKE=gmake
 
 if [ $# -ge 1 ]; then


### PR DESCRIPTION

Add  -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 to the mvm scripts for SunOS 32bit.

This could be due to a 'bug' in GNU autoconf / configure which makes AC_SYS_LARGEFILE only set those defines in the config.h and not on the cc command line in the Makefile's.

Even if the configure script would be fixed, I think the defines on the cmd.line would not hurt, but if configure would be fixed then these defines would be unnecessary.

David Stes