### PR TITLE
SunOS:  update mvm scripts

### DIFF
--- a/building/sunos32x86/squeak.cog.spur/build/mvm
+++ b/building/sunos32x86/squeak.cog.spur/build/mvm
@@ -33,6 +33,8 @@ test -f config.h || ../../../../platforms/unix/config/configure --without-npsque
 		--with-vmversion=5.0 \
 		--without-libtls \
 		--disable-dynamicopenssl \
+		--without-vm-sound-Sun \
+		--without-vm-sound-OSS \
 		--with-src=src/spur32.cog \
 		--with-scriptname=spur32 \
 	TARGET_ARCH="-m32" \

--- a/building/sunos32x86/squeak.stack.spur/build/mvm
+++ b/building/sunos32x86/squeak.stack.spur/build/mvm
@@ -32,6 +32,8 @@ test -f config.h || ../../../../platforms/unix/config/configure \
 		--with-vmversion=5.0 \
 		--disable-dynamicopenssl \
 		--without-libtls \
+		--without-vm-sound-Sun \
+		--without-vm-sound-OSS \
 	--with-src=src/spur32.stack --disable-cogit \
 	--without-vm-display-fbdev --without-npsqueak \
 	--with-scriptname=spur32 \

--- a/building/sunos64x64/HowToBuild
+++ b/building/sunos64x64/HowToBuild
@@ -356,11 +356,18 @@ For the Makefiles, pkg:/developer/build/gnu-make  must be installed.
 pkg-config
 ----------
 
-The configure script uses the pkg-config tool for some plugins.
+The configure script uses the pkg.m4 file from the pkg-config or pkgconf tool for some plugins.
 
 Be sure to install it:
 
    pkg install developer/build/pkg-config
+
+or
+
+   pkg install developer/build/pkgconf  (from pkgconf.org)
+
+
+See the README in platforms/unix/config for the required versions of automake, autoconf, libtool and pkg-config.
 
 IPS Package
 -----------

--- a/building/sunos64x64/squeak.cog.spur/build/mvm
+++ b/building/sunos64x64/squeak.cog.spur/build/mvm
@@ -26,6 +26,8 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../../platforms/unix/config/configure --without-npsqueak \
 		--with-vmversion=5.0 \
 		--without-libtls \
+		--without-vm-sound-Sun \
+		--without-vm-sound-OSS \
 		--disable-dynamicopenssl \
 		--with-src=src/spur64.cog \
 		--with-scriptname=spur64 \

--- a/building/sunos64x64/squeak.stack.spur/build/mvm
+++ b/building/sunos64x64/squeak.stack.spur/build/mvm
@@ -22,6 +22,8 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../../platforms/unix/config/configure \
 		--with-vmversion=5.0 \
 		--without-libtls \
+		--without-vm-sound-Sun \
+		--without-vm-sound-OSS \
 		--disable-dynamicopenssl \
 		--with-src=src/spur64.stack --disable-cogit \
 		--without-vm-display-fbdev --without-npsqueak \


### PR DESCRIPTION
Add --without-vm-sound-OSS --without-vm-sound-Sun.
These modules build fine,  but I prefer the vm-sound-pulse plugin