### PR TITLE
Add PseudoTTYPlugin to Linux and Solaris builds. Tested on Linux 64x6…

### DIFF
--- a/building/linux32/squeak.stack.spur/plugins.ext
+++ b/building/linux32/squeak.stack.spur/plugins.ext
@@ -16,4 +16,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin 
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32ARMv6/squeak.cog.spur/plugins.ext
+++ b/building/linux32ARMv6/squeak.cog.spur/plugins.ext
@@ -17,4 +17,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32ARMv6/squeak.cog.v3/plugins.ext
+++ b/building/linux32ARMv6/squeak.cog.v3/plugins.ext
@@ -17,4 +17,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32ARMv6/squeak.stack.spur/plugins.ext
+++ b/building/linux32ARMv6/squeak.stack.spur/plugins.ext
@@ -15,4 +15,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32ARMv6/squeak.stack.v3/plugins.ext
+++ b/building/linux32ARMv6/squeak.stack.v3/plugins.ext
@@ -15,4 +15,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32x86/squeak.cog.spur/plugins.ext
+++ b/building/linux32x86/squeak.cog.spur/plugins.ext
@@ -20,4 +20,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32x86/squeak.cog.v3/plugins.ext
+++ b/building/linux32x86/squeak.cog.v3/plugins.ext
@@ -16,4 +16,5 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \

--- a/building/linux32x86/squeak.sista.spur/plugins.ext
+++ b/building/linux32x86/squeak.sista.spur/plugins.ext
@@ -16,4 +16,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32x86/squeak.stack.spur/plugins.ext
+++ b/building/linux32x86/squeak.stack.spur/plugins.ext
@@ -17,3 +17,5 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux32x86/squeak.stack.v3/plugins.ext
+++ b/building/linux32x86/squeak.stack.v3/plugins.ext
@@ -16,4 +16,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux64/squeak.stack.spur/plugins.ext
+++ b/building/linux64/squeak.stack.spur/plugins.ext
@@ -16,4 +16,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux64ARMv8/squeak.cog.spur/plugins.ext
+++ b/building/linux64ARMv8/squeak.cog.spur/plugins.ext
@@ -19,6 +19,8 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
 ## CameraPlugin  -- fails on OpenBSD
 # GdbARMPlugin # fails to compile
 # GdbARMv8Plugin # ditto
+

--- a/building/linux64ARMv8/squeak.cogmt.spur/plugins.ext
+++ b/building/linux64ARMv8/squeak.cogmt.spur/plugins.ext
@@ -20,5 +20,7 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
 # GdbARMPlugin # fails to compile
 # GdbARMv8Plugin # ditto
+

--- a/building/linux64ARMv8/squeak.stack.spur/plugins.ext
+++ b/building/linux64ARMv8/squeak.stack.spur/plugins.ext
@@ -16,5 +16,7 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin 
+VectorEnginePlugin \
+PseudoTTYPlugin \
 ## CameraPlugin \ -- fails on OpenBSD
+

--- a/building/linux64x64/squeak.cog.spur/plugins.ext
+++ b/building/linux64x64/squeak.cog.spur/plugins.ext
@@ -1,11 +1,13 @@
 # Copied, perhaps edited, from ../../../src/examplePlugins.ext
 EXTERNAL_PLUGINS = \
+MIDIPlugin \
 B3DAcceleratorPlugin \
+ClipboardExtendedPlugin \
 BochsIA32Plugin \
 BochsX64Plugin \
-ClipboardExtendedPlugin \
+GdbARMPlugin \
+GdbARMv8Plugin \
 FileAttributesPlugin \
-MIDIPlugin \
 Squeak3D \
 SqueakFFIPrims \
 SqueakSSL \
@@ -19,6 +21,7 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
-## CameraPlugin   OpenBSD fails to build this..
-# GdbARMPlugin # fails to compile
-# GdbARMv8Plugin # ditto
+HelloWorldPlugin \
+HelloExternalWorldPlugin \
+PseudoTTYPlugin \
+

--- a/building/linux64x64/squeak.sista.spur/plugins.ext
+++ b/building/linux64x64/squeak.sista.spur/plugins.ext
@@ -20,4 +20,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/linux64x64/squeak.stack.spur/plugins.ext
+++ b/building/linux64x64/squeak.stack.spur/plugins.ext
@@ -16,4 +16,6 @@ XDisplayControlPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \
-VectorEnginePlugin
+VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/sunos32x86/squeak.cog.spur/plugins.ext
+++ b/building/sunos32x86/squeak.cog.spur/plugins.ext
@@ -19,3 +19,5 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/sunos32x86/squeak.stack.spur/plugins.ext
+++ b/building/sunos32x86/squeak.stack.spur/plugins.ext
@@ -16,3 +16,5 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/sunos64x64/squeak.cog.spur/plugins.ext
+++ b/building/sunos64x64/squeak.cog.spur/plugins.ext
@@ -19,3 +19,5 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
+

--- a/building/sunos64x64/squeak.stack.spur/plugins.ext
+++ b/building/sunos64x64/squeak.stack.spur/plugins.ext
@@ -16,3 +16,5 @@ DESPlugin \
 MD5Plugin \
 SHA2Plugin \
 VectorEnginePlugin \
+PseudoTTYPlugin \
+


### PR DESCRIPTION
Tested on Linux 64x64 so far but this plugin can reasonably be expected to work on any Unix platform. To test, load Telnet301 from www.squeaksource.com/IanPiumartaGoodies repository, then evaluate "TeletypeWindow open" to start a terminal emulator and use its window menu to select "new shell session ..." to start a pty connected terminal session. Try running the Linux "top" command for example.