### PR TITLE
windows: resync the VM time when the system clock gets changed

### DIFF
--- a/platforms/win32/vm/sqWin32Heartbeat.c
+++ b/platforms/win32/vm/sqWin32Heartbeat.c
@@ -260,6 +260,13 @@ ioInitTime(void)
 	utcStartMicroseconds = utcMicrosecondClock;
 }
 
+void resyncSystemTime() {
+  // By setting these values to maximum, currentUTCMicroseconds() will resync to the system time.
+  lastTick = (DWORD)-1;
+  vmThreadLastTick = (DWORD)-1;
+  ioUpdateVMTimezone();
+}
+
 unsigned long long
 ioUTCMicroseconds() { return get64(utcMicrosecondClock); }
 

--- a/platforms/win32/vm/sqWin32Heartbeat.c
+++ b/platforms/win32/vm/sqWin32Heartbeat.c
@@ -261,9 +261,13 @@ ioInitTime(void)
 }
 
 void resyncSystemTime() {
+  #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+  // Nothing to be done, time will be resynced upon every heartbeat tick
+  #else // (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
   // By setting these values to maximum, currentUTCMicroseconds() will resync to the system time.
   lastTick = (DWORD)-1;
   vmThreadLastTick = (DWORD)-1;
+  #endif
   ioUpdateVMTimezone();
 }
 

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -625,6 +625,10 @@ MainWndProcW(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
   case WM_KILLFOCUS:
     fHasFocus = 0;
     return DefWindowProcW(hwnd,message,wParam,lParam);
+
+  case WM_TIMECHANGE:
+    resyncSystemTime();
+
   default:
     /* Unprocessed messages may be processed outside the current
        module. If firstMessageHook is non-NULL and returns a non

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -628,6 +628,7 @@ MainWndProcW(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
   case WM_TIMECHANGE:
     resyncSystemTime();
+    return DefWindowProcW(hwnd,message,wParam,lParam);
 
   default:
     /* Unprocessed messages may be processed outside the current


### PR DESCRIPTION
As of today, if the Windows system time is changed, already running VM instances will not reflect this change. With this patch, this bug is fixed. The full bug report is on squeak-dev: https://lists.squeakfoundation.org/pipermail/squeak-dev/2021-August/216306.html

This bug only affects builds for Windows versions prior to Windows 8, never builds do not use the tick variables any longer. See:

https://github.com/OpenSmalltalk/opensmalltalk-vm/blob/57260c215c025e17b57e0b7d8478edbcddb74407/platforms/win32/vm/sqWin32Heartbeat.c#L79-L85

(However, as #499 is still unmerged, currently, also builds for Windows 10 are affected by the bug. Looks like we were never benefitting from @eliotmiranda's improvements for the Win8 APIs (cf. fae0d31cd52341977d37d150d8d2c9272f9864bf) until today 😆)

Independently of this patch, we will want to fix cross-platform-occurring VM hangs when the system clock is pulled backward. See the bug report on squeak-dev for this, again.

Please review thoroughly!

/cc @marceltaeumel 