### PR TITLE
Adds builds for macos64ARMv8 to GHA

### DIFF
--- a/.github/workflows/extra-arm.yml
+++ b/.github/workflows/extra-arm.yml
@@ -37,7 +37,7 @@ jobs:
           # - arch: linux32ARMv8
           #   flavor: squeak.cogmt.spur
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # we setup QEMU to produce binaries anyway
     name: ${{ matrix.flavor }} for ${{ matrix.arch }}
     env:
       ARCH: ${{ matrix.arch }}

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -21,7 +21,7 @@ jobs:
           - { name: win32x86, os: windows-latest }
           - { name: linux64x64, os: ubuntu-18.04 }
           - { name: linux32x86, os: ubuntu-18.04 }
-          - { name: macos64x64, os: macos-latest }
+          - { name: macos64x64, os: macos-10.15 }
           # - { name: macos32x86, os: macos-latest }
 
         flavor:
@@ -50,7 +50,7 @@ jobs:
 
           # - arch: { name: macos64x64, os: macos-latest }
           #   flavor: pharo.cog.spur.lowcode # impl. decl. getThisSessionID
-          - arch: { name: macos64x64, os: macos-latest }
+          - arch: { name: macos64x64, os: macos-10.15 }
             flavor: pharo.stack.spur.lowcode
 
     runs-on: ${{ matrix.arch.os }}

--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -9,7 +9,9 @@ on:
       - 'scripts/ci/*build.sh'
       - 'deploy/**'
       # Relevant sources for this platform
-      - 'building/linux*/**' # Makefile-based build scripts
+      - 'building/linux*ARM*/**' # Makefile-based build scripts
+      - 'building/linux32/**' # Makefile-based build scripts
+      - 'building/linux64/**' # Makefile-based build scripts
       - '*src/**' # Generated VMMaker sources (incl. plugins)
       - 'platforms/Cross/**'
       - 'platforms/unix/**'
@@ -26,7 +28,9 @@ on:
       - 'scripts/ci/*build.sh'
       - 'deploy/**'
       # Relevant sources for this platform
-      - 'building/linux*/**' # Makefile-based build scripts
+      - 'building/linux*ARM*/**' # Makefile-based build scripts
+      - 'building/linux32/**' # Makefile-based build scripts
+      - 'building/linux64/**' # Makefile-based build scripts
       - '*src/**' # Generated VMMaker sources (incl. plugins)
       - 'platforms/Cross/**'
       - 'platforms/unix/**'
@@ -57,7 +61,7 @@ jobs:
           - debug
           - assert
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # we setup QEMU to produce binaries anyway
     name: ${{ matrix.flavor }} for ${{ matrix.arch }}${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
     env:
       ARCH: ${{ matrix.arch }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,7 +9,9 @@ on:
       - 'scripts/ci/*build.sh'
       - 'deploy/**'
       # Relevant sources for this platform
-      - 'building/linux*/**' # Makefile-based build scripts
+      - 'building/linux*x*/**' # Makefile-based build scripts
+      - 'building/linux32/**' # Makefile-based build scripts
+      - 'building/linux64/**' # Makefile-based build scripts
       - '*src/**' # Generated VMMaker sources (incl. plugins)
       - 'platforms/Cross/**'
       - 'platforms/unix/**'
@@ -26,7 +28,9 @@ on:
       - 'scripts/ci/*build.sh'
       - 'deploy/**'
       # Relevant sources for this platform
-      - 'building/linux*/**' # Makefile-based build scripts
+      - 'building/linux*x*/**' # Makefile-based build scripts
+      - 'building/linux32/**' # Makefile-based build scripts
+      - 'building/linux64/**' # Makefile-based build scripts
       - '*src/**' # Generated VMMaker sources (incl. plugins)
       - 'platforms/Cross/**'
       - 'platforms/unix/**'
@@ -79,7 +83,7 @@ jobs:
             heartbeat: threaded
             mode: fast
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-18.04 # better backwards compatibility than ubuntu-20.04
     name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
     env:
       ARCH: ${{ matrix.arch }}

--- a/.github/workflows/macos-arm.yml
+++ b/.github/workflows/macos-arm.yml
@@ -1,0 +1,131 @@
+name: Build for macOS (ARM)
+
+on:
+  push: # All branches, but appropriate paths only.
+    paths:
+      # This workflow spec and its support scripts
+      - '.github/workflows/macos.yml' 
+      - 'scripts/ci/*build.sh'
+      - 'deploy/**'
+      # Relevant sources for this platform
+      - 'building/macos*ARM*/**' # Makefile-based build scripts
+      - '*src/**' # Generated VMMaker sources (incl. plugins)
+      - 'platforms/Cross/**'
+      - 'platforms/iOS/**' # Note that 'platforms/Mac OS' is deprecated
+      # Skip changes in documentation artifacts
+      - '!**.md'
+      - '!**HowToBuild'
+  pull_request:
+    branches:
+      - Cog
+    paths:
+      # This workflow spec and its support scripts
+      - '.github/workflows/macos.yml' 
+      - 'scripts/ci/*build.sh'
+      - 'deploy/**'
+      # Relevant sources for this platform
+      - 'building/macos*ARM*/**' # Makefile-based build scripts
+      - '*src/**' # Generated VMMaker sources (incl. plugins)
+      - 'platforms/Cross/**'
+      - 'platforms/iOS/**' # Note that 'platforms/Mac OS' is deprecated
+      # Skip changes in documentation artifacts
+      - '!**.md'
+      - '!**HowToBuild'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Build new release candidate for tag"
+        required: true
+        default: YYYYMMDDHHMM
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: 
+          - macos64ARMv8
+        flavor:
+          - squeak.cog.spur
+          # - squeak.sista.spur # -Werror bc. decl. missing
+          - squeak.stack.spur
+          # - pharo.cog.spur
+          # - pharo.sista.spur # -Werror bc. decl. missing
+          # - pharo.stack.spur
+        mode:
+          - fast
+          - debug
+          - assert
+
+    runs-on: macos-10.15 # macos-11 macos-latest
+    name: ${{ matrix.flavor }} for ${{ matrix.arch }}${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      FLAVOR: ${{ matrix.flavor }}
+      MODE: ${{ matrix.mode }}
+    steps:
+      - name: Checkout files
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v2
+
+      - name: Checkout files for new release candidate
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v2
+        with:
+          ref: refs/tags/${{ github.event.inputs.tag }}
+
+      - name: Restore build cache
+        uses: actions/cache@v2
+        with:
+          path: .thirdparty-cache
+          key: thirdparty-cache-macos
+
+      - name: Build VM
+        run: ./scripts/ci/actions_build.sh
+
+      - name: Sign VM
+        continue-on-error: true # Save unsigned build artifacts
+        run: ./deploy/sign-vm.sh
+        env:
+          SQUEAK_SIGN_PASSWORD: ${{ secrets.SQUEAK_SIGN_PASSWORD }}
+          SQUEAK_CERT_PASSWORD: ${{ secrets.SQUEAK_CERT_PASSWORD }}
+          SQUEAK_SIGN_IDENTITY: ${{ secrets.SQUEAK_SIGN_IDENTITY }}
+          PHARO_SIGN_PASSWORD: ${{ secrets.PHARO_SIGN_PASSWORD }}
+          PHARO_CERT_PASSWORD: ${{ secrets.PHARO_CERT_PASSWORD }}
+          PHARO_SIGN_IDENTITY: ${{ secrets.PHARO_SIGN_IDENTITY }}
+          NEWSPEAK_SIGN_PASSWORD: ${{ secrets.NEWSPEAK_SIGN_PASSWORD }}
+          NEWSPEAK_CERT_PASSWORD: ${{ secrets.NEWSPEAK_CERT_PASSWORD }}
+          NEWSPEAK_SIGN_IDENTITY: ${{ secrets.NEWSPEAK_SIGN_IDENTITY }}
+
+      - name: Pack VM
+        run: ./deploy/pack-vm.sh
+
+      - name: Store artifact w/ revision
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.ASSET_NAME }}_${{ env.ASSET_REVISION }}
+          path: products/${{ env.ASSET_NAME }}.${{ env.ASSET_EXTENSION }}
+
+      - name: Update artifact in latest-build
+        uses: ncipollo/release-action@v1.8.6
+        if: github.event_name == 'push' && endsWith( github.ref , 'Cog' )
+        with:
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: products/${{ env.ASSET_NAME }}.${{ env.ASSET_EXTENSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ matrix.mode == 'debug' && 'latest-debug-build' || matrix.mode == 'assert' && 'latest-assert-build' || 'latest-build' }}
+          body: ${{ github.event.head_commit.message }}
+
+      - name: Deploy artifact as new release candidate
+        uses: ncipollo/release-action@v1.8.6
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          prerelease: true # release candidate
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: products/${{ env.ASSET_NAME }}.${{ env.ASSET_EXTENSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.inputs.tag }}
+          body: ${{ github.event.head_commit.message }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
       - 'scripts/ci/*build.sh'
       - 'deploy/**'
       # Relevant sources for this platform
-      - 'building/macos*/**' # Makefile-based build scripts
+      - 'building/macos*x*/**' # Makefile-based build scripts
       - '*src/**' # Generated VMMaker sources (incl. plugins)
       - 'platforms/Cross/**'
       - 'platforms/iOS/**' # Note that 'platforms/Mac OS' is deprecated
@@ -24,7 +24,7 @@ on:
       - 'scripts/ci/*build.sh'
       - 'deploy/**'
       # Relevant sources for this platform
-      - 'building/macos*/**' # Makefile-based build scripts
+      - 'building/macos*x*/**' # Makefile-based build scripts
       - '*src/**' # Generated VMMaker sources (incl. plugins)
       - 'platforms/Cross/**'
       - 'platforms/iOS/**' # Note that 'platforms/Mac OS' is deprecated
@@ -58,7 +58,7 @@ jobs:
           - debug
           - assert
 
-    runs-on: macos-latest
+    runs-on: macos-10.15 # macos-11 macos-latest
     name: ${{ matrix.flavor }} for ${{ matrix.arch }}${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
     env:
       ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
- Adds some commentary to build files
- Pins macOS builds to `macos-10.15` because that has been our build platform for the past weeks; `macos-11` is the new default on GHA `macos-latest`
- Specialize filters for `building/**` in our GHA `.yml` files to reduce the number of actually needed builds