### PR TITLE
[SqueakSSL/unix/openssl] Fix for OpenSSL3

### DIFF
--- a/platforms/unix/plugins/SqueakSSL/openssl_overlay.h
+++ b/platforms/unix/plugins/SqueakSSL/openssl_overlay.h
@@ -78,7 +78,13 @@
 #define sqo_SSL_free SSL_free
 #define sqo_SSL_ctrl SSL_ctrl
 #define sqo_SSL_get_error SSL_get_error
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define sqo_SSL_get_peer_certificate SSL_get1_peer_certificate
+#define sqo_SSL_get1_peer_certificate SSL_get1_peer_certificate
+#else
 #define sqo_SSL_get_peer_certificate SSL_get_peer_certificate
+#define sqo_SSL_get1_peer_certificate NULL_FUNC
+#endif
 #define sqo_SSL_get_verify_result SSL_get_verify_result
 #define sqo_SSL_new SSL_new
 #define sqo_SSL_read SSL_read
@@ -253,7 +259,8 @@ OPENSSL_INIT_SETTINGS;
   SQO_DECL___(void, SSL_free, SSL *ssl)                                 \
   SQO_DECL___(long, SSL_ctrl, SSL *ssl, int cmd, long larg, void *parg) \
   SQO_DECL___(int, SSL_get_error, const SSL *s, int ret_code)           \
-  SQO_DECL___(X509 *, SSL_get_peer_certificate, const SSL *s)           \
+  SQO_DECL_IF(X509 *, SSL_get_peer_certificate, const SSL *s)           \
+  SQO_DECL_IF(X509 *, SSL_get1_peer_certificate, const SSL *s)          \
   SQO_DECL___(long, SSL_get_verify_result, const SSL *ssl)              \
   SQO_DECL___(SSL *, SSL_new, SSL_CTX *ctx)                             \
   SQO_DECL___(int, SSL_read, SSL *ssl, void *buf, int num)              \

--- a/platforms/unix/plugins/SqueakSSL/sqUnixOpenSSL.inc
+++ b/platforms/unix/plugins/SqueakSSL/sqUnixOpenSSL.inc
@@ -72,6 +72,32 @@ sqInt sqCopyBioSSL(sqSSL *ssl, BIO *bio, char *dstBuf, sqInt dstLen) {
 }
 
 
+/* sqGetPeerCertificate: Tiny wrapper to find out which get_peer_cert to use */
+static X509* sqGetPeerCertificate(const SSL* s)
+{
+#define DEBUG_FUNC(f) \
+  DEBUG_PRINT("sqGetPeerCertificate: Using %s as get_cert func\n", #f)
+
+  static bool initialized = false;
+  static X509* (*_get_peer_certificate)(const SSL* s) = NULL;
+  if (!initialized) {
+    initialized = true;
+    if (sqo_SSL_get1_peer_certificate) {
+      DEBUG_FUNC(sqo_SSL_get1_peer_certificate);
+      _get_peer_certificate = sqo_SSL_get1_peer_certificate;
+    } else if (sqo_SSL_get_peer_certificate) {
+      DEBUG_FUNC(sqo_SSL_get_peer_certificate);
+      _get_peer_certificate = sqo_SSL_get_peer_certificate;
+    }
+  }
+  if (_get_peer_certificate) {
+    return _get_peer_certificate(s);
+  } else {
+    return NULL;
+  }
+#undef DEBUG_FUNC
+}
+
 enum sqMatchResult sqVerifyIP(sqSSL* ssl, X509* cert, const char* serverName, const size_t serverNameLength);
 enum sqMatchResult sqVerifyDNS(sqSSL* ssl, X509* cert, const char* serverName, const size_t serverNameLength);
 enum sqMatchResult sqVerifyNameInner(sqSSL* ssl, X509* cert, const void* serverName, const size_t serverNameLength, const int matchType);
@@ -414,7 +440,7 @@ sqInt sqConnectSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 	ssl->state = SQSSL_CONNECTED;
 
 	if(ssl->loglevel) printf("sqConnectSSL: SSL_get_peer_certificate\n");
-	cert = sqo_SSL_get_peer_certificate(ssl->ssl);
+	cert = sqGetPeerCertificate(ssl->ssl);
 	if(ssl->loglevel) printf("sqConnectSSL: cert = %p\n", cert);
 	/* Fail if no cert received. */
 	if(cert) {
@@ -553,7 +579,7 @@ sqInt sqAcceptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt 
 	ssl->state = SQSSL_CONNECTED;
 
 	if(ssl->loglevel) printf("sqAcceptSSL: SSL_get_peer_certificate\n");
-	cert = sqo_SSL_get_peer_certificate(ssl->ssl);
+	cert = sqGetPeerCertificate(ssl->ssl);
 	if(ssl->loglevel) printf("sqAcceptSSL: cert = %p\n", cert);
 
 	if(cert) {


### PR DESCRIPTION
OpenSSL 3 deprecated SSL_get_peer_certificate, made it a macro and an
provides SSL_get{0,1}_peer_certificate instead.

Why even more complicating that already messed API is beyond me.
Not promising ABI stability is well known for OpenSSL but, why the HECK
not simply providing an Alias Symbol instead of UNNECESSARILY ripping
the symbol out of that innocent object file?

Also, we now need a load-time disambiguation of which symbol to use.

(if you find a rant in this message, you can keep it)

Fixes #633