### PR TITLE
configure.ac: Fix tzet typo for tzset

### DIFF
--- a/platforms/unix/config/acinclude.m4
+++ b/platforms/unix/config/acinclude.m4
@@ -161,7 +161,7 @@ test "$ac_cv_socklen_t" != "yes" && AC_DEFINE(socklen_t, int, [socklen size])])
 
 AC_DEFUN([AC_CHECK_TZSET],
 [AC_CACHE_CHECK([for tzset], ac_cv_tzset,
-  AC_TRY_COMPILE([#include <time.h>],[tzet();],
+  AC_TRY_COMPILE([#include <time.h>],[tzset();],
     ac_cv_tzset="yes", ac_cv_tzset="no"))
 test "$ac_cv_tzset" != "no" && AC_DEFINE(HAVE_TZSET, [], [tzset available])])
 

--- a/platforms/unix/config/configure
+++ b/platforms/unix/config/configure
@@ -14114,7 +14114,7 @@ else
 int
 main ()
 {
-tzet();
+tzset();
   ;
   return 0;
 }


### PR DESCRIPTION
Found with an instrumented compiler for:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC