### PR TITLE
Support for OpenBSD

### DIFF
--- a/building/linux64ARMv8/squeak.cog.spur/build/mvm
+++ b/building/linux64ARMv8/squeak.cog.spur/build/mvm
@@ -9,6 +9,10 @@ OPT="-g -O2 -DNDEBUG -DDEBUGVM=0 -D_GNU_SOURCE -DUSEEVDEV"
 ##OPT="-g -O3  -DMUSL -DNDEBUG -DDEBUGVM=0"
 
 if [ `uname` = "OpenBSD" ]; then
+    OPT="$OPT -DMUSL"
+    CFLAGS="$CFLAGS $OPT -I/usr/local/include"
+    LIBS="$LIBS -lexecinfo"
+    LDFLAGS="$LDFLAGS -L/usr/local/lib"
     DUALMAP="-DDUAL_MAPPED_CODE_ZONE=0"
 # librt and libpthread functions now supplied by libc.
 # Many Linux systems supply empty library files but

--- a/building/linux64x64/squeak.cog.spur/build/mvm
+++ b/building/linux64x64/squeak.cog.spur/build/mvm
@@ -13,15 +13,16 @@ if [ -n "$(command -v clang || true)" ]; then CC=clang; else CC=gcc; fi
 # but OpenBSD does not.
 if [ `uname` = "OpenBSD" ]; then LIBRT=""; else LIBRT="-lrt"; fi
 
-CFLAGS="$OPT -msse2 -DCOGMTVM=0"
-LIBS=$LIBRT
-LDFLAGS=""
-
 # Special treatment for OpenBSD Linux
 if [ `uname` = "OpenBSD" ]; then
-	CFLAGS="$CFLAGS -I/usr/local/include"
+	OPT="$OPT -DMUSL"
+	CFLAGS="$CFLAGS $OPT -I/usr/local/include"
 	LIBS="$LIBS -lexecinfo"
 	LDFLAGS="$LDFLAGS -L/usr/local/lib"
+else
+	CFLAGS="$CFLAGS $OPT -msse2 -DCOGMTVM=0"
+	LIBS="$LIBS -lrt"
+	LDFLAGS="$LDFLAGS"
 fi
 
 if [ $# -ge 1 ]; then

--- a/platforms/unix/vm/sqUnixMemory.c
+++ b/platforms/unix/vm/sqUnixMemory.c
@@ -87,7 +87,11 @@ int mmapErrno = 0;
 #endif
 
 #define MAP_PROT	(PROT_READ | PROT_WRITE)
+#ifdef __OpenBSD__
+#define MAP_FLAGS	(MAP_ANON | MAP_PRIVATE | MAP_STACK)
+#else
 #define MAP_FLAGS	(MAP_ANON | MAP_PRIVATE)
+#endif
 
 extern int useMmap;
 /* Since Cog needs to make memory executable via mprotect, and since mprotect


### PR DESCRIPTION
OpenBSD 7.8

Built & tested squeak.cog.spur/build/mvm on both x86_64 and Aarch64 on OpenBSD.
Also built & tested Aarch64 on Linux [Raspian,RasPi5].

