### PR TITLE
Remove socket file check in sqResolverGetAddressInfoHostSizeServiceSizeFlagsFamilyTypeProtocol

### DIFF
--- a/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
+++ b/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
@@ -83,7 +83,6 @@
 #   include <time.h>
 # endif
 # include <sys/param.h>
-# include <sys/stat.h>
 # include <sys/socket.h>
 # include <sys/ioctl.h>
 # include <net/if.h>

--- a/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
+++ b/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
@@ -1788,23 +1788,19 @@ sqResolverGetAddressInfoHostSizeServiceSizeFlagsFamilyTypeProtocol
    && servSize < sizeof(((struct sockaddr_un *)0)->sun_path)
    && !(flags & SQ_SOCKET_NUMERIC))
 	{
-	  struct stat st;
-	  if (!stat(servName, &st) && (st.st_mode & S_IFSOCK))
-		{
-		  struct sockaddr_un *saun= calloc(1, sizeof(struct sockaddr_un));
-		  localInfo= (struct addrinfo *)calloc(1, sizeof(struct addrinfo));
-		  localInfo->ai_family= AF_UNIX;
-		  localInfo->ai_socktype= SOCK_STREAM;
-		  localInfo->ai_addrlen= sizeof(struct sockaddr_un);
-		  localInfo->ai_addr= (struct sockaddr *)saun;
-		  /*saun->sun_len= sizeof(struct sockaddr_un);*/
-		  saun->sun_family= AF_UNIX;
-		  memcpy(saun->sun_path, servName, servSize);
-		  saun->sun_path[servSize]= '\0';
-		  addrInfo= localInfo;
-		  interpreterProxy->signalSemaphoreWithIndex(resolverSema);
-		  return;
-		}
+	  struct sockaddr_un *saun= calloc(1, sizeof(struct sockaddr_un));
+	  localInfo= (struct addrinfo *)calloc(1, sizeof(struct addrinfo));
+	  localInfo->ai_family= AF_UNIX;
+	  localInfo->ai_socktype= SOCK_STREAM;
+	  localInfo->ai_addrlen= sizeof(struct sockaddr_un);
+	  localInfo->ai_addr= (struct sockaddr *)saun;
+	  /*saun->sun_len= sizeof(struct sockaddr_un);*/
+	  saun->sun_family= AF_UNIX;
+	  memcpy(saun->sun_path, servName, servSize);
+	  saun->sun_path[servSize]= '\0';
+	  addrInfo= localInfo;
+	  interpreterProxy->signalSemaphoreWithIndex(resolverSema);
+	  return;
 	}
 
   memset(&request, 0, sizeof(request));


### PR DESCRIPTION
I was able to build the project on Linux, and I verified that I could generate a (valid) socket address for a socket path with `primitiveResolverGetAddressInfoHost:service:flags:family:type:protocol:` regardless of the file's existence and even bind a socket to it with `primitiveSocket:bindTo:` (if the file does not exist).

This change is necessary to make `primitiveResolverGetAddressInfoHost:service:flags:family:type:protocol:` usable for generating socket addresses as a unix socket server written in Smalltalk.