### PR TITLE
Fix sqWin32Backtrace pointer alignment

### DIFF
--- a/platforms/win32/vm/sqWin32Backtrace.c
+++ b/platforms/win32/vm/sqWin32Backtrace.c
@@ -128,7 +128,7 @@ backtrace_from_fp(void *startfp, void **retpcs, int nrpcs)
 	if (!validfp(fp,fp - 1)
 	 || !validfp(fp->savedfp,fp)) {
 		int attempts = 4;
-		fp = (Frame *)(((usqInt)fp | sizeof(void)-1) - (sizeof(void)-1));
+		fp = (Frame *)(((usqInt)fp | sizeof(void *)-1) - (sizeof(void *)-1));
 		while (--attempts >= 0) {
 			fp = (Frame *)((usqInt)fp + sizeof(void *));
 			if (validfp(fp,startfp)


### PR DESCRIPTION
The compiler barks:

>opensmalltalk-vm\platforms\win32\vm\sqWin32Backtrace.c(131,32): warning C4034: sizeof return 0

Indeed, we'd better keep our ears open to the compiler sounds.

If the intention to align fp on pointer length (that is zero out 2 lowest bits on x86 or 3 bits on x64), then we shall use `sizeof(void *)` rather than `sizeof(void)`