### PR TITLE
In forgetXDisplay() do not call aioDisable() for the socket connection

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -6797,8 +6797,10 @@ int forgetXDisplay(void)
   stDisplay= null;      /* Squeak display                       */
   if (isConnectedToXServer)
     close(stXfd);
+#if ! (HAVE_CONFIG_H && HAVE_EPOLL)
   if (stXfd >= 0)
     aioDisable(stXfd);
+#endif
   stXfd= -1;		/* X connection file descriptor         */
   stParent= null;
   stWindow= null;       /* Squeak window                        */


### PR DESCRIPTION
to the X11 server if Linux epoll event handling is being used, because
forgetXDisplay() is typically called after a fork(). With epoll event
handling the shared fd reference affects both parent and child badly.