### PR TITLE
Plumb OS X custom url scheme events into drop events

### DIFF
--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.h
@@ -53,5 +53,6 @@
 - (int) mapMouseAndModifierStateToSqueakBits: (NSEvent *) event;
 - (int) translateCocoaModifiersToSqueakModifiers: (NSUInteger) modifiers;
 - (void) recordDragEvent: (int) dragType numberOfFiles: (int) numFiles where: (NSPoint) local_point windowIndex: (sqInt) windowIndex view:(NSView *)aView;
+- (void) recordURLEvent: (int) dragType numberOfFiles: (int) numFiles;
 - (void) recordWindowEvent: (int) type window: (NSWindow *) window;
 @end

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -561,6 +561,23 @@ yZero()
 	interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
 }
 
+- (void) recordURLEvent:(int)dragType numberOfFiles:(int)numFiles
+{
+	sqDragDropFilesEvent evt;
+
+	evt.type= EventTypeDragDropFiles;
+	evt.timeStamp= ioMSecs();
+	evt.dragType= dragType;
+	evt.x = 0;
+	evt.y = 0;
+	evt.modifiers= 0;
+	evt.numFiles= numFiles;
+	evt.windowIndex =  0;
+	[self pushEventToQueue: (sqInputEvent *) &evt];
+
+	interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
+}
+
 - (void) recordWindowEvent: (int) windowEventType window: (NSWindow *) window {
 	sqWindowEvent evt;
 

--- a/platforms/iOS/vm/OSX/sqSqueakOSXDropAPI.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXDropAPI.m
@@ -51,13 +51,22 @@ sqInt dropShutdown(void) {
 };
 
 char *dropRequestFileName(sqInt dropIndex) {
-	/* return file name or NULL if error */
 	NSView <sqSqueakOSXView> *view = [((sqSqueakOSXScreenAndWindow*)((__bridge NSWindow *)windowHandleFromIndex(1)).delegate) getMainViewOnWindow];
-	NSString *fileNameString = [view dragFileNameStringAtIndex: dropIndex];
-	return (char *) [fileNameString UTF8String];
+	NSURL *dragURIAtIndex = [view dragURIAtIndex: dropIndex];
+	if(!dragURIAtIndex || !dragURIAtIndex.fileURL)
+		return NULL;
+	
+	return (char *) [dragURIAtIndex.path UTF8String];
 }
 
-char *dropRequestURI(sqInt dropIndex) { return NULL; }
+char *dropRequestURI(sqInt dropIndex) {
+	NSView <sqSqueakOSXView> *view = [((sqSqueakOSXScreenAndWindow*)((__bridge NSWindow *)windowHandleFromIndex(1)).delegate) getMainViewOnWindow];
+	NSURL *dragURIAtIndex = [view dragURIAtIndex: dropIndex];
+	if(!dragURIAtIndex)
+		return NULL;
+	
+	return (char *) [dragURIAtIndex.absoluteString UTF8String];
+}
 
 /* note: dropRequestFileHandle needs to bypass plugin security checks when implemented */
 sqInt dropRequestFileHandle(sqInt dropIndex) {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -169,6 +169,11 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 	colorspace = CGColorSpaceCreateDeviceRGB();
 	[self initializeSqueakColorMap];
     [[NSNotificationCenter defaultCenter] addObserver:self selector: @selector(didEnterFullScreen:) name:@"NSWindowDidEnterFullScreenNotification" object:nil];
+	
+	NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
+	[appleEventManager setEventHandler:self
+					   andSelector:@selector(handleGetURLEvent:withReplyEvent:)
+					 forEventClass:kInternetEventClass andEventID:kAEGetURL];
 }
 
 - (void) didEnterFullScreen: (NSNotification*) aNotification {
@@ -781,8 +786,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 	return results;
 }
 
-
-- (NSMutableArray *) filterOutSqueakImageFilesFromDraggedFiles: (id<NSDraggingInfo>)info {
+- (NSMutableArray *) filterOutSqueakImageFilesFromDraggedURIs: (id<NSDraggingInfo>)info {
 	NSPasteboard *pboard= [info draggingPasteboard];
 	NSMutableArray *results = [NSMutableArray arrayWithCapacity: 10];
 	if ([[pboard types] containsObject: NSFilenamesPboardType]) {
@@ -790,14 +794,17 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 		NSString *fileName;
 		for (fileName in files) {
 			if ([((sqSqueakOSXApplication*) gDelegateApp.squeakApplication) isImageFile: fileName] == NO)
-				[results addObject: fileName];
+			{
+				[results addObject: [NSURL fileURLWithPath: fileName]];
+			}
 		}
 	}
+
 	return results;
 }
 
 - (NSUInteger) countNumberOfNoneSqueakImageFilesInDraggedFiles: (id<NSDraggingInfo>)info {
-	NSArray *files = [self filterOutSqueakImageFilesFromDraggedFiles: info];
+	NSArray *files = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 	return [files count];
 }
 
@@ -836,7 +843,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 - (BOOL) performDragOperation: (id<NSDraggingInfo>)info {
 //    NSLog(@"performDragOperation %@",info);
 	if (self.dragCount) {
-		self.dragItems = [self filterOutSqueakImageFilesFromDraggedFiles: info];
+		self.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	}
 
@@ -860,13 +867,22 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,l
 	return YES;
 }
 
-- (NSString*) dragFileNameStringAtIndex: (sqInt) index {
-	if (!self.dragItems
-	 || index < 1 || index > [self.dragItems count])
-		return NULL;
-	return (self.dragItems)[(NSUInteger) index - 1];
+- (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
+{
+	NSString* urlString = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+	NSURL *url = [NSURL URLWithString: urlString];
+	dragItems = [NSMutableArray arrayWithCapacity: 1];
+	[dragItems addObject: url];
+	
+	[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordURLEvent: SQDragDrop numberOfFiles: 1];
 }
 
+- (NSURL*) dragURIAtIndex: (sqInt) index {
+	if (!self.dragItems || index < 1 || index > [self.dragItems count])
+		return NULL;
+	
+	return (self.dragItems)[(NSUInteger) index - 1];
+}
 
 - (BOOL)ignoreModifierKeysWhileDragging {
 	return YES;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXView.h
@@ -53,10 +53,9 @@
 - (void) ioSetFullScreen: (sqInt) fullScreen;
 
 - (NSUInteger) countNumberOfNoneSqueakImageFilesInDraggedFiles: (id<NSDraggingInfo>)info;
-- (NSMutableArray *) filterOutSqueakImageFilesFromDraggedFiles: (id<NSDraggingInfo>)info;
+- (NSMutableArray *) filterOutSqueakImageFilesFromDraggedURIs: (id<NSDraggingInfo>)info;
 - (NSMutableArray *) filterSqueakImageFilesFromDraggedFiles: (id<NSDraggingInfo>)info;
-- (NSString*) dragFileNameStringAtIndex:(sqInt) index;
-
+- (NSURL*) dragURIAtIndex:(sqInt) index;
 - (void) drawThelayers;
 - (void) preDrawThelayers;
 - (void) drawImageUsingClip: (CGRect) clip;


### PR DESCRIPTION
These changes are needed for handling custom url schemes in OS X, which gets translated into drop events. Feature requested by Eliot.