### PR TITLE
use --whole-archive option instead of -whole-archive for solaris ld

### DIFF
--- a/platforms/unix/config/Makefile.in
+++ b/platforms/unix/config/Makefile.in
@@ -45,7 +45,7 @@ all : $(squeak) plugins squeak.1 $(npsqueak)
 # VM
 
 $(squeak) : config.sh $(SQLIBS) version.o
-	$(LINK) $(squeak) $(SQLIBS) version.o $(LIBS) [plibs] -Wl,-whole-archive,vm/vm.a,-no-whole-archive
+	$(LINK) $(squeak) $(SQLIBS) version.o $(LIBS) [plibs] -Wl,--whole-archive,vm/vm.a,--no-whole-archive
 	@echo
 	@size $(squeak)
 	@echo


### PR DESCRIPTION
I believe that the GNU link editor supports both single hyphen and double hyphen options -whole-archive and --whole-archive

However the SUN (Solaris and SunOS and Illumos) link editor uses different names like "-z weakextract"

Three is a GNU compatibility layer but the SUN link editor insists for GNU compatibility on the double hyphen format -whole-archive and --no-whole-archive

David Stes