### PR TITLE
Fix issue #557 (workaround?)

### DIFF
--- a/platforms/Cross/vm/sqAssert.h
+++ b/platforms/Cross/vm/sqAssert.h
@@ -21,12 +21,18 @@ IMPORT(void) error(const char *);
 IMPORT(void) warning(const char *);
 IMPORT(void) warningat(const char *,int);
 #else
-# if !defined(EXPORT)
-#	define EXPORT(returnType) returnType
-# endif
+# if defined(SQUEAK_BUILTIN_PLUGIN)
+void error(const char *);
+void warning(const char *);
+void warningat(const char *,int);
+# else
+#   if !defined(EXPORT)
+#	  define EXPORT(returnType) returnType
+#   endif
 EXPORT(void) error(const char *);
 EXPORT(void) warning(const char *);
 EXPORT(void) warningat(const char *,int);
+#  endif
 #endif
 #pragma auto_inline(on)
 


### PR DESCRIPTION
If we build an internal plugin `SQUEAK_BUILTIN_PLUGIN`, then we don't need to `EXPORT` the error/warning functions.
There are still conflicting definitions in sqVirtualMachine.h which totally ignore IMPORT/EXPORT but these only generate warnings, not errors.