### PR TITLE
vm-sound-Sun: replace AC_TRY_COMPILE by AC_COMPILE_IFELSE

### DIFF
--- a/platforms/unix/vm-sound-Sun/acinclude.m4
+++ b/platforms/unix/vm-sound-Sun/acinclude.m4
@@ -1,4 +1,5 @@
 # -*- sh -*-
+# test whether the macro AUDIO_SUNVTS is defined in <sys/audioio.h> or <sun/audioio.h>
 
 AC_ARG_WITH(vm-sound-Sun,
   AS_HELP_STRING([--without-vm-sound-Sun],[disable Sun vm sound support (default=enabled)]),
@@ -7,11 +8,11 @@ AC_ARG_WITH(vm-sound-Sun,
 
 if test "$with_vm_sound_Sun" = "yes"; then
 AC_MSG_CHECKING([for SunOS/Solaris audio])
-AC_TRY_COMPILE([#include <sys/audioio.h>],[AUDIO_SUNVTS;],[
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <sys/audioio.h> int test = AUDIO_SUNVTS;]])],[
   AC_MSG_RESULT(yes)
   AC_DEFINE_UNQUOTED(HAVE_SYS_AUDIOIO_H,1, [SunOS/Solaris audio])
 ],[
-  AC_TRY_COMPILE([#include <sun/audioio.h>],[AUDIO_SUNVTS;],[
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <sun/audioio.h> int test = AUDIO_SUNVTS;]])],[
     AC_MSG_RESULT(yes)
     AC_DEFINE_UNQUOTED(HAVE_SUN_AUDIOIO_H,1, [Sun audioio])
   ],[


### PR DESCRIPTION

this pull request/commit only changes the vm-sound-Sun plugin

autoconf 2.72 claims that AC_TRY_COMPILE is obsolete.

https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/autoconf.html#index-AC_005fTRY_005fCOMPILE

In section: _18.4 Obsolete Macros
Several macros are obsoleted in Autoconf, for various reasons (typically they failed to quote properly, couldn’t be extended for more recent issues, etc.). They are still supported, but deprecated: their use should be avoided._

apparently AC_TRY_COMPILE is still accepted and it seems autoconf 2.72 only prints a warning

however, it may be a good idea to move to AC_COMPILE_IFELSE

this commit replaces the old AC_TRY_COMPILE which I think comes from old code from original Squeak developers by a more recent variation which is intented to do the same thing
