### PR TITLE
Makes dropRequestFileName percent-decode on Unix.

### DIFF
--- a/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
+++ b/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
@@ -41,6 +41,7 @@
 #include "sqVirtualMachine.h"
 #include "FilePlugin.h"
 #include "DropPlugin.h"
+#include <ctype.h>
 
 extern struct VirtualMachine  *interpreterProxy;
 extern int						uxDropFileCount;

--- a/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
+++ b/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
@@ -66,6 +66,18 @@ fileValueOf(sqInt anSQFileRecord)
 sqInt dropInit(void)     { return 1; }
 sqInt dropShutdown(void) { return 1; }
 
+static int
+hexValue(const int c)
+{
+  if (c <  '0') return 0;
+  if (c <= '9') return c - '0';
+  if (c <  'A') return 0;
+  if (c <= 'F') return c - 'A' + 10;
+  if (c <  'a') return 0;
+  if (c <= 'f') return c - 'a' + 10;
+  return 0;
+}
+
 /* We now set USE_FILE_URIs to 1 in platforms/unix//vm-display-X11/sqUnixXdnd.c
  * hence dropRequestFileName skips the URI prefix and dropRequestURI includes it
  */
@@ -95,9 +107,19 @@ dropRequestFileName(sqInt dropIndex)	// in st coordinates
 		++prefixLength;
 
 	// file:///path & file:/path => /path; anything else answered verbatim
-	return prefixLength == 8 || prefixLength == 6
+	char *path = prefixLength == 8 || prefixLength == 6
 		? uxDropFileNames[dropIndex - 1] + prefixLength - 1
 		: uxDropFileNames[dropIndex - 1];
+
+	// Decode path (i.e. URI => String)
+	for (int i = 0; path[i]; ++i) {
+		if ((path[i] == '%') && isxdigit(path[i + 1]) && isxdigit(path[i + 2])) {
+			path[i] = hexValue(path[i + 1]) << 4 | hexValue(path[i + 2]);
+			memmove(path + i + 1, path + i + 3, strlen(path + i + 3) + 1);
+		}
+	}
+
+	return path;
 }
 
 char *

--- a/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
+++ b/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
@@ -112,10 +112,11 @@ dropRequestFileName(sqInt dropIndex)	// in st coordinates
 		: uxDropFileNames[dropIndex - 1];
 
 	// Decode path (i.e. URI => String)
-	for (int i = 0; path[i]; ++i) {
+	for (int i = 0, l = strlen(path); path[i]; ++i, --l) {
 		if ((path[i] == '%') && isxdigit(path[i + 1]) && isxdigit(path[i + 2])) {
 			path[i] = hexValue(path[i + 1]) << 4 | hexValue(path[i + 2]);
-			memmove(path + i + 1, path + i + 3, strlen(path + i + 3) + 1);
+			l -= 2;
+			memmove(path + i + 1, path + i + 3, l);
 		}
 	}
 

--- a/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
+++ b/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
@@ -68,15 +68,13 @@ sqInt dropInit(void)     { return 1; }
 sqInt dropShutdown(void) { return 1; }
 
 static int
-hexValue(const int c)
-{
-  if (c <  '0') return 0;
-  if (c <= '9') return c - '0';
-  if (c <  'A') return 0;
-  if (c <= 'F') return c - 'A' + 10;
-  if (c <  'a') return 0;
-  if (c <= 'f') return c - 'a' + 10;
-  return 0;
+hexValue(const int c) {
+	switch (c) {
+		case '0' ... '9': return c - '0';
+		case 'A' ... 'F': return c - 'A' + 10;
+		case 'a' ... 'f': return c - 'a' + 10;
+		default: return 0;
+	}
 }
 
 /* We now set USE_FILE_URIs to 1 in platforms/unix//vm-display-X11/sqUnixXdnd.c
@@ -88,6 +86,7 @@ dropRequestFileName(sqInt dropIndex)	// in st coordinates
 	char *fileURIPrefix = "file:///";
 	int prefixLength = 0;
 	char *dropFileName;
+	char *path;
 
 	if (dropIndex <= 0 || dropIndex > uxDropFileCount)
 		return 0;
@@ -108,7 +107,7 @@ dropRequestFileName(sqInt dropIndex)	// in st coordinates
 		++prefixLength;
 
 	// file:///path & file:/path => /path; anything else answered verbatim
-	char *path = prefixLength == 8 || prefixLength == 6
+	path = prefixLength == 8 || prefixLength == 6
 		? uxDropFileNames[dropIndex - 1] + prefixLength - 1
 		: uxDropFileNames[dropIndex - 1];
 

--- a/platforms/unix/vm-display-X11/sqUnixXdnd.c
+++ b/platforms/unix/vm-display-X11/sqUnixXdnd.c
@@ -184,6 +184,12 @@ xrealloc(void *ptr, size_t size)
 }
 
 
+/* e.g. StandardFileStream>>requestDropStream: doesn't deal with file: URIs.
+ * Neither does unix/plugins/DropPlugin/sqUnixDragDrop.c::dropRequestFileHandle.
+ * Simplest thing is to convert file: URIs to file names at source.
+ */
+#define USE_FILE_URIs 1
+#if !USE_FILE_URIs
 static int
 hexValue(const int c)
 {
@@ -197,12 +203,6 @@ hexValue(const int c)
 }
 
 
-/* e.g. StandardFileStream>>requestDropStream: doesn't deal with file: URIs.
- * Neither does unix/plugins/DropPlugin/sqUnixDragDrop.c::dropRequestFileHandle.
- * Simplest thing is to convert file: URIs to file names at source.
- */
-#define USE_FILE_URIs 1
-#if !USE_FILE_URIs
 static char *
 uri2string(const char *uri)
 {


### PR DESCRIPTION
Resolves https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/666, which describes a problem on Unix systems where dropping a file with spaces or special characters in its path results in a percent-encoded version of the path being returned by `primitiveDropRequestFileName`.

The issue occurs because `dropRequestFileName` skips the `file:///` prefix of the URI but does not perform percent-decoding on the path.