### PR TITLE
Adds action for building squeak.stack.spur on Linux using the generic…

### DIFF
--- a/.github/workflows/linux-generic.yml
+++ b/.github/workflows/linux-generic.yml
@@ -1,0 +1,79 @@
+name: Build for Linux (generic)
+
+on:
+  push: # All branches, but appropriate paths only.
+    paths:
+        # This workflow spec and its support scripts
+      - '.github/workflows/linux-generic.yml'
+      - 'scripts/ci/*linux_x86.sh'
+      - 'scripts/ci/*build.sh'
+      - 'deploy/**'
+      # Relevant sources for this platform
+      - 'building/linux32/**' # Makefile-based build scripts
+      - 'building/linux64/**' # Makefile-based build scripts
+      - '*src/**' # Generated VMMaker sources (incl. plugins)
+      - 'platforms/Cross/**'
+      - 'platforms/unix/**'
+      # Skip changes in documentation artifacts
+      - '!**.md'
+      - '!**HowToBuild'
+  pull_request:
+    branches:
+      - Cog
+    paths-ignore:
+      - '**.md'
+      - '**HowToBuild'
+
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - linux64
+          - linux32
+        flavor:
+          - squeak.stack.spur
+        heartbeat:
+          - threaded
+        mode:
+          - fast
+
+
+    runs-on: ubuntu-latest
+    name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      FLAVOR: ${{ matrix.flavor }}
+      MODE: ${{ matrix.mode }}
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v2
+
+      # - name: Restore build cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .thirdparty-cache
+      #     key: thirdparty-cache-linux-generic
+
+      - name: Prepare environment
+        run: ./scripts/ci/actions_prepare_linux_x86.sh
+
+      - name: Build VM
+        run: ./scripts/ci/actions_build.sh
+        env:
+          HEARTBEAT: ${{ matrix.heartbeat }}
+
+      # - name: Sign VM (not implemented)
+      #   if: false
+      #   run: ./deploy/sign-vm.sh
+
+      - name: Pack VM
+        run: ./deploy/pack-vm.sh
+
+      - name: Store artifact w/ revision
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.ASSET_NAME }}_${{ env.ASSET_REVISION }}
+          path: ${{ env.PRODUCTS_PATH }}/${{ env.ASSET_NAME }}.${{ env.ASSET_EXTENSION }}

--- a/building/linux64/squeak.stack.spur/build/mvm
+++ b/building/linux64/squeak.stack.spur/build/mvm
@@ -19,7 +19,6 @@ test -f config.h || ../../../../platforms/unix/config/configure \
 		--with-vmversion=5.0 \
 	--with-src=src/spur64.stack --disable-cogit \
 	--without-vm-display-fbdev --without-npsqueak \
-	TARGET_ARCH="-m64" \
 	CC=clang \
 	VM_WORD_SIZE="64" \
 	VM_CFLAGS="-DNDEBUG -DDEBUGVM=0"

--- a/platforms/unix/config/configure.ac
+++ b/platforms/unix/config/configure.ac
@@ -229,11 +229,18 @@ then
 			CFLAGS="-g -O2 -msse2"
 		;;
 
-		x86_64) TARGET_ARCH="-m64"
-			CFLAGS="-g -O1 -msse2"
+		x86_64)
+			if [[ "$VM_WORD_SIZE" == "32" ]]
+			then
+				TARGET_ARCH="-m32"
+				CFLAGS="-g -O2 -msse2"
+			else
+				TARGET_ARCH="-m64"
+				CFLAGS="-g -O1 -msse2"
+			fi
 		;;
 
-	        # Omitting -DNO_VM_PROFILE=1 for now
+		# Omitting -DNO_VM_PROFILE=1 for now
 		armhf) TARGET_ARCH="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 			CFLAGS="-g -O3"
 		;;

--- a/scripts/ci/actions_prepare_linux_x86.sh
+++ b/scripts/ci/actions_prepare_linux_x86.sh
@@ -6,7 +6,7 @@ set -e
 # and #64-bit architectures, which means that the host Linux platform
 # has to support the older i386 packages to make 32-bit compile.
 
-if [[ "${ARCH}" = "linux64x64" ]]; then
+if [[ "${ARCH}" = "linux64"* ]]; then
     sudo apt-get update -y
     sudo apt-get install -yq --no-install-suggests --no-install-recommends --allow-unauthenticated \
             debhelper \
@@ -30,7 +30,7 @@ if [[ "${ARCH}" = "linux64x64" ]]; then
             libtool \
             curl \
             cmake
-elif [[ "${ARCH}" = "linux32x86" ]]; then
+elif [[ "${ARCH}" = "linux32"* ]]; then
     sudo dpkg --add-architecture i386
     sudo apt-get update -y
     sudo apt-get install -yq --no-install-suggests --no-install-recommends --allow-unauthenticated \


### PR DESCRIPTION
… mvm files, which are prepared for our Debian builds. No update of latest-build release but artifact upload for 90-day reviews. Fixes minor issue in configure.ac to be able to build 32-bit binaries on x86_64 platforms again.