### PR TITLE
Use distinct VERSION_TAG based on sizeof(void *) to distinguish 32/64…

### DIFF
--- a/platforms/Cross/vm/sqSCCSVersion.h
+++ b/platforms/Cross/vm/sqSCCSVersion.h
@@ -239,7 +239,7 @@ main(int _argc, char **_argv)
 	if (printit("VM_RELEASE"))
 		printf("%s\n", revisionAsString());
 	if (printit("VERSION_TAG"))
-		printf("%s-%s\n", vm_version, revisionAsString());
+		printf("%s-%s-%ibit\n", vm_version, revisionAsString(), 8 * sizeof(void *));
 	if (printit("VERSION_NUMBER"))
 		printf("%s.%s\n", vm_version, revisionAsString());
 # if GIT


### PR DESCRIPTION
… bit

installation libraries. VERSION_TAG is used for naming the installation
directory, append "-32bit" or -"64bit" to VERSION_TAG to enable 32-bit
and 64-bit VMs to be installed side by side in standard unix directories.