### PR TITLE
(Re-post) Fixes mvm error codes for Linux and Windows builds

### DIFF
--- a/build.linux32ARMv6/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv6/newspeak.cog.spur/build.assert/mvm
@@ -27,5 +27,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv6/newspeak.cog.spur/build.debug/mvm
@@ -27,5 +27,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/newspeak.cog.spur/build/mvm
+++ b/build.linux32ARMv6/newspeak.cog.spur/build/mvm
@@ -27,5 +27,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARMv6/newspeak.stack.spur/build.assert/mvm
@@ -27,5 +27,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARMv6/newspeak.stack.spur/build.debug/mvm
@@ -27,5 +27,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/newspeak.stack.spur/build/mvm
+++ b/build.linux32ARMv6/newspeak.stack.spur/build/mvm
@@ -27,5 +27,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/pharo.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build.assert/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/pharo.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build.debug/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv6/pharo.cog.spur/build/mvm
+++ b/build.linux32ARMv6/pharo.cog.spur/build/mvm
@@ -49,7 +49,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32ARMv6/squeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.cog.spur/build.assert/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.cog.spur/build.debug/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.cog.spur/build/mvm
+++ b/build.linux32ARMv6/squeak.cog.spur/build/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.cog.v3/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.cog.v3/build.assert/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.cog.v3/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.cog.v3/build.debug/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.cog.v3/build/mvm
+++ b/build.linux32ARMv6/squeak.cog.v3/build/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.stack.spur/build.assert/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.stack.spur/build.debug/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.stack.spur/build/mvm
+++ b/build.linux32ARMv6/squeak.stack.spur/build/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.stack.v3/build.assert/mvm
+++ b/build.linux32ARMv6/squeak.stack.v3/build.assert/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.stack.v3/build.debug/mvm
+++ b/build.linux32ARMv6/squeak.stack.v3/build.debug/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv6/squeak.stack.v3/build/mvm
+++ b/build.linux32ARMv6/squeak.stack.v3/build/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32ARMv7/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARMv7/newspeak.cog.spur/build.assert/mvm
@@ -26,5 +26,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv7/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARMv7/newspeak.cog.spur/build.debug/mvm
@@ -26,5 +26,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv7/newspeak.cog.spur/build/mvm
+++ b/build.linux32ARMv7/newspeak.cog.spur/build/mvm
@@ -26,5 +26,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv7/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARMv7/newspeak.stack.spur/build.assert/mvm
@@ -26,5 +26,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv7/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARMv7/newspeak.stack.spur/build.debug/mvm
@@ -26,5 +26,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32ARMv7/newspeak.stack.spur/build/mvm
+++ b/build.linux32ARMv7/newspeak.stack.spur/build/mvm
@@ -26,5 +26,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -35,5 +35,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.assert/mvm
@@ -37,5 +37,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -35,5 +35,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.debug/mvm
@@ -37,5 +37,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build.itimerheartbeat/mvm
@@ -36,5 +36,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.cog.spur/build/mvm
+++ b/build.linux32x86/newspeak.cog.spur/build/mvm
@@ -38,5 +38,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32x86/newspeak.stack.spur/build.assert/mvm
@@ -37,5 +37,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32x86/newspeak.stack.spur/build.debug/mvm
@@ -37,5 +37,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/newspeak.stack.spur/build/mvm
+++ b/build.linux32x86/newspeak.stack.spur/build/mvm
@@ -38,5 +38,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
@@ -35,5 +35,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -DEnforceAccessControl=0 -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux32x86/nsnac.cog.spur/build.assert/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.assert/mvm
@@ -37,5 +37,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux32x86/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
@@ -35,5 +35,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -DEnforceAccessControl=0 -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux32x86/nsnac.cog.spur/build.debug/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.debug/mvm
@@ -37,5 +37,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux32x86/nsnac.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build.itimerheartbeat/mvm
@@ -36,5 +36,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -DEnforceAccessControl=0 -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux32x86/nsnac.cog.spur/build/mvm
+++ b/build.linux32x86/nsnac.cog.spur/build/mvm
@@ -38,5 +38,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.assert.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.assert/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.assert/mvm
@@ -35,5 +35,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.debug.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.debug/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.debug/mvm
@@ -34,5 +34,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/pharo.cog.spur.lowcode/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build.itimerheartbeat/mvm
@@ -47,7 +47,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 for lib in ${THIRDPARTYLIBS}; do
 	../../third-party/${lib}/mvm install `find ../../../products/$INSTALLDIR -name "5.0*"`
 done

--- a/build.linux32x86/pharo.cog.spur.lowcode/build/mvm
+++ b/build.linux32x86/pharo.cog.spur.lowcode/build/mvm
@@ -48,7 +48,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
@@ -35,4 +35,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
@@ -35,4 +35,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
@@ -48,7 +48,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.assert.itimerheartbeat/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.cog.spur/build.assert/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.assert/mvm
@@ -36,5 +36,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/pharo.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.debug.itimerheartbeat/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.cog.spur/build.debug/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.debug/mvm
@@ -36,5 +36,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/pharo.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.cog.spur/build.itimerheartbeat/mvm
@@ -47,7 +47,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.cog.spur/build/mvm
+++ b/build.linux32x86/pharo.cog.spur/build/mvm
@@ -49,7 +49,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.sista.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.assert.itimerheartbeat/mvm
@@ -37,7 +37,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.sista.spur/build.assert/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.assert/mvm
@@ -37,7 +37,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.sista.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.debug.itimerheartbeat/mvm
@@ -40,7 +40,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.sista.spur/build.debug/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.debug/mvm
@@ -40,7 +40,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.sista.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.sista.spur/build.itimerheartbeat/mvm
@@ -41,7 +41,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.sista.spur/build/mvm
+++ b/build.linux32x86/pharo.sista.spur/build/mvm
@@ -42,7 +42,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.assert.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.assert/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.assert/mvm
@@ -35,5 +35,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.debug.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.debug/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.debug/mvm
@@ -34,5 +34,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux32x86/pharo.stack.spur.lowcode/build.itimerheartbeat/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build.itimerheartbeat/mvm
@@ -46,7 +46,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 for lib in ${THIRDPARTYLIBS}; do
 	../../third-party/${lib}/mvm install `find ../../../products/$INSTALLDIR -name "5.0*"`
 done

--- a/build.linux32x86/pharo.stack.spur.lowcode/build/mvm
+++ b/build.linux32x86/pharo.stack.spur.lowcode/build/mvm
@@ -48,7 +48,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux32x86/squeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.spur/build.assert/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.assert/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.spur/build.debug/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.debug/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.spur/build.itimerheartbeat/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.spur/build/mvm
+++ b/build.linux32x86/squeak.cog.spur/build/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.assert.itimerheartbeat/mvm
@@ -31,4 +31,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.assert/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.assert/mvm
@@ -31,4 +31,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.debug.itimerheartbeat/mvm
@@ -31,4 +31,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.debug/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.debug/mvm
@@ -31,4 +31,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.itimerheartbeat/mvm
@@ -32,4 +32,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.multithreaded.assert/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.multithreaded.assert/mvm
@@ -32,4 +32,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.multithreaded.debug/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.multithreaded.debug/mvm
@@ -32,4 +32,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build.multithreaded/mvm
+++ b/build.linux32x86/squeak.cog.v3/build.multithreaded/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.cog.v3/build/mvm
+++ b/build.linux32x86/squeak.cog.v3/build/mvm
@@ -32,4 +32,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.sista.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.assert.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.sista.spur/build.assert/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.assert/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.sista.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.debug.itimerheartbeat/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.sista.spur/build.debug/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.debug/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.sista.spur/build.itimerheartbeat/mvm
+++ b/build.linux32x86/squeak.sista.spur/build.itimerheartbeat/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.sista.spur/build/mvm
+++ b/build.linux32x86/squeak.sista.spur/build/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.stack.spur/build.assert/mvm
+++ b/build.linux32x86/squeak.stack.spur/build.assert/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.stack.spur/build.debug/mvm
+++ b/build.linux32x86/squeak.stack.spur/build.debug/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.stack.spur/build/mvm
+++ b/build.linux32x86/squeak.stack.spur/build/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.stack.v3/build.assert/mvm
+++ b/build.linux32x86/squeak.stack.v3/build.assert/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.stack.v3/build.debug/mvm
+++ b/build.linux32x86/squeak.stack.v3/build.debug/mvm
@@ -33,4 +33,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux32x86/squeak.stack.v3/build/mvm
+++ b/build.linux32x86/squeak.stack.v3/build/mvm
@@ -34,4 +34,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/pharo.stack.spur/build.debug/mvm
+++ b/build.linux64ARMv8/pharo.stack.spur/build.debug/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64ARMv8/pharo.stack.spur/build/mvm
+++ b/build.linux64ARMv8/pharo.stack.spur/build/mvm
@@ -48,7 +48,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag and Raspbian lacks `readlinks`
-make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make -j4 install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux64ARMv8/squeak.cog.spur/build.assert/mvm
+++ b/build.linux64ARMv8/squeak.cog.spur/build.assert/mvm
@@ -28,4 +28,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.cog.spur/build.debug/mvm
+++ b/build.linux64ARMv8/squeak.cog.spur/build.debug/mvm
@@ -28,4 +28,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.cog.spur/build/mvm
+++ b/build.linux64ARMv8/squeak.cog.spur/build/mvm
@@ -29,4 +29,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.cogmt.spur/build.assert/mvm
+++ b/build.linux64ARMv8/squeak.cogmt.spur/build.assert/mvm
@@ -29,4 +29,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.cogmt.spur/build.debug/mvm
+++ b/build.linux64ARMv8/squeak.cogmt.spur/build.debug/mvm
@@ -29,4 +29,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.cogmt.spur/build/mvm
+++ b/build.linux64ARMv8/squeak.cogmt.spur/build/mvm
@@ -30,4 +30,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.stack.spur/build.assert/mvm
+++ b/build.linux64ARMv8/squeak.stack.spur/build.assert/mvm
@@ -26,4 +26,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.stack.spur/build.debug/mvm
+++ b/build.linux64ARMv8/squeak.stack.spur/build.debug/mvm
@@ -29,4 +29,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64ARMv8/squeak.stack.spur/build/mvm
+++ b/build.linux64ARMv8/squeak.stack.spur/build/mvm
@@ -30,4 +30,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -29,5 +29,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.assert/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -29,5 +29,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.debug/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build.itimerheartbeat/mvm
@@ -30,5 +30,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.cog.spur/build/mvm
+++ b/build.linux64x64/newspeak.cog.spur/build/mvm
@@ -32,5 +32,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux64x64/newspeak.stack.spur/build.assert/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux64x64/newspeak.stack.spur/build.debug/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/newspeak.stack.spur/build/mvm
+++ b/build.linux64x64/newspeak.stack.spur/build/mvm
@@ -32,5 +32,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.assert.itimerheartbeat/mvm
@@ -29,5 +29,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -DEnforceAccessControl=0 -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux64x64/nsnac.cog.spur/build.assert/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.assert/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux64x64/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.debug.itimerheartbeat/mvm
@@ -29,5 +29,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -DEnforceAccessControl=0 -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux64x64/nsnac.cog.spur/build.debug/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.debug/mvm
@@ -31,5 +31,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux64x64/nsnac.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build.itimerheartbeat/mvm
@@ -30,5 +30,5 @@ test -f config.h || ../../../platforms/unix/config/configure \
 	CFLAGS="$OPT -DEnforceAccessControl=0 -msse2 -DITIMER_HEARTBEAT=1"
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux64x64/nsnac.cog.spur/build/mvm
+++ b/build.linux64x64/nsnac.cog.spur/build/mvm
@@ -32,5 +32,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editnewspeakinstall.sh ../../../products/$INSTALLDIR -source SqueakV41 "$@"

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.assert.itimerheartbeat/mvm
@@ -35,4 +35,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.debug.itimerheartbeat/mvm
@@ -35,4 +35,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur.minheadless/build.itimerheartbeat/mvm
@@ -48,7 +48,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux64x64/pharo.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.assert.itimerheartbeat/mvm
@@ -29,5 +29,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/pharo.cog.spur/build.assert/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.assert/mvm
@@ -29,5 +29,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/pharo.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.debug.itimerheartbeat/mvm
@@ -29,5 +29,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/pharo.cog.spur/build.debug/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.debug/mvm
@@ -29,5 +29,5 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 ../../editpharoinstall.sh ../../../products/$INSTALLDIR "$@"

--- a/build.linux64x64/pharo.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/pharo.cog.spur/build.itimerheartbeat/mvm
@@ -40,7 +40,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux64x64/pharo.cog.spur/build/mvm
+++ b/build.linux64x64/pharo.cog.spur/build/mvm
@@ -40,7 +40,7 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0
 productDir=`find ../../../products/$INSTALLDIR -name "5.0*"`
 productDir=`(cd $productDir;pwd)`
 for lib in ${THIRDPARTYLIBS}; do

--- a/build.linux64x64/squeak.cog.spur/build.assert.itimerheartbeat/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.assert.itimerheartbeat/mvm
@@ -27,4 +27,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.cog.spur/build.assert/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.assert/mvm
@@ -27,4 +27,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.cog.spur/build.debug.itimerheartbeat/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.debug.itimerheartbeat/mvm
@@ -27,4 +27,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.cog.spur/build.debug/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.debug/mvm
@@ -27,4 +27,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.cog.spur/build.itimerheartbeat/mvm
+++ b/build.linux64x64/squeak.cog.spur/build.itimerheartbeat/mvm
@@ -28,4 +28,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.cog.spur/build/mvm
+++ b/build.linux64x64/squeak.cog.spur/build/mvm
@@ -41,4 +41,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.stack.spur/build.assert/mvm
+++ b/build.linux64x64/squeak.stack.spur/build.assert/mvm
@@ -28,4 +28,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.stack.spur/build.debug/mvm
+++ b/build.linux64x64/squeak.stack.spur/build.debug/mvm
@@ -28,4 +28,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.linux64x64/squeak.stack.spur/build/mvm
+++ b/build.linux64x64/squeak.stack.spur/build/mvm
@@ -27,4 +27,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+make install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.sunos32x86/squeak.cog.spur/build/mvm
+++ b/build.sunos32x86/squeak.cog.spur/build/mvm
@@ -41,4 +41,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer $MAKE install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-$MAKE install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+$MAKE install-squeak install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.sunos32x86/squeak.stack.spur/build/mvm
+++ b/build.sunos32x86/squeak.stack.spur/build/mvm
@@ -41,4 +41,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer $MAKE install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-$MAKE install-squeak install-doc install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+$MAKE install-squeak install-doc install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.sunos64x64/squeak.cog.spur/build/mvm
+++ b/build.sunos64x64/squeak.cog.spur/build/mvm
@@ -36,4 +36,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer $MAKE install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-$MAKE install-squeak install-doc install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+$MAKE install-squeak install-doc install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.sunos64x64/squeak.stack.spur/build/mvm
+++ b/build.sunos64x64/squeak.stack.spur/build/mvm
@@ -32,4 +32,4 @@ rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR
 # prefer $MAKE install prefix=`readlink -f \`pwd\`/../../../products/$INSTALLDIR`
 # but older linux readlinks lack the -f flag
-$MAKE install-squeak install-doc install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG
+$MAKE install-squeak install-doc install-plugins prefix=`(cd ../../../;pwd)`/products/$INSTALLDIR 2>&1 | tee LOG ; test ${PIPESTATUS[0]} -eq 0

--- a/build.win32x86/squeak.cog.spur.lowcode/mvm
+++ b/build.win32x86/squeak.cog.spur.lowcode/mvm
@@ -23,13 +23,13 @@ fi
 if ../../scripts/checkSCCSversion ; then exit 1; fi
 if [ -n "$D" ]; then
 	rm -rf builddbg/vm/*.exe
-	make $@ debug 2>&1 | tee LOGD
+	make $@ debug 2>&1 | tee LOGD ; test ${PIPESTATUS[0]} -eq 0
 fi
 if [ -n "$A" ]; then
 	rm -rf buildast/vm/*.exe
-	make $@ assert 2>&1 | tee LOGA
+	make $@ assert 2>&1 | tee LOGA ; test ${PIPESTATUS[0]} -eq 0
 fi
 if [ -n "$F" ]; then
 	rm -rf build/vm/*.exe
-	make $@ 2>&1 | tee LOGF
+	make $@ 2>&1 | tee LOGF ; test ${PIPESTATUS[0]} -eq 0
 fi

--- a/build.win32x86/squeak.cog.spur/mvm
+++ b/build.win32x86/squeak.cog.spur/mvm
@@ -23,13 +23,13 @@ fi
 if ../../scripts/checkSCCSversion ; then exit 1; fi
 if [ -n "$D" ]; then
 	rm -rf builddbg/vm/*.exe
-	make $@ debug 2>&1 | tee LOGD
+	make $@ debug 2>&1 | tee LOGD ; test ${PIPESTATUS[0]} -eq 0
 fi
 if [ -n "$A" ]; then
 	rm -rf buildast/vm/*.exe
-	make $@ assert 2>&1 | tee LOGA
+	make $@ assert 2>&1 | tee LOGA ; test ${PIPESTATUS[0]} -eq 0
 fi
 if [ -n "$F" ]; then
 	rm -rf build/vm/*.exe
-	make $@ 2>&1 | tee LOGF
+	make $@ 2>&1 | tee LOGF ; test ${PIPESTATUS[0]} -eq 0
 fi

--- a/build.win32x86/squeak.sista.spur/mvm
+++ b/build.win32x86/squeak.sista.spur/mvm
@@ -23,13 +23,13 @@ fi
 if ../../scripts/checkSCCSversion ; then exit 1; fi
 if [ -n "$D" ]; then
 	rm -rf builddbg/vm/*.exe
-	make $@ debug 2>&1 | tee LOGD
+	make $@ debug 2>&1 | tee LOGD ; test ${PIPESTATUS[0]} -eq 0
 fi
 if [ -n "$A" ]; then
 	rm -rf buildast/vm/*.exe
-	make $@ assert 2>&1 | tee LOGA
+	make $@ assert 2>&1 | tee LOGA ; test ${PIPESTATUS[0]} -eq 0
 fi
 if [ -n "$F" ]; then
 	rm -rf build/vm/*.exe
-	make $@ 2>&1 | tee LOGF
+	make $@ 2>&1 | tee LOGF ; test ${PIPESTATUS[0]} -eq 0
 fi

--- a/scripts/ci/actions_prepare_linux_x86.sh
+++ b/scripts/ci/actions_prepare_linux_x86.sh
@@ -33,7 +33,6 @@ if [[ "${ARCH}" = "linux64x64" ]]; then
 elif [[ "${ARCH}" = "linux32x86" ]]; then
     sudo dpkg --add-architecture i386
     sudo apt-get update -y
-    sudo apt-get remove -q -y gvfs-daemons
     sudo apt-get install -yq --no-install-suggests --no-install-recommends --allow-unauthenticated \
             devscripts \
             libc6-dev:i386 \
@@ -45,6 +44,9 @@ elif [[ "${ARCH}" = "linux32x86" ]]; then
             libx11-dev:i386 \
             libsm-dev:i386 \
             libice-dev:i386 \
+            libllvm12:i386 \
+            libgl1-mesa-glx:i386 \
+            libgl1-mesa-dev:i386 \
             libxext-dev:i386 \
             libxrender-dev:i386 \
             libglapi-mesa:i386 \


### PR DESCRIPTION
Uses a workaround for Linux 32-bit builds by loading "libllvm12:i386" explicitely to then also load "libgl1-mesa-glx:i386". See https://github.com/actions/virtual-environments/issues/3852

This is a re-post or extension of 
 - #582 
 - #581