### PR TITLE
OBSD does not supply librt

### DIFF
--- a/building/linux64ARMv8/squeak.cog.spur/build.assert/mvm
+++ b/building/linux64ARMv8/squeak.cog.spur/build.assert/mvm
@@ -6,10 +6,16 @@ INSTALLDIR=assert/sqcogspur64ARMv8linuxht
 MACHINE="-march=armv8-a -mtune=cortex-a72"
 OPT="-g3 -O1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DDEBUGVM=0"
 
+# librt and libpthread funs now supplied by libc
+# Many Linux systems supply empty library files 
+# but OpenBSD does not.
+
 if [ `uname` = "OpenBSD" ]; then
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
+    LIBRT=""
 else
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=1"
+    LIBRT="-lrt"
 fi
 
 # Prefer clang over gcc, but use gcc if clang isn't available...
@@ -33,7 +39,7 @@ test -f config.h || ../../../../platforms/unix/config/configure \
 	--with-scriptname=spur64 \
 	CC=$CC \
 	CFLAGS="$MACHINE $OPT -DCOGMTVM=0 $DUALMAP" \
-	LIBS="-lrt"
+	LIBS=$LIBRT
 
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../../products/$INSTALLDIR

--- a/building/linux64ARMv8/squeak.cog.spur/build.debug/mvm
+++ b/building/linux64ARMv8/squeak.cog.spur/build.debug/mvm
@@ -6,10 +6,15 @@ INSTALLDIR=debug/sqcogspur64ARMv8linuxht
 MACHINE="-march=armv8-a -mtune=cortex-a72"
 OPT="-g3 -O0 -DDEBUGVM=1 -DAIO_DEBUG=1"
 
+# librt and libpthread funs now supplied by libc
+# Many Linux systems supply empty library files 
+# but OpenBSD does not.
 if [ `uname` = "OpenBSD" ]; then
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
+    LIBRT=""
 else
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=1"
+    LIBRT="-lrt"
 fi
 
 # Prefer clang over gcc, but use gcc if clang isn't available...
@@ -32,9 +37,9 @@ test -f config.h || ../../../../platforms/unix/config/configure \
 	--with-vmversion=5.0 --with-src=src/spur64.cog \
 	--without-vm-display-fbdev --without-npsqueak \
 	--with-scriptname=spur64 \
-	cc=$CC \
+	CC=$CC \
 	CFLAGS="$MACHINE $OPT -DCOGMTVM=0 $DUALMAP" \
-	LIBS="-lrt"
+	LIBS=$LIBRT
 
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../../products/$INSTALLDIR

--- a/building/linux64ARMv8/squeak.cog.spur/build/mvm
+++ b/building/linux64ARMv8/squeak.cog.spur/build/mvm
@@ -14,13 +14,19 @@ CC=gcc
 # but compiles, then segfaults with clang.
 # OpenBSD has problems with either, so no fast bitblt there.
 
+# librt and libpthread funs now supplied by libc
+# Many Linux systems supply empty library files 
+# but OpenBSD does not.
+
 if [ `uname` = "OpenBSD" ]; then
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
+    LIBRT=""
     FASTBITBLT=""
 # Prefer clang over gcc, but use gcc if clang isn't available...
     if [ -x /usr/bin/clang ]; then CC=clang; fi
 else
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=1"
+    LIBRT="-lrt"
 # Linux fast bitblt requires gcc
     FASTBITBLT=" --enable-fast-bitblt "
 fi
@@ -44,7 +50,7 @@ test -f config.h || ../../../../platforms/unix/config/configure \
 	$FASTBITBLT \
 	CC=$CC \
 	CFLAGS="$MACHINE $OPT -DCOGMTVM=0 $DUALMAP" \
-	LIBS="-lrt"
+	LIBS=$LIBRT
 ##	--without-vm-display-fbdev --without-npsqueak \
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../../products/$INSTALLDIR

--- a/building/linux64x64/squeak.cog.spur/build.assert/mvm
+++ b/building/linux64x64/squeak.cog.spur/build.assert/mvm
@@ -8,6 +8,18 @@ OPT="-g3 -O1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DDEBUGVM=0"
 CC=gcc
 if [ -x /usr/bin/clang ]; then CC=clang; fi
 
+# librt and libpthread funs now supplied by libc
+# Many Linux systems supply empty library files 
+# but OpenBSD does not.
+
+if [ `uname` = "OpenBSD" ]; then
+    DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
+    LIBRT=""
+else
+    DUALMAP="-DDUAL_MAPPED_CODE_ZONE=1"
+    LIBRT="-lrt"
+fi
+
 if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
@@ -26,7 +38,9 @@ test -f config.h || ../../../../platforms/unix/config/configure --without-npsque
 		--with-scriptname=spur64 \
 	TARGET_ARCH="-m64" \
 	CC=$CC \
-	CFLAGS="$OPT -msse2 -DCOGMTVM=0"
+	CFLAGS="$OPT -msse2 -DCOGMTVM=0 $DUALMAP"
+	LIBS=$LIBRT
+
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../../products/$INSTALLDIR`

--- a/building/linux64x64/squeak.cog.spur/build.debug/mvm
+++ b/building/linux64x64/squeak.cog.spur/build.debug/mvm
@@ -12,6 +12,18 @@ if [ $# -ge 1 ]; then
 	INSTALLDIR="$1"; shift
 fi
 
+# librt and libpthread funs now supplied by libc
+# Many Linux systems supply empty library files 
+# but OpenBSD does not.
+
+if [ `uname` = "OpenBSD" ]; then
+    DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
+    LIBRT=""
+else
+    DUALMAP="-DDUAL_MAPPED_CODE_ZONE=1"
+    LIBRT="-lrt"
+fi
+
 if ../../../../scripts/checkSCCSversion ; then exit 1; fi
 echo -n "clean? "
 read a
@@ -26,7 +38,9 @@ test -f config.h || ../../../../platforms/unix/config/configure --without-npsque
 		--with-scriptname=spur64 \
 	TARGET_ARCH="-m64" \
 	CC=$CC \
-	CFLAGS="$OPT -msse2 -DCOGMTVM=0"
+	CFLAGS="$OPT -msse2 -DCOGMTVM=0 $DUALMAP" \
+	LIBS=$LIBRT
+
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../../products/$INSTALLDIR
 # prefer make install prefix=`readlink -f \`pwd\`/../../../../products/$INSTALLDIR`

--- a/building/linux64x64/squeak.cog.spur/build/mvm
+++ b/building/linux64x64/squeak.cog.spur/build/mvm
@@ -5,15 +5,20 @@ INSTALLDIR=sqcogspur64linuxht
 # Some gcc versions create a broken VM using -O2
 OPT="-g -O2 -DNDEBUG -DDEBUGVM=0"
 
+# librt and libpthread funs now supplied by libc
+# Many Linux systems supply empty library files 
+# but OpenBSD does not.
 
 if [ `uname` = "OpenBSD" ]; then
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
+    LIBRT=""
 else
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=1"
+    LIBRT="-lrt"
 fi
 
-CFLAGS="$OPT -msse2 -DCOGMTVM=0"
-LIBS=""
+CFLAGS="$OPT -msse2 -DCOGMTVM=0 $DUALMAP"
+LIBS=$LIBRT
 LDFLAGS=""
 case $(uname -s) in
   OpenBSD)

--- a/platforms/unix/plugins/SqueakSSL/sqOBSDOpenSSL.inc
+++ b/platforms/unix/plugins/SqueakSSL/sqOBSDOpenSSL.inc
@@ -292,6 +292,9 @@ sqInt sqCreateSSL(void) {
 	sqInt handle = 0;
 	sqSSL *ssl = NULL;
 
+	ssl = calloc(1, sizeof(sqSSL));
+	/*@@KenD@@*/
+	ssl->loglevel = 1;
 	if (!wasInitialized) {
 		if(SSL_library_init() < 0) {
 		  if(ssl->loglevel)
@@ -301,7 +304,6 @@ sqInt sqCreateSSL(void) {
 		wasInitialized = true;
 	}
 
-	ssl = calloc(1, sizeof(sqSSL));
 	ssl->bioRead  = BIO_new(BIO_s_mem());
 	ssl->bioWrite = BIO_new(BIO_s_mem());
 	BIO_set_close(ssl->bioRead,  BIO_CLOSE);


### PR DESCRIPTION
Not long ago, "librt" functions moved into "libc".  Most Linux distros supply empty "librt" library for back compatibility.
OpenBSD does not supply "librt" and this chokes the build on OBSD when "-lrt" asked of the linker.
