### PR TITLE
Fix gdi leak

### DIFF
--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -1794,7 +1794,12 @@ static thisGetDpiForMonitor_t thisGetDpiForMonitor = NULL;
  */
 static double getDpiSystem(void)
 {
-  return (double) GetDeviceCaps(GetWindowDC(stWindow), LOGPIXELSY);
+  double dpi;
+  HDC dc = GetWindowDC(stWindow);
+  if (!dc) return 0.0; /* fail */
+  dpi = (double) GetDeviceCaps(dc, LOGPIXELSY);
+  ReleaseDC(stWindow,dc);
+  return dpi;
 }
 
 

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -125,6 +125,7 @@ int keyBufOverflows = 0;	/* number of characters dropped */
 HWND stWindow = NULL;      /*	the squeak window */
 HINSTANCE hInstance;	     /*	the instance of squeak running */
 HCURSOR currentCursor=0;	 /*	current cursor displayed by squeak */
+BOOL    currentCursorIsIcon = 0;
 HPALETTE palette;	         /*	the palette (might be unused) */
 LOGPALETTE *logPal;	       /*	the logical palette definition */
 BITMAPINFO *bmi1;	         /*	1 bit depth bitmap info */
@@ -1880,6 +1881,7 @@ ioScreenDepth(void)
 sqInt
 ioSetCursorWithMask(sqInt cursorBitsIndex, sqInt cursorMaskIndex, sqInt offsetX, sqInt offsetY)
 {
+  HCURSOR oldCursor;
   static unsigned char *andMask=0,*xorMask=0;
   static int cx=0,cy=0,cursorSize=0;
   int i;
@@ -1896,9 +1898,6 @@ ioSetCursorWithMask(sqInt cursorBitsIndex, sqInt cursorMaskIndex, sqInt offsetX,
       andMask = malloc(cursorSize);
       xorMask = malloc(cursorSize);
   }
-
-  /* free last used cursor */
-  if (currentCursor) DestroyCursor(currentCursor);
 
   memset(andMask,0xff,cursorSize);
   memset(xorMask,0x00,cursorSize);
@@ -1928,14 +1927,22 @@ ioSetCursorWithMask(sqInt cursorBitsIndex, sqInt cursorMaskIndex, sqInt offsetX,
         andMask[i*cx/8+1] = ~(checkedLongAt(cursorBitsIndex + (4 * i)) >> 16) & 0xFF;
       }
 
+  oldCursor = currentCursor;
   currentCursor = CreateCursor(hInstance,-offsetX,-offsetY,cx,cy,andMask,xorMask);
   if (currentCursor)
     {
       SetCursor(0);
       SetCursor(currentCursor);
+      /* free last used cursor */
+      if (oldCursor) {
+	if(currentCursorIsIcon) DestroyIcon(oldCursor);
+        else DestroyCursor(oldCursor);
+      }
+      currentCursorIsIcon = FALSE;
     }
   else
     {
+      currentCursor = oldCursor;
       printLastError(TEXT("CreateCursor failed"));
     }
 
@@ -1951,6 +1958,7 @@ ioSetCursor(sqInt cursorBitsIndex, sqInt offsetX, sqInt offsetY)
 sqInt
 ioSetCursorARGB(sqInt bitsIndex, sqInt w, sqInt h, sqInt x, sqInt y)
 {
+  HCURSOR oldCursor;
   ICONINFO info;
   HBITMAP hbmMask = NULL;
   HBITMAP hbmColor = NULL;
@@ -1976,13 +1984,27 @@ ioSetCursorARGB(sqInt bitsIndex, sqInt w, sqInt h, sqInt x, sqInt y)
   info.hbmMask = hbmMask;
   info.hbmColor = hbmColor;
 
-  DestroyCursor(currentCursor);
+  oldCursor = currentCursor;
   currentCursor = CreateIconIndirect(&info);
   if (hbmColor) DeleteObject(hbmColor);
   if (hbmMask) DeleteObject(hbmMask);
   if (mDC) DeleteDC(mDC);
 
-  SetCursor(currentCursor);
+  if (currentCursor)
+    {
+      SetCursor(currentCursor);
+      /* free last used cursor */
+      if (oldCursor) {
+	if(currentCursorIsIcon) DestroyIcon(oldCursor);
+        else DestroyCursor(oldCursor);
+      }
+      currentCursorIsIcon = TRUE;
+    }
+  else
+    {
+      currentCursor = oldCursor;
+      printLastError(TEXT("CreateIconIndirect failed"));
+    }
 
   return 1;
 }


### PR DESCRIPTION
On some win32 configurations and/or with some specific image,
we observe a GDI leak : numbers of GDI objects rapidly grow up to 10,000 (about 50 new objects/second).
when the limit is reached, the image hangs and we have to kill it...

With those fixes, the number of GDI objects remains stable at 20.
