### PR TITLE
Fix socket file check in sqResolverGetAddressInfoHostSizeServiceSizeF…

### DIFF
--- a/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
+++ b/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
@@ -1789,7 +1789,7 @@ sqResolverGetAddressInfoHostSizeServiceSizeFlagsFamilyTypeProtocol
    && !(flags & SQ_SOCKET_NUMERIC))
 	{
 	  struct stat st;
-	  if (!stat(servName, &st) && (st.st_mode & S_IFSOCK))
+	  if (!stat(servName, &st) || (st.st_mode & S_IFSOCK))
 		{
 		  struct sockaddr_un *saun= calloc(1, sizeof(struct sockaddr_un));
 		  localInfo= (struct addrinfo *)calloc(1, sizeof(struct addrinfo));


### PR DESCRIPTION
…lagsFamilyTypeProtocol

Replacing `&&` with `||` ensures it actually checks that either:
- the file does not exist
- the file does exist and it is a socket file