### PR TITLE
Use Ubuntu 22.04 for Linux Builds (x86)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,7 +77,7 @@ jobs:
             heartbeat: threaded
             mode: fast
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
     env:
       ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
The CI jobs were failing due to the scheduled retirement of the Ubuntu 20.04 runner, which was removed on 2025-04-15. For more details, see: https://github.com/actions/runner-images/issues/11101.

The runner image was updated to `ubuntu-22.04`, the closest available release to `ubuntu-20.04`.