### PR TITLE
vm-sound-Sun: simplify acinclude.m4 by using AC_CHECK_HEADERS

### DIFF
--- a/platforms/unix/vm-sound-Sun/acinclude.m4
+++ b/platforms/unix/vm-sound-Sun/acinclude.m4
@@ -1,4 +1,6 @@
 # -*- sh -*-
+# test header file <sys/audioio.h> and enable vm-sound-Sun, unless --without-vm-sound-Sun 
+# support for HAVE_SUN_AUDIOIO_H dropped (originally the plugin supported <sun/audioio.h> and <sys/audioio.h>
 
 AC_ARG_WITH(vm-sound-Sun,
   AS_HELP_STRING([--without-vm-sound-Sun],[disable Sun vm sound support (default=enabled)]),
@@ -6,20 +8,9 @@ AC_ARG_WITH(vm-sound-Sun,
   [with_vm_sound_Sun="yes"])
 
 if test "$with_vm_sound_Sun" = "yes"; then
-AC_MSG_CHECKING([for SunOS/Solaris audio])
-AC_TRY_COMPILE([#include <sys/audioio.h>],[AUDIO_SUNVTS;],[
-  AC_MSG_RESULT(yes)
-  AC_DEFINE_UNQUOTED(HAVE_SYS_AUDIOIO_H,1, [SunOS/Solaris audio])
-],[
-  AC_TRY_COMPILE([#include <sun/audioio.h>],[AUDIO_SUNVTS;],[
-    AC_MSG_RESULT(yes)
-    AC_DEFINE_UNQUOTED(HAVE_SUN_AUDIOIO_H,1, [Sun audioio])
-  ],[
-    AC_MSG_RESULT(no)
-    AC_PLUGIN_DISABLE
-  ])
-])
+  AC_MSG_CHECKING([for SunOS/Solaris audio])
+  AC_CHECK_HEADERS([sys/audioio.h],[],[AC_PLUGIN_DISABLE])
 else
-	AC_PLUGIN_DISABLE_PLUGIN(vm-sound-Sun);
+  AC_PLUGIN_DISABLE_PLUGIN(vm-sound-Sun);
 fi
 

--- a/platforms/unix/vm-sound-Sun/sqUnixSoundSun.c
+++ b/platforms/unix/vm-sound-Sun/sqUnixSoundSun.c
@@ -40,10 +40,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+/* support for HAVE_SUN_AUDIOIO_H <sun/audioio.h> dropped, only support <sys/audioio.h> */
 #ifdef HAVE_SYS_AUDIOIO_H
 # include <sys/audioio.h>
-#else
-# include <sun/audioio.h>
 #endif
 #include <errno.h>
 


### PR DESCRIPTION

Fix for the warning that AC_TRY_COMPILE is obsolete in autoconf 2.72  (when running gmake configure in platforms/unix/config).

Drop the HAVE_SUN_AUDIOIO_H define (do not try to include <sun/audioio.h>)
Solaris systems have <sys/audioio.h>

Replace AC_TRY_COMPILE by AC_CHECK_HEADERS in acinclude.m4

This is similar as in the ALSA and OSS sound plugins, and it avoids the use of AC_COMPILE_IFELSE   (compare to the acinclude.m4 in the other sound plugin directories).
