### PR TITLE
For macOS -metal -core-graphics -opengl backends, fixes several issues concerning performance and high-resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ platforms/unix/config/autom4te.cache/
 # except do track these files
 !/building/**/common*/*
 !/building/**/**/Makefile
+!/building/**/**/Makefile.*
 !/building/**/**/NotYetImplemented
 !/building/**/**/mvm
 !/building/**/**/plugins.*

--- a/building/macos64ARMv8/common/Makefile.flags
+++ b/building/macos64ARMv8/common/Makefile.flags
@@ -5,8 +5,8 @@
 
 XCODE:=$(shell /usr/bin/xcode-select -p)
 XCUB:=$(XCODE)/usr/bin
-#SDKsDIR:=$(XCODE)/Platforms/MacOSX.platform/Developer/SDKs
-SDKsDIR:=$(XCODE)/SDKs
+SDKsDIR:=$(XCODE)/Platforms/MacOSX.platform/Developer/SDKs
+#SDKsDIR:=$(XCODE)/SDKs
 #Build oldest installed SDK
 SDKs:=MacOSX.sdk
 ifeq ($(SDK),)

--- a/building/macos64ARMv8/common/Makefile.flags
+++ b/building/macos64ARMv8/common/Makefile.flags
@@ -5,7 +5,8 @@
 
 XCODE:=$(shell /usr/bin/xcode-select -p)
 XCUB:=$(XCODE)/usr/bin
-SDKsDIR:=$(XCODE)/Platforms/MacOSX.platform/Developer/SDKs
+#SDKsDIR:=$(XCODE)/Platforms/MacOSX.platform/Developer/SDKs
+SDKsDIR:=$(XCODE)/SDKs
 #Build oldest installed SDK
 SDKs:=MacOSX.sdk
 ifeq ($(SDK),)

--- a/platforms/iOS/plugins/HostWindowPlugin/sqMacHostWindow.m
+++ b/platforms/iOS/plugins/HostWindowPlugin/sqMacHostWindow.m
@@ -138,10 +138,10 @@ ioSizeOfWindowSetxy(wIndexType windowIndex, sqInt x, sqInt y)
 		return 0;
 
 	NSWindow *window = nsWindowFromIndex(windowIndex);
-    NSRect frame = [window frame];
+    NSRect frame = [window convertRectToBacking: [window frame]];
     frame.size.width = x;
     frame.size.height = y;
-    [window setFrame: frame display: YES];    
+    [window setFrame: [window convertRectFromBacking: frame] display:YES];  
 
 	return 0;
 }

--- a/platforms/iOS/vm/Common/Classes/sqSqueakEventsAPI.m
+++ b/platforms/iOS/vm/Common/Classes/sqSqueakEventsAPI.m
@@ -69,17 +69,16 @@ void vmIOProcessEvents(void) {
 		[getMainWindowDelegate() ioForceDisplayUpdate];
 	}
 
-	/* THIS SHOULD BE COMMENTED TO EXPLAIN WHAT ARE THE TWO CONTEXTS IN WHICH
-	 * THIS IS INVOKED.  THIS SEEMS SUPER DANGEROUS BECAUSE WHETHER THERE IS
-	 * A PRIMITIVE INDEX OR NOT DEPENDS ON WHETHER THIS IS INVOKED WITHIN A
-	 * PRIMITIVE OR NOT.  IF INVOKED IN PARALLEL TO THE VM IT IS ARBITRARY.
-	 * SO PLEASE, WHOEVER UNDERATANDS WHAT'S GOING ON, REPLACE MY CAPS WITH
-	 * A COGENT EXPLANATION ASAP.
+	/* If this is NOT invoked from within a PRIMITIVE, we assume a PUSH
+	 * rather than a PULL model for managing user-input events in the
+	 * image. In that case, we must SIGNAL the input semaphore. Otherwise,
+	 * just pump all the events and assume that the image will ask for them
+	 * in a while-loop directly after returning from here.
 	 */
 	if (interpreterProxy->methodPrimitiveIndex() == 0) {
 		[gDelegateApp.squeakApplication pumpRunLoopEventSendAndSignal:YES];
     } else {
-		[gDelegateApp.squeakApplication pumpRunLoop];
+		[gDelegateApp.squeakApplication pumpRunLoopEventSendAndSignal:NO];
 	}
 
 	if (gQuitNowRightNow) {

--- a/platforms/iOS/vm/Common/Classes/sqSqueakEventsAPI.m
+++ b/platforms/iOS/vm/Common/Classes/sqSqueakEventsAPI.m
@@ -95,7 +95,7 @@ extern void setIoProcessEventsHandler(void * handler) {
 sqInt ioProcessEvents(void) {
     aioPoll(0);
 
-#if !defined(USE_METAL)
+#if defined(PharoVM) && !defined(USE_METAL)
 	// We need to restore the opengl context to whatever the image was
 	// already using. This is required by SDL2 in Pharo.
 	NSOpenGLContext *oldContext = [NSOpenGLContext currentContext];
@@ -107,7 +107,7 @@ sqInt ioProcessEvents(void) {
     if(ioProcessEventsHandler && ioProcessEventsHandler != vmIOProcessEvents)
         ioProcessEventsHandler();
 
-#if !defined(USE_METAL)
+#if defined(PharoVM) && !defined(USE_METAL)
 	NSOpenGLContext *newContext = [NSOpenGLContext currentContext];
 	if(oldContext != newContext) {
 		if (oldContext != nil) {

--- a/platforms/iOS/vm/Common/Classes/sqSqueakScreenAndWindow.m
+++ b/platforms/iOS/vm/Common/Classes/sqSqueakScreenAndWindow.m
@@ -91,13 +91,13 @@ void MyProviderReleaseData (
 	sqInt w, h;
 
 #if BUILD_FOR_OSX
-	NSRect screenSize = [gDelegateApp.mainView bounds];
+		NSRect
 #else
-	CGRect screenSize = [gDelegateApp.mainView bounds];
+		CGRect
 #endif
-
-	w = (sqInt) screenSize.size.width;
-	h = (sqInt) screenSize.size.height;
+    screenSize = [gDelegateApp.mainView sqScreenSize];
+		w = (sqInt) screenSize.size.width;
+		h = (sqInt) screenSize.size.height;
 
 	return (w << 16) | (h & 0xFFFF);  /* w is high 16 bits; h is low 16 bits */
 }

--- a/platforms/iOS/vm/OSX/Newspeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Newspeak-Info.plist
@@ -126,6 +126,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>SqueakOSXApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 	<key>SqueakBrowserMouseCmdButton1</key>
 	<integer>3</integer>
 	<key>SqueakBrowserMouseCmdButton2</key>

--- a/platforms/iOS/vm/OSX/Newspeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Newspeak-Info.plist
@@ -128,6 +128,8 @@
 	<string>SqueakOSXApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSHighResolutionMagnifyAllowed</key>
+	<true>
 	<key>SqueakBrowserMouseCmdButton1</key>
 	<integer>3</integer>
 	<key>SqueakBrowserMouseCmdButton2</key>

--- a/platforms/iOS/vm/OSX/Newspeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Newspeak-Info.plist
@@ -129,7 +129,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHighResolutionMagnifyAllowed</key>
-	<true>
+	<true/>
 	<key>SqueakBrowserMouseCmdButton1</key>
 	<integer>3</integer>
 	<key>SqueakBrowserMouseCmdButton2</key>

--- a/platforms/iOS/vm/OSX/Pharo-Info.plist
+++ b/platforms/iOS/vm/OSX/Pharo-Info.plist
@@ -379,6 +379,8 @@
 	<string>SqueakOSXApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSHighResolutionMagnifyAllowed</key>
+	<true>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/platforms/iOS/vm/OSX/Pharo-Info.plist
+++ b/platforms/iOS/vm/OSX/Pharo-Info.plist
@@ -380,7 +380,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHighResolutionMagnifyAllowed</key>
-	<true>
+	<true/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/platforms/iOS/vm/OSX/Pharo-Info.plist
+++ b/platforms/iOS/vm/OSX/Pharo-Info.plist
@@ -377,6 +377,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>SqueakOSXApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/platforms/iOS/vm/OSX/Squeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Squeak-Info.plist
@@ -377,6 +377,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>SqueakOSXApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
     <key>NSCameraUsageDescription</key>
     <string>This app requires camera access to use the CameraPlugin.</string>
     <key>NSMicrophoneUsageDescription</key>

--- a/platforms/iOS/vm/OSX/Squeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Squeak-Info.plist
@@ -379,6 +379,8 @@
 	<string>SqueakOSXApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSHighResolutionMagnifyAllowed</key>
+	<true>
     <key>NSCameraUsageDescription</key>
     <string>This app requires camera access to use the CameraPlugin.</string>
     <key>NSMicrophoneUsageDescription</key>

--- a/platforms/iOS/vm/OSX/Squeak-Info.plist
+++ b/platforms/iOS/vm/OSX/Squeak-Info.plist
@@ -380,7 +380,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHighResolutionMagnifyAllowed</key>
-	<true>
+	<true/>
     <key>NSCameraUsageDescription</key>
     <string>This app requires camera access to use the CameraPlugin.</string>
     <key>NSMicrophoneUsageDescription</key>

--- a/platforms/iOS/vm/OSX/SqueakOSXAppDelegate.m
+++ b/platforms/iOS/vm/OSX/SqueakOSXAppDelegate.m
@@ -163,16 +163,17 @@ SqueakOSXAppDelegate *gDelegateApp;
 	width  = ((unsigned) getSavedWindowSize()) >> 16;
 	height = getSavedWindowSize() & 0xFFFF;
 	width = (sqInt) ((width*4)/32.0f+0.5)*8.0;  //JMM OPEN/GL THOUGHTS FOR PERFORMANCE
-	NSSize sizeOfWindowContent;
-	sizeOfWindowContent.width = width;
-	sizeOfWindowContent.height = height;
 	
-	[gDelegateApp.window setContentSize: sizeOfWindowContent];
 	NSRect resetFrame;
 	resetFrame.origin.x = 0.0f;
 	resetFrame.origin.y	= 0.0f;
 	resetFrame.size.width = width;
 	resetFrame.size.height = height;
+	resetFrame = [[self mainView] convertRectFromBacking: resetFrame];
+
+	NSSize sizeOfWindowContent = resetFrame.size;
+	[gDelegateApp.window setContentSize: sizeOfWindowContent];
+
     [self.window setAcceptsMouseMovedEvents: YES];
 #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_9
 	[self.window useOptimizedDrawing: YES];

--- a/platforms/iOS/vm/OSX/plugins/HostWindowPlugin/sqMacHostWindow.m
+++ b/platforms/iOS/vm/OSX/plugins/HostWindowPlugin/sqMacHostWindow.m
@@ -93,10 +93,10 @@ sqInt ioPositionOfNativeDisplay(unsigned long windowHandle)
 sqInt ioSizeOfWindowSetxy(wIndexType windowIndex, sqInt x, sqInt y)
 {
     NSWindow *window = [[NSApplication sharedApplication] mainWindow];
-    NSRect rect = [window frame];
+    NSRect rect = [window convertRectToBacking: [window frame]];
     rect.size.width = x;
     rect.size.height = y;
-    [window setFrame:rect display:YES];    
+    [window setFrame: [window convertRectFromBacking: rect] display:YES];
 	return (0);  /* w is high 16 bits; h is low 16 bits */
 }
 

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -550,11 +550,11 @@ yZero()
 	return buttonState;
 }
 
-- (void) recordDragEvent:(int)dragType numberOfFiles:(int)numFiles where:(NSPoint)point windowIndex:(sqInt)windowIndex view:(NSView *)aView
+- (void) recordDragEvent:(int)dragType numberOfFiles:(int)numFiles where:(NSPoint)point windowIndex:(sqInt)windowIndex view:(NSView <sqSqueakOSXView> *)aView
 {
 	sqDragDropFilesEvent evt;
 
-    NSPoint local_point = [aView convertPoint:point fromView:nil];
+    NSPoint local_point = [aView sqDragPosition: point];
 
 	evt.type= EventTypeDragDropFiles;
 	evt.timeStamp= ioMSecs();

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -292,8 +292,8 @@ yZero()
 
 	evt.type = EventTypeMouse;
 	evt.timeStamp = ioMSecs();
-
-	NSPoint local_point = [aView convertPoint: [theEvent locationInWindow] fromView:nil];
+	
+	NSPoint local_point = [aView sqMousePosition: theEvent];
 
 	evt.x =  lrintf((float)local_point.x);
 	evt.y =  lrintf((float)local_point.y);
@@ -319,7 +319,7 @@ yZero()
 	evt.type = EventTypeMouse;
 	evt.timeStamp = ioMSecs();
 
-	NSPoint local_point = [aView convertPoint: [theEvent locationInWindow] fromView:nil];
+	NSPoint local_point = [aView sqMousePosition: theEvent];
 
 	evt.x =  lrintf((float)local_point.x);
 	evt.y =  lrintf((float)local_point.y);

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.h
@@ -47,7 +47,6 @@
 
 @interface sqSqueakOSXCGView : NSView <sqSqueakOSXView, sqViewClut, NSTextInputClient> {
 	sqSqueakOSXScreenAndWindow *__weak windowLogic;
-	NSTrackingRectTag squeakTrackingRectForCursor;
 	NSRange inputMark;
 	NSRange inputSelection;
 	keyBoardStrokeDetails* lastSeenKeyBoardStrokeDetails;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -85,6 +85,12 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 	dragCount = 0;
 	clippyIsEmpty = YES;
 	colorspace = CGColorSpaceCreateDeviceRGB();
+
+    // macOS 10.5 introduced NSTrackingArea for mouse tracking
+    NSTrackingArea *trackingArea = [[NSTrackingArea alloc] initWithRect: [self frame]
+    	options: (NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingActiveAlways | NSTrackingInVisibleRect)
+    	owner: self userInfo: nil];
+    [self addTrackingArea: trackingArea];
 }
 
 - (void) initializeVariables {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -57,7 +57,7 @@ static NSString *stringWithCharacter(unichar character) {
 }
 
 @implementation sqSqueakOSXCGView
-@synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
+@synthesize lastSeenKeyBoardStrokeDetails,
 lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
 
 #pragma mark Initialization / Release
@@ -142,19 +142,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 
 
 #pragma mark Updating callbacks
-
-- (void)viewDidMoveToWindow {
-	if (self.squeakTrackingRectForCursor)
-		[self removeTrackingRect: self.squeakTrackingRectForCursor];
-	
-	self.squeakTrackingRectForCursor = [self addTrackingRect: [self bounds] owner: self userData:NULL assumeInside: NO];
-}
-
-- (void) updateTrackingAreas {
-	[super updateTrackingAreas];
-	[self removeTrackingRect: self.squeakTrackingRectForCursor];
-	self.squeakTrackingRectForCursor = [self addTrackingRect: [self bounds] owner: self userData:NULL assumeInside: NO];
-}
 
 - (void) viewWillStartLiveResize {
 	[[NSCursor arrowCursor] set];

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -127,6 +127,14 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 	return NSMakePoint(converted.x, -converted.y);
 }
 
+- (NSPoint) sqDragPosition: (NSPoint)draggingLocation {
+	// TODO: Reuse conversion from sqMousePosition:.
+	NSPoint local_pt = [self convertPoint: draggingLocation fromView: nil];
+	NSPoint converted = [self convertPointToBacking: local_pt];
+	return NSMakePoint(converted.x, -converted.y);
+}
+
+
 #pragma mark Updating callbacks
 
 - (void)viewDidMoveToWindow {
@@ -631,6 +639,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 	if (self.dragInProgress)
 		return NSDragOperationNone;
 	dragInProgress = YES;
+	gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 	self.dragCount = (int) [self countNumberOfNoneSqueakImageFilesInDraggedFiles: info];
 	
 	if (self.dragCount)
@@ -657,7 +666,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 
 - (BOOL) performDragOperation: (id<NSDraggingInfo>)info {
 	if (self.dragCount) {
-		gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex  view: self];
 	}
 	

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -86,6 +86,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 	dragCount = 0;
 	clippyIsEmpty = YES;
 	colorspace = CGColorSpaceCreateDeviceRGB();
+	[self initializeSqueakColorMap];
 
     // macOS 10.5 introduced NSTrackingArea for mouse tracking
     NSTrackingArea *trackingArea = [[NSTrackingArea alloc] initWithRect: [self frame]

--- a/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.h
@@ -46,7 +46,6 @@
 // TODO: Remove the unneeded elements.
 @interface sqSqueakOSXHeadlessView : NSView <sqSqueakOSXView, sqViewClut, NSTextInputClient> {
 	sqSqueakOSXScreenAndWindow *__weak windowLogic;
-	NSTrackingRectTag squeakTrackingRectForCursor;
 	NSRange inputMark;
 	NSRange inputSelection;
 	keyBoardStrokeDetails* lastSeenKeyBoardStrokeDetails;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXHeadlessView.m
@@ -50,7 +50,7 @@ static NSString *stringWithCharacter(unichar character) {
 }
 
 @implementation sqSqueakOSXHeadlessView
-@synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
+@synthesize lastSeenKeyBoardStrokeDetails,
 lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreenBoundsAtTimeOfFullScreen;
 
 #pragma mark Initialization / Release
@@ -107,12 +107,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,savedScreen
 }
 
 #pragma mark Updating callbacks
-
-- (void)viewDidMoveToWindow {
-}
-
-- (void) updateTrackingAreas {
-}
 
 - (void) viewWillStartLiveResize {
 }

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
@@ -63,9 +63,6 @@
 	BOOL clippyIsEmpty;
 	CGRect clippy;
     CGSize lastFrameSize;
-	
-    BOOL fullScreenInProgress;
-    void* fullScreendispBitsIndex;
 	void* currentDisplayStorage;
 	
 	BOOL metalInitialized;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.h
@@ -48,7 +48,6 @@
 
 @interface sqSqueakOSXMetalView : MTKView <sqSqueakOSXView, sqViewClut, NSTextInputClient> {
 	sqSqueakOSXScreenAndWindow *__weak windowLogic;
-	NSTrackingRectTag squeakTrackingRectForCursor;
 	NSRange inputMark;
 	NSRange inputSelection;
 	keyBoardStrokeDetails* lastSeenKeyBoardStrokeDetails;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -105,7 +105,7 @@ static NSString *stringWithCharacter(unichar character) {
 @end
 
 @implementation sqSqueakOSXMetalView
-@synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
+@synthesize lastSeenKeyBoardStrokeDetails,
 lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSize,fullScreenInProgress,fullScreendispBitsIndex,graphicsCommandQueue;
 
 + (BOOL) isMetalViewSupported {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -214,6 +214,14 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	return NSMakePoint(converted.x, -converted.y);
 }
 
+- (NSPoint) sqDragPosition: (NSPoint)draggingLocation {
+	// TODO: Reuse conversion from sqMousePosition:.
+	NSPoint local_pt = [self convertPoint: draggingLocation fromView: nil];
+	NSPoint converted = [self convertPointToBacking: local_pt];
+	return NSMakePoint(converted.x, -converted.y);
+}
+
+
 #pragma mark Drawing
 
 - (void) setupFullScreendispBitsIndex {
@@ -822,6 +830,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	if (self.dragInProgress)
 		return NSDragOperationNone;
 	dragInProgress = YES;
+	gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 	self.dragCount = (int) [self countNumberOfNoneSqueakImageFilesInDraggedFiles: info];
 
 	if (self.dragCount)
@@ -851,7 +860,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 - (BOOL) performDragOperation: (id<NSDraggingInfo>)info {
 //    NSLog(@"performDragOperation %@",info);
 	if (self.dragCount) {
-		gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	}
 

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -168,6 +168,12 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	colorspace = CGColorSpaceCreateDeviceRGB();
 	[self initializeSqueakColorMap];
     [[NSNotificationCenter defaultCenter] addObserver:self selector: @selector(didEnterFullScreen:) name:@"NSWindowDidEnterFullScreenNotification" object:nil];
+
+    // macOS 10.5 introduced NSTrackingArea for mouse tracking
+    NSTrackingArea *trackingArea = [[NSTrackingArea alloc] initWithRect: [self frame]
+    	options: (NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingActiveAlways | NSTrackingInVisibleRect)
+    	owner: self userInfo: nil];
+    [self addTrackingArea: trackingArea];
 }
 
 - (void) didEnterFullScreen: (NSNotification*) aNotification {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXMetalView.m
@@ -200,6 +200,20 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	return YES;
 }
 
+- (NSRect) sqScreenSize {
+  return [self convertRectToBacking: [self bounds]];
+}
+
+
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent {
+	/* Our client expects the mouse coordinates in Squeak's coordinates,
+	 * but theEvent's location is in "user" coords. so we have to convert. */
+	NSPoint local_pt = [self convertPoint: [theEvent locationInWindow] fromView:nil];
+	NSPoint converted = [self convertPointToBacking: local_pt];
+	// Squeak is upside down
+	return NSMakePoint(converted.x, -converted.y);
+}
+
 #pragma mark Drawing
 
 - (void) setupFullScreendispBitsIndex {
@@ -362,7 +376,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 }
 
 - (CGSize) screenSizeForTexture {
-	CGRect screenRect = [self bounds];
+	CGRect screenRect = [self sqScreenSize];
 	CGSize screenSize;
 	screenSize.width = (sqInt)screenRect.size.width;
 	screenSize.height = (sqInt)screenRect.size.height;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
@@ -87,5 +87,6 @@
 - (void) preDrawThelayers;
 - (NSRect) sqScreenSize;
 - (NSPoint) sqMousePosition: (NSEvent*)theEvent;
+- (NSPoint) sqDragPosition: (NSPoint)draggingLocation;
 @end
 #endif //USE_OPENGL

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
@@ -85,7 +85,7 @@
 
 - (void) setupOpenGL;
 - (void) preDrawThelayers;
--(void)drawRect:(NSRect)rect flush:(BOOL)flush;
-
+- (NSRect) sqScreenSize;
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
 @end
 #endif //USE_OPENGL

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.h
@@ -49,7 +49,6 @@
 
 @interface sqSqueakOSXOpenGLView : NSOpenGLView <sqSqueakOSXView, sqViewClut, NSTextInputClient> {
 	sqSqueakOSXScreenAndWindow *__weak windowLogic;
-	NSTrackingRectTag squeakTrackingRectForCursor;
 	NSRange inputMark;
 	NSRange inputSelection;
 	keyBoardStrokeDetails* lastSeenKeyBoardStrokeDetails;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
@@ -361,8 +361,8 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	
 	glClearColor(1, 1, 1, 1);
 
-//	GLint newSwapInterval = 1;
-//	CGLSetParameter(cgl_ctx, kCGLCPSwapInterval, &newSwapInterval);
+	GLint newSwapInterval = 0; // vsync on (1) or off (0)
+	CGLSetParameter(ctx, kCGLCPSwapInterval, &newSwapInterval);
 	/*glDisable(GL_DITHER);
 	glDisable(GL_ALPHA_TEST);
 	glDisable(GL_BLEND);

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
@@ -559,6 +559,14 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 
 -(void)drawRect:(NSRect)rect
 {
+	// TODO: Figure out who calls this to convert rect there.
+	// It is rather dangerous to have such different semantics
+	// between drawRect: and drawRect:flush:. We assume that
+	// only the OS calls this, not any image primitive.
+	NSPoint priorOrigin = rect.origin;
+	rect = [self convertRectToBacking: rect];
+	rect.origin = priorOrigin;
+
 	// Called by Cocoa. We need to flush.
 	[self drawRect: rect flush: YES];
 }

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
@@ -207,6 +207,12 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	colorspace = CGColorSpaceCreateDeviceRGB();
 	[self initializeSqueakColorMap];
     [[NSNotificationCenter defaultCenter] addObserver:self selector: @selector(didEnterFullScreen:) name:@"NSWindowDidEnterFullScreenNotification" object:nil];
+
+    // macOS 10.5 introduced NSTrackingArea for mouse tracking
+    NSTrackingArea *trackingArea = [[NSTrackingArea alloc] initWithRect: [self frame]
+    	options: (NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved | NSTrackingActiveAlways | NSTrackingInVisibleRect)
+    	owner: self userInfo: nil];
+    [self addTrackingArea: trackingArea];
 }
 
 - (void) didEnterFullScreen: (NSNotification*) aNotification {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
@@ -150,7 +150,7 @@ static NSString *stringWithCharacter(unichar character) {
 @end
 
 @implementation sqSqueakOSXOpenGLView
-@synthesize squeakTrackingRectForCursor,lastSeenKeyBoardStrokeDetails,
+@synthesize lastSeenKeyBoardStrokeDetails,
 lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSize,fullScreenInProgress,fullScreendispBitsIndex;
 
 + (NSOpenGLPixelFormat *)defaultPixelFormat {
@@ -271,19 +271,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 
 
 #pragma mark Updating callbacks
-
-- (void)viewDidMoveToWindow {
-	if (self.squeakTrackingRectForCursor)
-		[self removeTrackingRect: self.squeakTrackingRectForCursor];
-	
-	self.squeakTrackingRectForCursor = [self addTrackingRect: [self sqScreenSize] owner: self userData:NULL assumeInside: NO];
-}
-
-- (void) updateTrackingAreas {
-	[super updateTrackingAreas];
-	[self removeTrackingRect: self.squeakTrackingRectForCursor];
-	self.squeakTrackingRectForCursor = [self addTrackingRect: [self sqScreenSize] owner: self userData:NULL assumeInside: NO];
-}
 
 - (void) viewWillStartLiveResize {
     //NSLog(@"viewWillStartLiveResize");

--- a/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXOpenGLView.m
@@ -256,6 +256,14 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	return NSMakePoint(converted.x, -converted.y);
 }
 
+- (NSPoint) sqDragPosition: (NSPoint)draggingLocation {
+	// TODO: Reuse conversion from sqMousePosition:.
+	NSPoint local_pt = [self convertPoint: draggingLocation fromView: nil];
+	NSPoint converted = [self convertPointToBacking: local_pt];
+	return NSMakePoint(converted.x, -converted.y);
+}
+
+
 #pragma mark Updating callbacks
 
 - (void)viewDidMoveToWindow {
@@ -1055,6 +1063,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 	if (self.dragInProgress)
 		return NSDragOperationNone;
 	dragInProgress = YES;
+	gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 	self.dragCount = (int) [self countNumberOfNoneSqueakImageFilesInDraggedFiles: info];
 
 	if (self.dragCount)
@@ -1084,7 +1093,6 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,windowLogic,lastFrameSi
 - (BOOL) performDragOperation: (id<NSDraggingInfo>)info {
 //    NSLog(@"performDragOperation %@",info);
 	if (self.dragCount) {
-		gDelegateApp.dragItems = [self filterOutSqueakImageFilesFromDraggedURIs: info];
 		[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordDragEvent: SQDragDrop numberOfFiles: self.dragCount where: [info draggingLocation] windowIndex: self.windowLogic.windowIndex view: self];
 	}
 

--- a/platforms/iOS/vm/OSX/sqSqueakOSXView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXView.h
@@ -61,5 +61,6 @@
 
 - (NSRect) sqScreenSize;
 - (NSPoint) sqMousePosition: (NSEvent*)theEvent;
+- (NSPoint) sqDragPosition: (NSPoint)draggingLocation;
 
 @end

--- a/platforms/iOS/vm/OSX/sqSqueakOSXView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXView.h
@@ -59,4 +59,7 @@
 - (void) preDrawThelayers;
 - (void) drawImageUsingClip: (CGRect) clip;
 
+- (NSRect) sqScreenSize;
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
+
 @end

--- a/platforms/iOS/vm/OSX/sqSqueakOSXView.h
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXView.h
@@ -41,7 +41,6 @@
 
 @protocol sqSqueakOSXView <NSObject>
 
-@property (nonatomic,assign) NSTrackingRectTag squeakTrackingRectForCursor;
 @property (nonatomic,strong) keyBoardStrokeDetails* lastSeenKeyBoardStrokeDetails;
 @property (nonatomic,strong) keyBoardStrokeDetails* lastSeenKeyBoardModifierDetails;
 @property (nonatomic,assign) BOOL dragInProgress;

--- a/platforms/iOS/vm/iPhone/Classes/SqueakUIView.h
+++ b/platforms/iOS/vm/iPhone/Classes/SqueakUIView.h
@@ -54,5 +54,6 @@ Some of this code was funded via a grant from the European Smalltalk User Group 
 	- (void) drawImageUsingClip: (CGRect) clip;
 	- (CGRect) sqScreenSize;
 	- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
+    - (NSPoint) sqDragPosition: (NSPoint)draggingLocation;
     @property (nonatomic,strong) NSArray *arrowsNames;  // jdr
 @end

--- a/platforms/iOS/vm/iPhone/Classes/SqueakUIView.h
+++ b/platforms/iOS/vm/iPhone/Classes/SqueakUIView.h
@@ -52,5 +52,7 @@ Some of this code was funded via a grant from the European Smalltalk User Group 
     - (void) preDrawThelayers;
 	- (void) drawThelayers;
 	- (void) drawImageUsingClip: (CGRect) clip;
+	- (CGRect) sqScreenSize;
+	- (NSPoint) sqMousePosition: (NSEvent*)theEvent;
     @property (nonatomic,strong) NSArray *arrowsNames;  // jdr
 @end

--- a/platforms/iOS/vm/iPhone/Classes/SqueakUIView.m
+++ b/platforms/iOS/vm/iPhone/Classes/SqueakUIView.m
@@ -73,6 +73,14 @@ SInt32 undoCounter=1, oldValue=0;  // jdr undo support
 - (void) drawImageUsingClip: (CGRect) clip {
 }
 
+- (CGRect) sqScreenSize {
+	return [self bounds];
+}
+
+- (NSPoint) sqMousePosition: (NSEvent*)theEvent {
+	return [self convertPoint: [theEvent locationInWindow] fromView:nil];
+}
+
 // Handles the start of a touch
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {

--- a/platforms/iOS/vm/iPhone/Classes/SqueakUIView.m
+++ b/platforms/iOS/vm/iPhone/Classes/SqueakUIView.m
@@ -81,6 +81,10 @@ SInt32 undoCounter=1, oldValue=0;  // jdr undo support
 	return [self convertPoint: [theEvent locationInWindow] fromView:nil];
 }
 
+- (NSPoint) sqDragPosition: (NSPoint)draggingLocation {
+	return [aView convertPoint: draggingLocation fromView:nil];
+}
+
 // Handles the start of a touch
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {


### PR DESCRIPTION
Tested with **Squeak6.0alpha** and **Cuis6.0-5069**.

Fixed issues:
- Correct image-side display bounds in high-resolution mode on start-up and via `#setNewScreenSize:` (i.e., HostWindowPlugin primitiveHostWindowSizeSet)
- File drag in high-resolution mode is now matching image-side display bounds
- File drag has now access to file paths in DragEnter, not just DragDrop (i.e., mouseUp)
- `-core-graphics` usable again
- `-opengl` does not slow down VM interpeter loop anymore (e.g., in Morphic's use of primitive 127 and 231)
- `-metal` does not slow down VM interpeter loop anymore (e.g., in Morphic's use of primitive 127 and 231)

Known issues:
- <s>**Rather frequent segfaults in macOS64ARMv8**, maybe related to JIT via `checkForEventsMayContextSwitch:` where `checkCogCompiledCodeCompactionCalledFor` is called before `ioProcessEvents` ... maybe because of new display events queued in `-core-graphics` and `-metal` backends</s>
- **Update:** I think I just did a mistake when partially re-compiling the VM. A full, clean compile after `make cleanall` yields a VM that did not crash for over an hour.

----

Known issues on macOS 12:
- No OS-supported "Low Resolution" mode; use magnifier
- No `-opengl` support
- High-resolution mode scales up hardware cursor

Known issues on macOS 11.6:
- No `-opengl` support
- High-resolution mode scales up hardware cursor

Known issues on macOS 10.15:
- High-resolution mode scales up hardware cursor

----

Known issues for `-metal` backend:
- Must use image-side buffer for composition to avoid flickering

Known issues for `-core-graphics` backend:
- Must use image-side buffer for composition to avoid flickering
- Blitting on `Display` via `Form reverse` not working bc. alpha value must be FF (255)
- Rather slow bc. only full and no clippy-based updates due to inaccessible double-buffering in CoreGraphics

Known issues for `-opengl` backend:
- No blitting support for Squeak's MVC
- No blitting support for Squeak's Morph's fast window dragging/resizing

-----

Note that Squeak6.0alpha has direct support for that image-side buffer via `#disableDeferredUpdates` preference. The support in Squeak's Morphic has been there since at least 1999. Cuis does not yet have an image-side buffer for composition but flickering is rare.

Note that `-core-graphics` could be made compatible with `Form reverse` blitting rule by using a color with alpha value (almost) 0 such as `Color gray alpha: 1/255` or `Color colorFromPixelValue: 16r01808080`. Try out via `Display fill: (0@0 corner: 200@200) rule: Form reverse fillColor: Color gray`.

Finally note that both `-metal` and `-core-graphics` now do rather nothing in primitive 231 (i.e., `forceDisplayUpdate`/ `ioForceDisplayUpdate` / `drawThelayers`) but rely on a scheduled display event to be delivered via primitive 94 (i.e., `primitiveGetNextEvent` / `ioProcessEvents` / `vmIOProcessEvents`), which is also called every 20 milliseconds on any other primitive send. See `checkForEventsMayContextSwitch` in VMMaker sources.

-----

**Big thanks to [krono](https://github.com/krono/) for helping out with this high-resolution stuff and other details on macOS!**