### PR TITLE
[ci] add extra monthly builds for older linux/glibc versions

### DIFF
--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -1,0 +1,111 @@
+name: Extra Monthly Builds (Linux Classic)
+# For older glibc version
+# See: https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/742
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Build on the 1st of every month at midnight
+  workflow_dispatch:
+    inputs:
+      should-deploy:
+        description: 'Deploy on success'
+        required: true
+        default: "true" # No boolean support at the moment
+
+# !! NOTICE !!
+# This workflow spec is basically a copy of linux.yml. It includes
+# aspects of extra.yml for the manual workflow dispatch. Please update
+# this file according to its original files.
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+        arch:
+          - linux64x64
+          - linux32x86
+        flavor:
+          - squeak.cog.spur
+        heartbeat:
+          - threaded
+          - itimer
+        mode:
+          - fast
+          #- debug
+          #- assert
+        #include:
+        #  # sista build not fully prepared for linux64x64, so only choose selected configurations for linux32x86
+        #  - arch: linux32x86
+        #    flavor: squeak.sista.spur
+        #    heartbeat: threaded
+        #    mode: fast
+        #  # squeak.stack.spur builds are not prepared for itimer
+        #  - arch: linux64x64
+        #    flavor: squeak.stack.spur
+        #    heartbeat: threaded
+        #    mode: fast
+        #  - arch: linux32x86
+        #    flavor: squeak.stack.spur
+        #    heartbeat: threaded
+        #    mode: fast
+
+    runs-on: ubuntu-22.04
+    container:
+      image: ${{ matrix.os }}
+    name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}/${{ matrix.os }} ${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      FLAVOR: ${{ matrix.flavor }}
+      MODE: ${{ matrix.mode }}
+    steps:
+      - name: Checkout files
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v3
+
+      - name: Checkout files for new release candidate
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v3
+        with:
+          ref: refs/tags/${{ github.event.inputs.tag }}
+
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: .thirdparty-cache
+          key: thirdparty-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.flavor }}
+
+      - name: Prepare environment
+        run: ./scripts/ci/actions_prepare_linux_x86.sh
+
+      - name: Build VM
+        run: ./scripts/ci/actions_build.sh
+        env:
+          HEARTBEAT: ${{ matrix.heartbeat }}
+
+      - name: Sign VM (not implemented)
+        if: false
+        run: ./deploy/sign-vm.sh
+
+      - name: Pack VM
+        run: ./deploy/pack-vm.sh
+
+      - name: Store artifact w/ revision
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_NAME }}_${{ env.ASSET_REVISION }}
+          path: ${{ env.PRODUCTS_PATH }}/${{ env.ASSET_NAME }}.${{ env.ASSET_EXTENSION }}
+
+      - name: Update artifact in latest-build
+        uses: ncipollo/release-action@v1
+        if: github.event_name == 'schedule' || (github.event.inputs.should-deploy == 'true' && endsWith( github.ref , 'Cog' ))
+        with:
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: ${{ env.PRODUCTS_PATH }}/${{ env.ASSET_NAME }}.${{ env.ASSET_EXTENSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ matrix.mode == 'debug' && 'latest-debug-build' || matrix.mode == 'assert' && 'latest-assert-build' || 'latest-build' }}
+          body: ${{ github.event.head_commit.message }}

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu:20.04
         arch:
           - linux64x64
           - linux32x86

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -63,6 +63,7 @@ jobs:
       ARCH: ${{ matrix.arch }}
       FLAVOR: ${{ matrix.flavor }}
       MODE: ${{ matrix.mode }}
+      DEBIAN_FRONTEND: noninteractive  # for container
     steps:
       - name: Checkout files
         if: github.event_name != 'workflow_dispatch'
@@ -81,7 +82,7 @@ jobs:
           key: thirdparty-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.flavor }}
 
       - name: Install sudo
-        run: apt-get update && apt-get install -y sudo
+        run: apt-get update -y && apt-get install -y sudo
 
       - name: Prepare environment
         run: ./scripts/ci/actions_prepare_linux_x86.sh

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -80,6 +80,9 @@ jobs:
           path: .thirdparty-cache
           key: thirdparty-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.flavor }}
 
+      - name: Install sudo
+        run: apt-get update && apt-get install -y sudo
+
       - name: Prepare environment
         run: ./scripts/ci/actions_prepare_linux_x86.sh
 

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -62,6 +62,7 @@ jobs:
     name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}/${{ matrix.os.name }} ${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
     env:
       ARCH: ${{ matrix.arch }}
+      ARCH_DETAILS: ${{ matrix.os.name }}
       FLAVOR: ${{ matrix.flavor }}
       MODE: ${{ matrix.mode }}
       DEBIAN_FRONTEND: noninteractive  # for container

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -3,6 +3,9 @@ name: Extra Monthly Builds (Linux Classic)
 # See: https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/742
 
 on:
+  push:
+    paths:
+      - '.github/workflows/extra-linux-classic.yml'
   schedule:
     - cron: '0 0 1 * *' # Build on the 1st of every month at midnight
   workflow_dispatch:

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -76,6 +76,9 @@ jobs:
         with:
           ref: refs/tags/${{ github.event.inputs.tag }}
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Restore build cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -81,9 +81,6 @@ jobs:
           path: .thirdparty-cache
           key: thirdparty-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.flavor }}
 
-      - name: Install sudo
-        run: apt-get update -y && apt-get install -y sudo
-
       - name: Prepare environment
         run: ./scripts/ci/actions_prepare_linux_x86.sh
 

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -26,7 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu:20.04
+          - name: ubuntu-20.04
+            docker: buildpack-deps:22.04-scm
         arch:
           - linux64x64
           - linux32x86
@@ -57,8 +58,8 @@ jobs:
 
     runs-on: ubuntu-22.04
     container:
-      image: ${{ matrix.os }}
-    name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}/${{ matrix.os }} ${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
+      image: ${{ matrix.os.docker }}
+    name: ${{ matrix.flavor }}${{ matrix.heartbeat == 'itimer' && ' (itimer)' || '' }} for ${{ matrix.arch }}/${{ matrix.os.name }} ${{ matrix.mode == 'debug' && ' (DEBUG)' || matrix.mode == 'assert' && ' (ASSERT)' || '' }}
     env:
       ARCH: ${{ matrix.arch }}
       FLAVOR: ${{ matrix.flavor }}
@@ -79,7 +80,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .thirdparty-cache
-          key: thirdparty-cache-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.flavor }}
+          key: thirdparty-cache-${{ matrix.os.name }}-${{ matrix.arch }}-${{ matrix.flavor }}
 
       - name: Prepare environment
         run: ./scripts/ci/actions_prepare_linux_x86.sh

--- a/.github/workflows/extra-linux-classic.yml
+++ b/.github/workflows/extra-linux-classic.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - name: ubuntu-20.04
-            docker: buildpack-deps:22.04-scm
+            docker: buildpack-deps:20.04-scm
         arch:
           - linux64x64
           - linux32x86

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Prepare Linux build environment
         if: startsWith(matrix.arch.name, 'linux')
-        run: ./scripts/ci/actions_prepare_linux_x86.sh
+        run: sudo ./scripts/ci/actions_prepare_linux_x86.sh
 
       - name: Prepare MSYS2/Windows build environment
         if: startsWith(matrix.arch.name, 'win')

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -83,7 +83,7 @@ jobs:
           key: thirdparty-cache-${{ matrix.arch }}-${{ matrix.flavor }}
 
       - name: Prepare environment
-        run: ./scripts/ci/actions_prepare_linux_arm.sh
+        run: sudo ./scripts/ci/actions_prepare_linux_arm.sh
 
       - name: Build VM
         run: ./scripts/ci/actions_build.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
           key: thirdparty-cache-${{ matrix.arch }}-${{ matrix.flavor }}
 
       - name: Prepare environment
-        run: ./scripts/ci/actions_prepare_linux_x86.sh
+        run: sudo ./scripts/ci/actions_prepare_linux_x86.sh
 
       - name: Build VM
         run: ./scripts/ci/actions_build.sh

--- a/scripts/ci/actions_build.sh
+++ b/scripts/ci/actions_build.sh
@@ -9,6 +9,7 @@ set -e
 #
 # This script uses/requires to following variables:
 # - ARCH (e.g., "macos64x64")
+# - ARCH_DETAILS (optional - e.g., "ubuntu-20.04")
 # - ARCH_ARM (only set for ARM builds in docker container)
 # - FLAVOR (e.g., "squeak.cog.spur")
 # - RUNNER_OS (i.e., "Linux", "macOS", "Windows")
@@ -30,6 +31,9 @@ echo "$(cat platforms/Cross/plugins/sqPluginsSCCSVersion.h | .git_filters/RevDat
 readonly ASSET_REVISION=$(grep -m1 "SvnRawRevisionString" "platforms/Cross/vm/sqSCCSVersion.h" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 
 ASSET_NAME="${FLAVOR}_${ARCH}"
+if [[ ! -z "${ARCH_DETAILS}" ]]; then
+    ASSET_NAME="${ASSET_NAME}_${ARCH_DETAILS}"
+fi
 BUILD_PATH="$(pwd)/building/${ARCH}/${FLAVOR}"
 
 PRODUCTS_PATH="$(pwd)/products"
@@ -39,7 +43,7 @@ check_buildPath() {
     if [[ ! -d "${BUILD_PATH}" ]]; then
         echo "Build path does not exist: ${BUILD_PATH}"
         exit 11
-    fi 
+    fi
 }
 
 skip_BochsPlugins() {

--- a/scripts/ci/actions_prepare_linux_arm.sh
+++ b/scripts/ci/actions_prepare_linux_arm.sh
@@ -10,8 +10,8 @@ set -e
 # Note that "libtool automake autoconf libltdl-dev" are required to
 # let the configure script pass.
 
-sudo apt-get update -y
-sudo apt-get install -yq --no-install-suggests --no-install-recommends   build-essential git devscripts   uuid-dev libcairo2-dev libpango1.0-dev libgl1-mesa-dev libgl1 libglx-mesa0 libssl-dev libevdev-dev m4 libpulse-dev   libasound2-dev libfreetype6-dev libx11-dev libxrender-dev libxrandr-dev  libtool automake autoconf libltdl-dev
+apt-get update -y
+apt-get install -yq --no-install-suggests --no-install-recommends   build-essential git devscripts   uuid-dev libcairo2-dev libpango1.0-dev libgl1-mesa-dev libgl1 libglx-mesa0 libssl-dev libevdev-dev m4 libpulse-dev   libasound2-dev libfreetype6-dev libx11-dev libxrender-dev libxrandr-dev  libtool automake autoconf libltdl-dev
 
 
 

--- a/scripts/ci/actions_prepare_linux_x86.sh
+++ b/scripts/ci/actions_prepare_linux_x86.sh
@@ -24,6 +24,7 @@ DEV_PKGS=(
     uuid-dev
     libglu1-mesa-dev
     libpcre2-8-0
+    libltdl-dev
 )
 
 # Per default, let apt decide

--- a/scripts/ci/actions_prepare_linux_x86.sh
+++ b/scripts/ci/actions_prepare_linux_x86.sh
@@ -29,6 +29,9 @@ DEV_PKGS=(
 # Per default, let apt decide
 ARCHCODE=""
 if [[ "${ARCH}" = "linux32x86" ]]; then
+    sudo apt-get update -y
+    sudo apt-get install -y software-properties-common  # for add-apt-repository
+
     sudo dpkg --add-architecture i386
     sudo add-apt-repository ppa:ondrej/php
     ARCHCODE=":i386"

--- a/scripts/ci/actions_prepare_linux_x86.sh
+++ b/scripts/ci/actions_prepare_linux_x86.sh
@@ -29,16 +29,16 @@ DEV_PKGS=(
 # Per default, let apt decide
 ARCHCODE=""
 if [[ "${ARCH}" = "linux32x86" ]]; then
-    sudo apt-get update -y
-    sudo apt-get install -y software-properties-common  # for add-apt-repository
+    apt-get update -y
+    apt-get install -y software-properties-common  # for add-apt-repository
 
-    sudo dpkg --add-architecture i386
-    sudo add-apt-repository ppa:ondrej/php
+    dpkg --add-architecture i386
+    add-apt-repository ppa:ondrej/php
     ARCHCODE=":i386"
 fi
 
-sudo apt-get update -y
-sudo apt-get install -yq --no-install-suggests --no-install-recommends --allow-unauthenticated \
+apt-get update -y
+apt-get install -yq --no-install-suggests --no-install-recommends --allow-unauthenticated \
      debhelper \
      devscripts \
      gcc-multilib \


### PR DESCRIPTION
Closes #742

Also includes minor revisions for linux prepare scripts:

- extract `sudo` from prepare scripts because docker does not need it (and specifying env vars like `DEBIAN_FRONTEND` from the outside is not possible if the script uses `sudo` without `-E`)
- add missing dev package `libltdl-dev` (seems to be preinstalled in GitHub runner but not a stock build-essentials Ubuntu image)
- ensure `add-apt-repository` is installed before using it for linux32x68 builds

**When merging, please consider doing a squash merge to keep the ancestry clean.**