### PR TITLE
configure script option to build without vm-sound-Sun plugin

### DIFF
--- a/platforms/unix/vm-sound-Sun/acinclude.m4
+++ b/platforms/unix/vm-sound-Sun/acinclude.m4
@@ -1,5 +1,11 @@
 # -*- sh -*-
 
+AC_ARG_WITH(vm-sound-Sun,
+  AS_HELP_STRING([--without-vm-sound-Sun],[disable Sun vm sound support (default=enabled)]),
+  [with_vm_sound_Sun="$withval"],
+  [with_vm_sound_Sun="yes"])
+
+if test "$with_vm_sound_Sun" = "yes"; then
 AC_MSG_CHECKING([for SunOS/Solaris audio])
 AC_TRY_COMPILE([#include <sys/audioio.h>],[AUDIO_SUNVTS;],[
   AC_MSG_RESULT(yes)
@@ -13,3 +19,7 @@ AC_TRY_COMPILE([#include <sys/audioio.h>],[AUDIO_SUNVTS;],[
     AC_PLUGIN_DISABLE
   ])
 ])
+else
+	AC_PLUGIN_DISABLE_PLUGIN(vm-sound-Sun);
+fi
+


### PR DESCRIPTION
On Solaris, "configure" checks the header file sys/audioio.h and if it finds it enables support for vm-sound-Sun.

This patch introduces an option for configure (--without-vm-sound-Sun) so that support for vm-sound-Sun can be disabled even when the header file is present.

This change affects all unix platforms as "configure" is used on all unix builds.

I tested the patch by running "gmake configure" in platforms/unix/config and by building in the building/sunos cog-spur and stack-spur building directories (by running the "mvm" script).