### PR TITLE
OS X custom URL scheme and document open event injection fixup

### DIFF
--- a/platforms/iOS/vm/OSX/SqueakOSXAppDelegate.h
+++ b/platforms/iOS/vm/OSX/SqueakOSXAppDelegate.h
@@ -50,6 +50,8 @@
 	BOOL checkForFileNameOnFirstParm;
 	NSString *possibleImageNameAtLaunchTime;
     sqSqueakOSXScreenAndWindow *windowHandler;
+    
+	NSMutableArray*  dragItems;
 }
 
 @property (nonatomic,weak) IBOutlet NSWindow *window;
@@ -57,5 +59,9 @@
 @property (nonatomic,strong) NSString *possibleImageNameAtLaunchTime;
 @property (nonatomic,assign) BOOL checkForFileNameOnFirstParm;
 @property (nonatomic, strong) sqSqueakNullScreenAndWindow *windowHandler;
+@property (nonatomic, strong) NSMutableArray *dragItems;
+
+- (BOOL)isImageFile:(NSString *)filePath;
+- (NSURL*) dragURIAtIndex:(sqInt) index;
 
 @end

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -580,7 +580,9 @@ yZero()
 	evt.windowIndex =  0;
 	[self pushEventToQueue: (sqInputEvent *) &evt];
 
-	interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
+	// interpreterProxy is nil when injecting events before startup.
+	if(interpreterProxy)
+		interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
 }
 
 - (void) recordWindowEvent: (int) windowEventType window: (NSWindow *) window {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
@@ -46,6 +46,9 @@
 #import "sqSqueakOSXApplication+imageReadWrite.h"
 #import "sqSqueakOSXApplication+attributes.h"
 #import "sqSqueakOSXViewFactory.h"
+#import "SqueakOSXAppDelegate.h"
+
+extern SqueakOSXAppDelegate *gDelegateApp;
 
 #if !defined(IMAGE_DIALECT_NAME)
 # if NewspeakVM
@@ -594,23 +597,7 @@ static char *getVersionInfo(int verbose);
 
 - (BOOL) isImageFile: (NSString *) filePath
 {
- 	NSFileManager *dfm = [NSFileManager defaultManager];
-	BOOL isDirectory;
-
-	[dfm fileExistsAtPath: filePath isDirectory: &isDirectory];
-
-	if (isDirectory) 
-		return NO;
-
-	BOOL fileIsReadable = [[NSFileManager defaultManager] isReadableFileAtPath: filePath];
-
-	if (fileIsReadable == NO)
-		return NO;
-
-	if ([[[filePath lastPathComponent] pathExtension] compare: @"image" options: NSCaseInsensitiveSearch] ==   NSOrderedSame)
-		return YES;
-
-	return NO;
+	return [gDelegateApp isImageFile: filePath];
 }
 
 @end

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.h
@@ -56,7 +56,6 @@
 	int		dragCount;
 	BOOL	firstDrawCompleted;
 	BOOL	syncNeeded;
-	NSMutableArray*  dragItems;
 	CGDisplayFadeReservationToken    fadeToken;
 	NSRect	savedScreenBoundsAtTimeOfFullScreen;
 	CGColorSpaceRef colorspace;	

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -58,7 +58,7 @@ static NSString *stringWithCharacter(unichar character) {
 
 @implementation sqSqueakOSXCGView
 @synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
-lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
+lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
 
 #pragma mark Initialization / Release
 
@@ -83,14 +83,8 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
     [self registerForDraggedTypes: [NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
 	dragInProgress = NO;
 	dragCount = 0;
-	dragItems = NULL;
 	clippyIsEmpty = YES;
 	colorspace = CGColorSpaceCreateDeviceRGB();
-	
-	NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
-	[appleEventManager setEventHandler:self
-					   andSelector:@selector(handleGetURLEvent:withReplyEvent:)
-					 forEventClass:kInternetEventClass andEventID:kAEGetURL];
 }
 
 - (void) initializeVariables {
@@ -618,12 +612,12 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragLeave numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
 	self.dragCount = 0;
 	self.dragInProgress = NO;
-	self.dragItems = NULL;
+	gDelegateApp.dragItems = NULL;
 }
 
 - (BOOL) performDragOperation: (id<NSDraggingInfo>)info {
 	if (self.dragCount) {
-		self.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
+		gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
 	}
 	
@@ -648,24 +642,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	dragInProgress = NO;
 	return YES;
 }
-
-- (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
-{
-	NSString* urlString = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-	NSURL *url = [NSURL URLWithString: urlString];
-	dragItems = [NSMutableArray arrayWithCapacity: 1];
-	[dragItems addObject: url];
-	
-	[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordURLEvent: SQDragDrop numberOfFiles: 1];
-}
-
-- (NSURL*) dragURIAtIndex: (sqInt) index {
-	if (!self.dragItems || index < 1 || index > [self.dragItems count])
-		return NULL;
-	
-	return (self.dragItems)[(NSUInteger) index - 1];
-}
-
 
 - (BOOL)ignoreModifierKeysWhileDragging {
 	return YES;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXDropAPI.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXDropAPI.m
@@ -39,7 +39,9 @@
 #include "sqMacHostWindow.h"
 #include "sq.h"
 #import "sqSqueakOSXView.h"
+#import "SqueakOSXAppDelegate.h"
 
+extern SqueakOSXAppDelegate *gDelegateApp;
 extern struct VirtualMachine* interpreterProxy;
 
 sqInt dropInit(void) {
@@ -51,8 +53,7 @@ sqInt dropShutdown(void) {
 };
 
 char *dropRequestFileName(sqInt dropIndex) {
-	NSView <sqSqueakOSXView> *view = [((sqSqueakOSXScreenAndWindow*)((__bridge NSWindow *)windowHandleFromIndex(1)).delegate) getMainViewOnWindow];
-	NSURL *dragURIAtIndex = [view dragURIAtIndex: dropIndex];
+	NSURL *dragURIAtIndex = [gDelegateApp dragURIAtIndex: dropIndex];
 	if(!dragURIAtIndex || !dragURIAtIndex.fileURL)
 		return NULL;
 	
@@ -60,8 +61,7 @@ char *dropRequestFileName(sqInt dropIndex) {
 }
 
 char *dropRequestURI(sqInt dropIndex) {
-	NSView <sqSqueakOSXView> *view = [((sqSqueakOSXScreenAndWindow*)((__bridge NSWindow *)windowHandleFromIndex(1)).delegate) getMainViewOnWindow];
-	NSURL *dragURIAtIndex = [view dragURIAtIndex: dropIndex];
+	NSURL *dragURIAtIndex = [gDelegateApp dragURIAtIndex: dropIndex];
 	if(!dragURIAtIndex)
 		return NULL;
 	

--- a/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.h
@@ -55,7 +55,6 @@
 	int		dragCount;
 	BOOL	firstDrawCompleted;
 	BOOL	syncNeeded;
-	NSMutableArray*  dragItems;
 	CGDisplayFadeReservationToken    fadeToken;
 	NSRect	savedScreenBoundsAtTimeOfFullScreen;
 	CGColorSpaceRef colorspace;	

--- a/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.m
@@ -51,7 +51,7 @@ static NSString *stringWithCharacter(unichar character) {
 
 @implementation sqSqueakOSXHeadlessView
 @synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
-lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
+lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
 
 #pragma mark Initialization / Release
 
@@ -76,7 +76,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
     [self registerForDraggedTypes: [NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
 	dragInProgress = NO;
 	dragCount = 0;
-	dragItems = NULL;
 	clippyIsEmpty = YES;
 	colorspace = CGColorSpaceCreateDeviceRGB();
 }

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
@@ -57,7 +57,6 @@
 	int		dragCount;
 	BOOL	firstDrawCompleted;
 	BOOL	syncNeeded;
-	NSMutableArray*  dragItems;
 	CGDisplayFadeReservationToken    fadeToken;
 	NSRect	savedScreenBoundsAtTimeOfFullScreen;
 	CGColorSpaceRef colorspace;	

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
@@ -58,7 +58,6 @@
 	int		dragCount;
 	BOOL	firstDrawCompleted;
 	BOOL	syncNeeded;
-	NSMutableArray*  dragItems;
 	CGDisplayFadeReservationToken    fadeToken;
 	CGColorSpaceRef colorspace;
 	unsigned int*      colorMap32;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXView.h
@@ -55,7 +55,6 @@
 - (NSUInteger) countNumberOfNoneSqueakImageFilesInDraggedFiles: (id<NSDraggingInfo>)info;
 - (NSMutableArray *) filterOutSqueakImageFilesFromDraggedURIs: (id<NSDraggingInfo>)info;
 - (NSMutableArray *) filterSqueakImageFilesFromDraggedFiles: (id<NSDraggingInfo>)info;
-- (NSURL*) dragURIAtIndex:(sqInt) index;
 - (void) drawThelayers;
 - (void) preDrawThelayers;
 - (void) drawImageUsingClip: (CGRect) clip;


### PR DESCRIPTION
These change fixup the events for handling custom url schemes, and the support for opening document types registered in the plist that are received as events before the image is even opened by the VM. These event are injected as drop event into the image for further processing.