### PR TITLE
DnD/Unix: Fix `dropRequestFileName` which removed the trailing slash from the path

### DIFF
--- a/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
+++ b/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
@@ -1,23 +1,23 @@
 /* sqUnixDragDrop.c -- support for drag and drop, for those UIs that have it
- * 
+ *
  * Author: Ian Piumarta <ian.piumarta@inria.fr>
- * 
+ *
  *   Copyright (C) 1996-2004 by Ian Piumarta and other authors/contributors
  *                              listed elsewhere in this file.
  *   All rights reserved.
- *   
+ *
  *   This file is part of Unix Squeak.
- * 
+ *
  *   Permission is hereby granted, free of charge, to any person obtaining a
  *   copy of this software and associated documentation files (the "Software"),
  *   to deal in the Software without restriction, including without limitation
  *   the rights to use, copy, modify, merge, publish, distribute, sublicense,
  *   and/or sell copies of the Software, and to permit persons to whom the
  *   Software is furnished to do so, subject to the following conditions:
- * 
+ *
  *   The above copyright notice and this permission notice shall be included in
  *   all copies or substantial portions of the Software.
- * 
+ *
  *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -52,7 +52,7 @@ extern SQFile * fileValueOf(sqInt objectPointer);
 #else
 /*	Return a pointer to the first byte of of the SQFile data structure file
 	record within anSQFileRecord, which is expected to be a ByteArray of size
-	self>>fileRecordSize. 
+	self>>fileRecordSize.
  */
 
 	/* OSProcessPlugin>>#fileValueOf: */
@@ -94,9 +94,9 @@ dropRequestFileName(sqInt dropIndex)	// in st coordinates
 	while (*fileURIPrefix && *fileURIPrefix++ == *dropFileName++)
 		++prefixLength;
 
-	// file:///path & file:/path => path; anything else answered verbatim
+	// file:///path & file:/path => /path; anything else answered verbatim
 	return prefixLength == 8 || prefixLength == 6
-		? uxDropFileNames[dropIndex - 1] + prefixLength
+		? uxDropFileNames[dropIndex - 1] + prefixLength - 1
 		: uxDropFileNames[dropIndex - 1];
 }
 
@@ -120,6 +120,6 @@ dropRequestFileHandle(sqInt dropIndex)
 		sqInt handle = instantiateClassindexableSize(classByteArray(), fileRecordSize());
 		sqFileOpen(fileValueOf(handle), path, strlen(path), 0);
 		return handle;
-	}  
+	}
 	return interpreterProxy->nilObject();
 }


### PR DESCRIPTION
For more than one year, drag'n'drop from the host system into the VM was broken on Linux/X11 due to a regression introduced via facfd9012e9f95679dc054fde69c13d5d4b514ca. `primitiveDropRequestFileName` would always answer `home/Christoph/myfile.txt` rather than `/home/Christoph/myfile.txt`, causing the file to be ignored on the image-side in Squeak. Now I finally found the cause of the bug, it was a simple off-by-one error.

Tested on Linux/Ubuntu with XDG/Nautilus under WSL/VcXsrv. The bug was also reported to occur on native Linux distributions, though.

Notes:

- [ ] I don't know any system or application that would pass paths in one of the other formats (`file:/path` or `/path`). If anyone knows such applications, this would make a nice reprocase. Could you please test this out in your environment?
- Related issue: There was also a bug report for DnD on macOS always being one file behind, i.e., nothing appearing in the image on the first drop, the first file appearing on the drop, etc. However, I think this is unrelated to this bug (different platform) and I have also no option to reproduce this unless Apple provides usable visualization support. If anyone is addressing the issue, skimming the history around facfd9012e9f95679dc054fde69c13d5d4b514ca might be a good starting point, anyway.

Mentioning @eliotmiranda as the author of facfd9012e9f95679dc054fde69c13d5d4b514ca and @marceltaeumel FYIO. :-)