### PR TITLE
Revise docs on HowToBuild on Windows: cygwin tools must be in PATH [ci skip]

### DIFF
--- a/building/win32x86/HowToBuild
+++ b/building/win32x86/HowToBuild
@@ -109,6 +109,7 @@ If building from mingw32, it may be necessary to omit the tool prefix:
 
 MSVC 1. Install the tools:
 - follow step Cygwin 1. Install the tools
+- Make sure that the tools directory (e.g., C:\cygwin\bin) is in your PATH environment variable
 - Install Visual Studio Community from https://visualstudio.microsoft.com/downloads/
 
 MSVC 2. Build

--- a/building/win64x64/HowToBuild
+++ b/building/win64x64/HowToBuild
@@ -104,6 +104,7 @@ If building from mingw64, it may be necessary to omit the tool prefix:
 
 MSVC 1. Install the tools:
 - follow step Cygwin 1. Install the tools
+- Make sure that the tools directory (e.g., C:\cygwin\bin) is in your PATH environment variable
 - Install Visual Studio Community from https://visualstudio.microsoft.com/downloads/
 
 MSVC 2. Build


### PR DESCRIPTION
Otherwise, `MAKEDEBUG.BAT` & Co. might fail if some tools (such as `tee`) are not found.