### PR TITLE
Adds cross-platform compatible virtual-key codes to vm-display-x11 plugin

### DIFF
--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -51,6 +51,10 @@
  *
  * Support for OSProcess plugin contributed by:
  *	Dave Lewis <lewis@mail.msen.com> Mon Oct 18 20:36:54 EDT 1999
+ *
+ * Fixes calls to recordKeyboardEvent() for EventKeyDown and EventKeyUp to 
+ * provide codes for virtual keys instead of Unicode characters.
+ *  Marcel Taeumel <marcel.taeumel@hpi.de>
  */
 
 #include "sq.h"
@@ -1698,7 +1702,7 @@ static int recordPendingKeys(void)
       }
       return 0;
     }
-  else
+  else /* no composition input */
     {
       if (inputCount > 0)
 	{
@@ -3744,7 +3748,7 @@ handleEvent(XEvent *evt)
 	  }
 	if ((keyCode >= 0) || (ucs4 > 0))
 	  {
-	    recordKeyboardEvent(keyCode, EventKeyDown, modifierState, ucs4);
+	    recordKeyboardEvent(evt->xkey.keycode, EventKeyDown, modifierState, evt->xkey.keycode);
 	    if (ucs4) /* only generate a key char event if there's a code. */
 		recordKeyboardEvent(keyCode, EventKeyChar, modifierState, ucs4);
 	    if (multi_key_buffer != 0)
@@ -3772,7 +3776,7 @@ handleEvent(XEvent *evt)
 	keyCode= x2sqKey(&evt->xkey, &symbolic);
 	ucs4= xkeysym2ucs4(symbolic);
 	if ((keyCode >= 0) || (ucs4 > 0))
-	  recordKeyboardEvent(keyCode, EventKeyUp, modifierState, ucs4);
+	  recordKeyboardEvent(evt->xkey.keycode, EventKeyUp, modifierState, evt->xkey.keycode);
       }
       break;
 

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -2055,6 +2055,7 @@ static int xkey2sqVirtualKeyCode(int xKeycode, KeySym xKeysym)
     case XK_space: return 0x01;
     case XK_comma: return 0x02;
     case XK_period: return 0x03;
+    case XK_ISO_Left_Tab: return XK_Tab & 0x00ff; // shift-tab
   }
 
   // 5) If still no match, fall-back to US QWERTY layout using X11 keycodes

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -4766,37 +4766,33 @@ translateCode(KeySym symbolic, int *modp, XKeyEvent *evt)
 # endif
 
 # if defined(XK_Control_L)
-	/* For XK_Shift_L, XK_Shift_R, XK_Caps_Lock & XK_Shift_Lock we can't just
-	 * use the SHIFT metastate since it would generate key codes. We use
-	 * META + SHIFT as these are all meta keys (meta == OptionKeyBit).
-	 */
-	case XK_Shift_L:
-		return withMetaSet(255,OptionKeyBit+ShiftKeyBit,ShiftKeyBit,modp,evt);
-	case XK_Shift_R:
-		return withMetaSet(254,OptionKeyBit+ShiftKeyBit,ShiftKeyBit,modp,evt);
-	case XK_Caps_Lock:
-		return withMetaSet(253,OptionKeyBit+ShiftKeyBit,ShiftKeyBit,modp,evt);
-	case XK_Shift_Lock:
-		return withMetaSet(252,OptionKeyBit+ShiftKeyBit,ShiftKeyBit,modp,evt);
-	case XK_Control_L:
-		return withMetaSet(251,OptionKeyBit+CtrlKeyBit,CtrlKeyBit,modp,evt);
-	case XK_Control_R:
-		return withMetaSet(250,OptionKeyBit+CtrlKeyBit,CtrlKeyBit,modp,evt);
-	case XK_Meta_L:
-		return withMetaSet(249,OptionKeyBit,0,modp,evt);
-	case XK_Meta_R:
-		return withMetaSet(248,OptionKeyBit,0,modp,evt);
-	/* John Brandt notes on 2018/11/28:
-	 * This doesn't match the above; here OptionKeyBit is used for the notmeta
-	 * parameter but in the preceding cases we use the bit other than the
-	 * OptionKeyBit.  Which is right?
-	 * The underlying issue here is the lack of a key event on pressing the
-	 * shift key; a feature that GT depends upon.
-	 */
-	case XK_Alt_L:
-		return withMetaSet(247,OptionKeyBit+CommandKeyBit,OptionKeyBit,modp,evt);
-	case XK_Alt_R:
-		return withMetaSet(246,OptionKeyBit+CommandKeyBit,OptionKeyBit,modp,evt);
+    /* No need to return ascii value (> -1) because not an EventKeyChar */
+    case XK_Shift_L:
+        return withMetaSet(-1,ShiftKeyBit,ShiftKeyBit,modp,evt);
+    case XK_Shift_R:
+        return withMetaSet(-1,ShiftKeyBit,ShiftKeyBit,modp,evt);
+    case XK_Caps_Lock:
+        return withMetaSet(-1,ShiftKeyBit,ShiftKeyBit,modp,evt);
+    case XK_Shift_Lock:
+        return withMetaSet(-1,ShiftKeyBit,ShiftKeyBit,modp,evt);
+    case XK_Control_L:
+    case XK_Control_R: // Re-use conversion Ctrl+Alt=Opt, see x2sqModifier()
+        if (evt->type == KeyPress)
+          evt->state= evt->state | ControlMask;
+        else
+          evt->state= evt->state & ~ControlMask;
+        *modp= x2sqModifier(evt->state);
+        return -1;
+    case XK_Meta_L:
+    case XK_Meta_R:
+    case XK_Alt_L:
+    case XK_Alt_R: // Re-use conversion Ctrl+Alt=Opt, see x2sqModifier()
+        if (evt->type == KeyPress)
+          evt->state= evt->state | Mod1Mask;
+        else
+          evt->state= evt->state & ~Mod1Mask;
+        *modp= x2sqModifier(evt->state);
+        return -1;
 # endif
 
     default:;


### PR DESCRIPTION
Since X11 does not provide a localized version of virtual keys, I mapped the X11 event's `KeySym` to such a "virtual-key code", using `evt.keycode` only as a fall back. It's not perfect but close to what Windows and macOS have.

Here is the mapping schema:

```
 * 0x00         (unknown virtual key)
 * 0x01         XK_space (shifted from Latin-1)
 * 0x02         XK_comma (shifted from Latin-1 OR guessed from xKeycode)
 * 0x03         XK_period (shifted from Latin-1 OR guessed from xKeycode)
 * 0x04 .. 0x07 (unused)
 *
 * 0x08 .. 0x1f SPECIAL KEYS 1 (from all-mask 0xff00)
 * 0x20 .. 0x29 NUMERIC ASCII KEYS (shifted from Latin-1)
 * 0x2a .. 0x43 ALPHABETIC ASCII KEYS (shifted from Latin-1)
 *
 * 0x44         US_MINUS (guessed from xKeycode)
 * 0x45         US_PLUS (guessed from xKeycode)
 * 0x46         US_LBRACKET (guessed from xKeycode)
 * 0x47         US_RBRACKET (guessed from xKeycode)
 * 0x48         US_COLON (guessed from xKeycode)
 * 0x49         US_QUOTE (guessed from xKeycode)
 * 0x4a         US_TILDE (guessed from xKeycode)
 * 0x4b         US_BACKSLASH (guessed from xKeycode)
 * 0x4c         US_COMMA (guessed from xKeycode)
 * 0x4d         US_PERIOD (guessed from xKeycode)
 * 0x4e         US_SLASH (guessed from xKeycode)
 * 0x4f         US_102 (guessed from xKeycode)
 *
 * 0x50 .. 0xff SPECIAL KEYS 2 (from all-mask 0xff00)
```

Here is the new mapping table for Squeak:
<s>[new-x11-virtual-keys.1.cs.txt](https://github.com/OpenSmalltalk/opensmalltalk-vm/files/7269113/new-x11-virtual-keys.1.cs.txt)</s>
[new-x11-virtual-keys.6.cs.txt](https://github.com/OpenSmalltalk/opensmalltalk-vm/files/7286590/new-x11-virtual-keys.6.cs.txt) (updated 2021-10-06 14:00 UTC)


See /usr/include/X11/keysymdef.h to understand the "SPECIAL KEYS" (masked 0xff00).

The biggest remaining issue is all those "OEM keys", which means the ones you push for "+" or "/" or "~" and so on.

*Note that the idea of having a localized version of the virtual key is that you can print it in an application's user interface. Would be really annoying if an app insists on, e.g., Z while you actionally pushed Y.*


You can try out the changes in the `KeyboardExerciser` in Squeak 6.0alpha. The test is that the tool shows the labels of your physical keyboard while you keep on pressing keys or key combinations. Note that you need a physical keyboard that matches your keyboard layout. That is, US keyboard for US key layout.