### PR TITLE
Add support for publishing multiple clipboard format on unix/x11

### DIFF
--- a/platforms/unix/plugins/ClipboardExtendedPlugin/sqUnixExtendedClipboard.c
+++ b/platforms/unix/plugins/ClipboardExtendedPlugin/sqUnixExtendedClipboard.c
@@ -41,7 +41,9 @@ char **clipboardGetTypeNames();
 sqInt clipboardSizeWithType(char *typeName, int ntypeName);
 sqInt clipboardReadIntoAt(sqInt count, sqInt byteArrayIndex, sqInt startIndex);
 void *firstIndexableField(sqInt oop);
-void clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t ntypeName, int isDnd, int isClaiming);
+sqInt clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t ntypeName, int isDnd, int isClaiming);
+
+int formatCounter = 0;
 
 // TODO: clipboardGetTypeNames() should be cached. And the simplest way to do
 // this is to have display_clipboardGetTypeNames do the cacheing and freeing,
@@ -57,11 +59,10 @@ sqCreateClipboard(void) { return (void *)0xB0A4D; }
 void
 sqPasteboardClear(void *inPasteboard)
 {
-// perhaps PrimErrUnsupported is better, but it's inaccurate
-// we don't yet have PrimErrUnimplemented
-
-	// i.e. this still has to be implemented
-	interpreterProxy->primitiveFailFor(PrimErrOperationFailed);
+	int success = clipboardWriteWithType(NULL, 0, "", 0, 0, 0);
+	formatCounter = 0;
+	if (!success)
+		interpreterProxy->primitiveFailFor(PrimErrOperationFailed);
 }
 
 /* Return a number of types.
@@ -112,7 +113,8 @@ sqPasteboardCopyItemFlavorsitemNumber(void *inPasteboard, sqInt formatNumber)
 void
 sqPasteboardPutItemFlavordatalengthformatTypeformatLength(void *inPasteboard, char *data, sqInt ndata, char *typeName, sqInt ntypeName)
 {
-	clipboardWriteWithType(data, ndata, typeName, ntypeName, 0, 1);
+	if (!clipboardWriteWithType(data, ndata, typeName, ntypeName, 0, !formatCounter++))
+		interpreterProxy->primitiveFailFor(PrimErrOperationFailed);
 }
 
 

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -1277,7 +1277,7 @@ static Atom stringToAtom(char *target, size_t size)
 static sqInt
 display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t nTypeName, int isDnd, int isClaiming)
 {
-  sqInt success = 1;
+  sqInt success= 1;
 
   if (data == NULL) {
     // clear
@@ -1350,19 +1350,22 @@ display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t 
       }
       
       if (Success == xError) {
-        success = addOffer(xaCompoundText, (char *)textProperty.value, textProperty.nitems);
+        success= addOffer(xaCompoundText, (char *)textProperty.value, textProperty.nitems);
         XFree((void *)textProperty.value);
       } else {
-        success = 0;
+        success= 0;
       }
       
       free(buf);
     }
+	else {
+	  success= 0;
+	}
   }
   else {
     /* Typed format: add single offer */
     type= stringToAtom(typeName, nTypeName);
-    if (!(success = addOffer(type, data, ndata))) {
+    if (!(success= addOffer(type, data, ndata))) {
       fprintf(stderr, "display_clipboardWriteWithType: failed to add offer for type %s\n", typeName);
     }
   }
@@ -2644,7 +2647,10 @@ display_clipboardSizeWithType(char *typeName, int nTypeName)
   getSelectionChunk(chunk, inputSelection, type);
   bytes= sizeSelectionChunk(chunk);
 
-  allocateSelectionBuffer(bytes);
+  if (!allocateSelectionBuffer(bytes)) {
+	destroySelectionChunk(chunk);
+	return 1; /* out of memory */
+  }
   copySelectionChunk(chunk, stPrimarySelection);
   destroySelectionChunk(chunk);
   if (isDnd) dndHandleEvent(DndInFinished, 0);

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -205,6 +205,7 @@ typedef struct SelectionOffer {
   struct SelectionOffer *next;
 } SelectionOffer;
 
+/* FIFO */
 static SelectionOffer *offerTable= NULL;
 
 #define		 SELECTION_ATOM_COUNT  10
@@ -689,6 +690,7 @@ static SelectionOffer *findOffer(Atom type)
 static int addOffer(Atom type, const char *data, size_t size)
 {
   SelectionOffer *offer;
+  SelectionOffer *tail;
   
   /* Check if offer already exists - update it */
   offer= findOffer(type);
@@ -717,8 +719,17 @@ static int addOffer(Atom type, const char *data, size_t size)
   offer->data[size]= '\0';
   offer->type= type;
   offer->size= size;
-  offer->next= offerTable;
-  offerTable= offer;
+  offer->next= NULL;
+
+  /* Append to preserve FIFO order (see offerTable comment). */
+  if (!offerTable)
+    offerTable= offer;
+  else {
+    tail= offerTable;
+    while (tail->next)
+      tail= tail->next;
+    tail->next= offer;
+  }
   
   return 1;
 }

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -2602,8 +2602,16 @@ display_clipboardGetTypeNames(void)
         for (offer= offerTable; offer; offer= offer->next) {
           char *atomName= XGetAtomName(stDisplay, offer->type);
           if (atomName) {
-            typeNames[i++]= strdup(atomName);
+            typeNames[i]= strdup(atomName);
             XFree(atomName);
+            if (!typeNames[i]) {
+              /* strdup failed; free previously allocated strings and array */
+              int j;
+              for (j= 0; j < i; j++) free(typeNames[j]);
+              free(typeNames);
+              return 0;
+            }
+            i++;
           }
         }
         typeNames[i]= 0;

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -1231,7 +1231,7 @@ void initClipboard(void)
 }
 
 // NB: Must not put new offers in the same event loop cycle as relinquishClipboard is called
-void relinquishClipboard(void)
+static void relinquishClipboard(void)
 {
   Time ts = getXTimestamp();
 
@@ -1239,6 +1239,9 @@ void relinquishClipboard(void)
   stOwnsSelection = 0;
   stSelectionTime = ts;
   clearOffers();
+  if (stPrimarySelection != stEmptySelection) {
+    free(stPrimarySelection);
+  }
   stPrimarySelection = stEmptySelection;
   stPrimarySelectionSize = 0;
 
@@ -1313,11 +1316,17 @@ display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t 
     buf= (char *)malloc(len * 3 + 1);
     if (buf) {
       n= sq2uxUTF8(data, len, buf, len * 3 + 1, 1);
-      if (!addOffer(xaUTF8String, buf, n)) return 0;
+      if (!addOffer(xaUTF8String, buf, n)) {
+        free(buf);
+        return 0;
+      }
       
       /* Offer STRING (ISO Latin-1) - reuse same buffer */
       n= sq2uxText(data, len, buf, len * 3 + 1, 1);
-      if (!addOffer(XA_STRING, buf, n)) return 0;
+      if (!addOffer(XA_STRING, buf, n)) {
+        free(buf);
+        return 0;
+      }
       
       /* Offer COMPOUND_TEXT - use converted buffer
          If we don't report COMPOUND_TEXT in this list, KMail (and maybe other
@@ -1363,7 +1372,7 @@ display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t 
     /* Typed format: add single offer */
     type= stringToAtom(typeName, nTypeName);
     if (!(success = addOffer(type, data, ndata))) {
-      fprintf(stderr, "display_clipboardWriteWithType: failed to add offer for type %s\n", typeName);
+      fprintf(stderr, "display_clipboardWriteWithType: failed to add offer for type %.*s\n", (int)nTypeName, typeName);
     }
   }
 

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -1280,13 +1280,13 @@ display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t 
   sqInt success = 1;
 
   if (data == NULL) {
-	// clear
-	if (isClaiming) {
-	  relinquishClipboard();
-	} else {
-	  clearOffers();
-	}
-	return success;
+    // clear
+    if (isClaiming) {
+      relinquishClipboard();
+    } else {
+      clearOffers();
+    }
+    return success;
   }
   
   /* If claiming, clear previous offers and start fresh */
@@ -1353,8 +1353,8 @@ display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t 
         success = addOffer(xaCompoundText, (char *)textProperty.value, textProperty.nitems);
         XFree((void *)textProperty.value);
       } else {
-		success = 0;
-	  }
+        success = 0;
+      }
       
       free(buf);
     }
@@ -1368,7 +1368,7 @@ display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t 
   }
 
   if (!success) {
-	return 0;
+    return 0;
   }
 
   if (isClaiming) claimSelection();
@@ -1381,7 +1381,7 @@ static sqInt
 display_clipboardSize(void)
 {
   if (!stOwnsClipboard) {
-	getSelection();
+    getSelection();
   }
   return stPrimarySelectionSize;
 }

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -233,6 +233,47 @@ char		*selectionAtomNames[SELECTION_ATOM_COUNT]= {
 #define xaXdndSelection selectionAtoms[9]
 };
 
+/* Build a TARGETS atom list for the current offer table.
+ * The list always includes required meta targets first (TARGETS, MULTIPLE,
+ * TIMESTAMP) and then all offered types, deduplicated.
+ * Answer malloc'd array (caller must free) and set *outCount.
+ */
+static Atom *buildLocalTargets(int *outCount)
+{
+  size_t capacity= 3;
+  int targetsSize= 0;
+  SelectionOffer *offer;
+  Atom *targets;
+
+  for (offer= offerTable; offer; offer= offer->next)
+    capacity++;
+
+  targets= (Atom *)malloc(capacity * sizeof(Atom));
+  if (!targets) {
+    if (outCount) *outCount= 0;
+    return NULL;
+  }
+
+  targets[targetsSize++]= xaTargets;
+  targets[targetsSize++]= xaMultiple;
+  targets[targetsSize++]= xaTimestamp;  /* required by ICCM */
+
+  for (offer= offerTable; offer; offer= offer->next) {
+    int i, duplicate= 0;
+    for (i= 0; i < targetsSize; i++) {
+      if (targets[i] == offer->type) {
+        duplicate= 1;
+        break;
+      }
+    }
+    if (!duplicate)
+      targets[targetsSize++]= offer->type;
+  }
+
+  if (outCount) *outCount= targetsSize;
+  return targets;
+}
+
 Atom		 wmProtocolsAtom;	/* for window deletion messages */
 Atom		 wmDeleteWindowAtom;
 
@@ -725,35 +766,13 @@ static int sendSelection(XSelectionRequestEvent *requestEv, int isMultiple)
   }
   else if (xaTargets == requestEv->target)
     {
-      /* Report meta-formats plus offers from image */
-      size_t capacity= 3;
-      SelectionOffer *offer;
-      for (offer= offerTable; offer; offer= offer->next)
-        capacity++;
+      int targetsSize= 0;
+      Atom *targets= buildLocalTargets(&targetsSize);
 
-      Atom *targets= (Atom *)malloc(capacity * sizeof(Atom));
       if (!targets) {
         xError= BadAlloc;
         notifyEv.property= None;
       } else {
-        int targetsSize= 3;
-        targets[0]= xaTargets;
-        targets[1]= xaMultiple;
-        targets[2]= xaTimestamp;	        /* required by ICCCM */
-        /* Add all offers from the table, deduplicating against meta-formats */
-        for (offer= offerTable; offer; offer= offer->next) {
-          /* Skip if already in the list (handles user-provided meta-formats) */
-          int i, duplicate= 0;
-          for (i= 0; i < targetsSize; i++) {
-            if (targets[i] == offer->type) {
-              duplicate= 1;
-              break;
-            }
-          }
-          if (!duplicate) {
-            targets[targetsSize++]= offer->type;
-          }
-        }
         xError= XChangeProperty(requestEv->display, requestEv->requestor,
                                 targetProperty, XA_ATOM,
                                 32, PropModeReplace, (unsigned char *)targets, targetsSize);
@@ -1087,10 +1106,24 @@ static void copySelectionChunk(SelectionChunk *chunk, char *dest)
     memcpy(j, i->data, i->size);
 }
 
-static size_t bytes_for(int format, unsigned long nitems) {
+static size_t bytes_for(int format, unsigned long nitems)
+{
   if (format == 8)  return nitems;
   if (format == 16) return nitems * 2;
-  if (format == 32) return nitems * sizeof(long);   // critical on 64-bit
+  /* Xlib returns format==32 data in longs (sizeof(long) bytes each). */
+  if (format == 32) return nitems * sizeof(long);
+  return 0;
+}
+
+/* XGetWindowProperty long_offset/long_length are in 32-bit units, regardless
+ * of the property's format. Convert returned nitems (in 8/16/32-bit items)
+ * into the number of 32-bit units consumed so we can advance long_offset.
+ */
+static unsigned long units32_for(int format, unsigned long nitems)
+{
+  if (format == 8)  return (nitems + 3) / 4;
+  if (format == 16) return (nitems + 1) / 2;
+  if (format == 32) return nitems;
   return 0;
 }
 
@@ -1101,7 +1134,7 @@ static size_t getSelectionProperty(SelectionChunk *chunk, Window requestor, Atom
   unsigned char *data= 0;
   size_t size;
   int format;
-  unsigned long offset32 = 0; // in 32-bit units
+  unsigned long offset32= 0; /* in 32-bit units */
   
   do
     {
@@ -1112,7 +1145,7 @@ static size_t getSelectionProperty(SelectionChunk *chunk, Window requestor, Atom
 			 &data);
       
 	  size= bytes_for(format, nitems);
-	  offset32 += nitems;
+	  offset32 += units32_for(format, nitems);
       
 #    if defined(DEBUG_SELECTIONS)
       fprintf(stderr, "getprop type ");
@@ -2587,32 +2620,36 @@ display_clipboardGetTypeNames(void)
   else 
     {
       if (stOwnsClipboard) {
-        /* Serve from local offer table only */
-        SelectionOffer *offer;
-        int count= 0, i= 0;
-        
-        /* Count offers */
-        for (offer= offerTable; offer; offer= offer->next) count++;
-        
+        int count= 0;
+        int i= 0;
+        int outIndex= 0;
+        Atom *localTargets= buildLocalTargets(&count);
+        if (!localTargets) return 0;
+
         typeNames= calloc(count + 1, sizeof(char *));
-        if (!typeNames) return 0;
-        
-        for (offer= offerTable; offer; offer= offer->next) {
-          char *atomName= XGetAtomName(stDisplay, offer->type);
+        if (!typeNames) {
+          free(localTargets);
+          return 0;
+        }
+
+        for (i= 0; i < count; i++) {
+          char *atomName= XGetAtomName(stDisplay, localTargets[i]);
           if (atomName) {
-            typeNames[i]= strdup(atomName);
+            typeNames[outIndex]= strdup(atomName);
             XFree(atomName);
-            if (!typeNames[i]) {
-              /* strdup failed; free previously allocated strings and array */
+            if (!typeNames[outIndex]) {
               int j;
-              for (j= 0; j < i; j++) free(typeNames[j]);
+              for (j= 0; j < outIndex; j++) free(typeNames[j]);
               free(typeNames);
+              free(localTargets);
               return 0;
             }
-            i++;
+            outIndex++;
           }
         }
-        typeNames[i]= 0;
+
+        typeNames[outIndex]= 0;
+        free(localTargets);
         return typeNames;
       }
       targets= (Atom *)getSelectionData(xaClipboard, xaTargets, &bytes);
@@ -2643,9 +2680,34 @@ display_clipboardSizeWithType(char *typeName, int nTypeName)
   inputSelection= isDnd ? xaXdndSelection : xaClipboard;
 
   if ((!isDnd) && stOwnsClipboard) {
-    /* Serve from local offer table */
     SelectionOffer *offer;
     type= stringToAtom(typeName, nTypeName);
+
+    if (type == xaTargets) {
+      int count= 0;
+      Atom *targets= buildLocalTargets(&count);
+      size_t targetBytes;
+      if (!targets) return 0;
+      targetBytes= count * sizeof(Atom);
+      if (allocateSelectionBuffer(targetBytes)) {
+        memcpy(stPrimarySelection, targets, targetBytes);
+        stPrimarySelection[targetBytes]= '\0';
+        free(targets);
+        return stPrimarySelectionSize;
+      }
+      free(targets);
+      return 0;
+    }
+
+    if (type == xaTimestamp) {
+      if (allocateSelectionBuffer(sizeof(Time))) {
+        memcpy(stPrimarySelection, &stSelectionTime, sizeof(Time));
+        stPrimarySelection[sizeof(Time)]= '\0';
+        return stPrimarySelectionSize;
+      }
+      return 0;
+    }
+
     offer= findOffer(type);
     if (offer) {
       if (allocateSelectionBuffer(offer->size)) {

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -815,6 +815,14 @@ static int sendSelection(XSelectionRequestEvent *requestEv, int isMultiple)
 			}
 		    }
 		}
+        xError= XChangeProperty(requestEv->display,
+              requestEv->requestor,
+              requestEv->property,
+              type,
+              32, PropModeReplace,
+              (unsigned char *)multipleAtoms,
+              numberOfItems);
+        XFree((void *)multipleAtoms);
 	    }
 	}
     }
@@ -1006,28 +1014,11 @@ static int waitNotify(XEvent *ev, int (*condition)(XEvent *ev))
 	}
 
       XNextEvent(stDisplay, ev);
-      switch (ev->type)
-	{
-	case ConfigureNotify:
-	  noteResize(ev->xconfigure.width, ev->xconfigure.height);
-	  break;
-
-        /* this is necessary so that we can supply our own selection when we
-	   are the requestor -- this could (should) be optimised to return the
-	   stored selection value instead! */
-	case SelectionRequest:
-#	 if defined(DEBUG_SELECTIONS)
-	  fprintf(stderr, "getSelection: sending own selection\n");
-#	 endif
-	  sendSelection(&ev->xselectionrequest, 0);
-	  break;
-
 #       if defined(USE_XSHM)
-	default:
 	  if (ev->type == completionType)
 	    --completions;
 #       endif
-	}
+	  handleEvent(ev);
     }
   while (!condition(ev));
 
@@ -1096,25 +1087,32 @@ static void copySelectionChunk(SelectionChunk *chunk, char *dest)
     memcpy(j, i->data, i->size);
 }
 
+static size_t bytes_for(int format, unsigned long nitems) {
+  if (format == 8)  return nitems;
+  if (format == 16) return nitems * 2;
+  if (format == 32) return nitems * sizeof(long);   // critical on 64-bit
+  return 0;
+}
 
 /* get the value of the selection from the containing property */
 static size_t getSelectionProperty(SelectionChunk *chunk, Window requestor, Atom property, Atom *actualType)
 {
-  unsigned long bytesAfter= 0, nitems= 0, nread= 0;
+  unsigned long bytesAfter= 0, nitems= 0;
   unsigned char *data= 0;
   size_t size;
   int format;
+  unsigned long offset32 = 0; // in 32-bit units
   
   do
     {
       XGetWindowProperty(stDisplay, requestor, property,
-			 nread, (MAX_SELECTION_SIZE / 4),
+			 offset32, (MAX_SELECTION_SIZE / 4),
 			 True, AnyPropertyType,
 			 actualType, &format, &nitems, &bytesAfter,
 			 &data);
       
-      size= nitems * format / 8;
-      nread += size / 4;
+	  size= bytes_for(format, nitems);
+	  offset32 += nitems;
       
 #    if defined(DEBUG_SELECTIONS)
       fprintf(stderr, "getprop type ");

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -197,6 +197,16 @@ XColor		 stColorBlack;		/* black pixel value in stColormap */
 XColor		 stColorWhite;		/* white pixel value in stColormap */
 int		 savedWindowOrigin= -1;	/* initial origin of window */
 
+/* Multi-format clipboard offer table */
+typedef struct SelectionOffer {
+  Atom type;
+  char *data;
+  size_t size;
+  struct SelectionOffer *next;
+} SelectionOffer;
+
+static SelectionOffer *offerTable= NULL;
+
 #define		 SELECTION_ATOM_COUNT  10
 /* http://www.freedesktop.org/standards/clipboards-spec/clipboards.txt */
 Atom		 selectionAtoms[SELECTION_ATOM_COUNT];
@@ -610,6 +620,68 @@ static int allocateSelectionBuffer(int count)
   return 1;
 }
 
+/* Clear all offers from the table */
+static void clearOffers(void)
+{
+  SelectionOffer *offer= offerTable;
+  while (offer) {
+    SelectionOffer *next= offer->next;
+    if (offer->data) free(offer->data);
+    free(offer);
+    offer= next;
+  }
+  offerTable= NULL;
+}
+
+/* Find offer by type */
+static SelectionOffer *findOffer(Atom type)
+{
+  SelectionOffer *offer= offerTable;
+  while (offer) {
+    if (offer->type == type) return offer;
+    offer= offer->next;
+  }
+  return NULL;
+}
+
+/* Add or update offer in table */
+static int addOffer(Atom type, const char *data, size_t size)
+{
+  SelectionOffer *offer;
+  
+  /* Check if offer already exists - update it */
+  offer= findOffer(type);
+  if (offer) {
+    char *newData= (char *)malloc(size + 1);
+    if (!newData) return 0;
+    memcpy(newData, data, size);
+    newData[size]= '\0';
+    if (offer->data) free(offer->data);
+    offer->data= newData;
+    offer->size= size;
+    return 1;
+  }
+  
+  /* Add new offer */
+  offer= (SelectionOffer *)malloc(sizeof(SelectionOffer));
+  if (!offer) return 0;
+  
+  offer->data= (char *)malloc(size + 1);
+  if (!offer->data) {
+    free(offer);
+    return 0;
+  }
+  
+  memcpy(offer->data, data, size);
+  offer->data[size]= '\0';
+  offer->type= type;
+  offer->size= size;
+  offer->next= offerTable;
+  offerTable= offer;
+  
+  return 1;
+}
+
 
 /* answers true if selection could be handled */
 static int sendSelection(XSelectionRequestEvent *requestEv, int isMultiple)
@@ -642,95 +714,51 @@ static int sendSelection(XSelectionRequestEvent *requestEv, int isMultiple)
   fprintf(stderr, "\n");
 #endif
 
-  if ((XA_STRING == requestEv->target) || (xaUTF8String == requestEv->target))
-    {
-      int   len= strlen(stPrimarySelection);
-      char *buf= (char *)malloc(len * 3 + 1);
-      int   n;
-
-#    if defined(DEBUG_SELECTIONS)
-      fprintf(stderr, "sendSelection: len=%d, sel=", len);
-      dumpSelectionData(stPrimarySelection, len, 1);
-#    endif
-      if (xaUTF8String == requestEv->target)
-        n= sq2uxUTF8(stPrimarySelection, len, buf, len * 3 + 1, 1);
-      else
-        n= sq2uxText(stPrimarySelection, len, buf, len * 3 + 1, 1);
-#    if defined(DEBUG_SELECTIONS)
-      fprintf(stderr, "sendSelection: n=%d, buf=", n);
-      dumpSelectionData(buf, n, 1);
-#    endif
-      XChangeProperty(requestEv->display, requestEv->requestor,
-		      targetProperty, requestEv->target,
-		      8, PropModeReplace, (const unsigned char *)buf, n);
-      free(buf);
-    }
-  else if ((stSelectionType == requestEv->target) && (None != stSelectionType))
-    {
-      /* In case of type other than image/png */
-      XChangeProperty(requestEv->display, requestEv->requestor,
-		      targetProperty, requestEv->target,
-		      8, PropModeReplace,
-		      (const unsigned char *) stPrimarySelection,
-		      stPrimarySelectionSize);
-    }
+  /* Check offer table first - allows overriding even meta-formats if desired */
+  SelectionOffer *customOffer= findOffer(requestEv->target);
+  if (customOffer) {
+    XChangeProperty(requestEv->display, requestEv->requestor,
+                    targetProperty, requestEv->target,
+                    8, PropModeReplace,
+                    (const unsigned char *)customOffer->data,
+                    customOffer->size);
+  }
   else if (xaTargets == requestEv->target)
     {
-      /* If we don't report COMPOUND_TEXT in this list, KMail (and maybe other
-       * Qt/KDE apps) don't accept pastes from Squeak. Of course, they'll use
-       * UTF8_STRING anyway... */
-      Atom targets[7];
-      int targetsSize= 6;
-      targets[0]= xaTargets;
-      targets[1]= xaMultiple;
-      targets[2]= xaTimestamp;	        /* required by ICCCM */
-      targets[3]= xaUTF8String;
-      targets[4]= XA_STRING;
-      targets[5]= xaCompoundText;
-      if (stSelectionType != None)
-	{
-	  targetsSize += 1;
-	  targets[6]= stSelectionType;
-	}
-      xError= XChangeProperty(requestEv->display, requestEv->requestor,
-                              targetProperty, XA_ATOM,
-                              32, PropModeReplace, (unsigned char *)targets, targetsSize);
-    }
-  else if (xaCompoundText == requestEv->target)
-    {
-      /* COMPOUND_TEXT is handled here for older clients that don't handle UTF-8 */
-      XTextProperty  textProperty;
-      char          *list[]= { stPrimarySelection, NULL };
+      /* Report meta-formats plus offers from image */
+      size_t capacity= 3;
+      SelectionOffer *offer;
+      for (offer= offerTable; offer; offer= offer->next)
+        capacity++;
 
-      if (localeEncoding == sqTextEncoding)
-	xError= XmbTextListToTextProperty(requestEv->display, list, 1, XCompoundTextStyle, &textProperty);
-#    if defined(X_HAVE_UTF8_STRING)
-      else if (uxUTF8Encoding == sqTextEncoding)
-	xError= Xutf8TextListToTextProperty(requestEv->display, list, 1, XCompoundTextStyle, &textProperty);
-#    endif
-      else
-	{
-	  int	len= strlen(stPrimarySelection);
-	  char *buf= (char *)malloc(len * 3 + 1);
-
-	  list[0]= buf;
-	  sq2uxText(stPrimarySelection, len, buf, len * 3 + 1, 1);
-	  xError= XmbTextListToTextProperty(requestEv->display, list, 1, XCompoundTextStyle, &textProperty);
-	  free(buf);
-	}
-
-      if (Success == xError)
-        {
-	  xError= XChangeProperty(requestEv->display, requestEv->requestor,
-				  targetProperty, xaCompoundText,
-				  8, PropModeReplace, textProperty.value, textProperty.nitems);
-          XFree((void *)textProperty.value);
+      Atom *targets= (Atom *)malloc(capacity * sizeof(Atom));
+      if (!targets) {
+        xError= BadAlloc;
+        notifyEv.property= None;
+      } else {
+        int targetsSize= 3;
+        targets[0]= xaTargets;
+        targets[1]= xaMultiple;
+        targets[2]= xaTimestamp;	        /* required by ICCCM */
+        /* Add all offers from the table, deduplicating against meta-formats */
+        for (offer= offerTable; offer; offer= offer->next) {
+          /* Skip if already in the list (handles user-provided meta-formats) */
+          int i, duplicate= 0;
+          for (i= 0; i < targetsSize; i++) {
+            if (targets[i] == offer->type) {
+              duplicate= 1;
+              break;
+            }
+          }
+          if (!duplicate) {
+            targets[targetsSize++]= offer->type;
+          }
         }
-      else
-        {
-          fprintf(stderr, "XmbTextListToTextProperty returns %d\n", xError);
-          notifyEv.property= None;
-        }
+        xError= XChangeProperty(requestEv->display, requestEv->requestor,
+                                targetProperty, XA_ATOM,
+                                32, PropModeReplace, (unsigned char *)targets, targetsSize);
+        free(targets);
+      }
     }
   else if (xaTimestamp == requestEv->target)
     {
@@ -792,7 +820,8 @@ static int sendSelection(XSelectionRequestEvent *requestEv, int isMultiple)
     }
   else
     {
-      notifyEv.property= None;	/* couldn't handle it */
+      /* No hardcoded handler and not in offer table */
+      notifyEv.property= None;
     }
 
 #if defined(DEBUG_SELECTIONS)
@@ -1198,7 +1227,24 @@ void initClipboard(void)
   stPrimarySelectionSize= 0;
   stOwnsSelection= 0;
   stOwnsClipboard= 0;
-  stSelectionType= None;
+  clearOffers();
+}
+
+// NB: Must not put new offers in the same event loop cycle as relinquishClipboard is called
+void relinquishClipboard(void)
+{
+  Time ts = getXTimestamp();
+
+  stOwnsClipboard = 0;
+  stOwnsSelection = 0;
+  stSelectionTime = ts;
+  clearOffers();
+  stPrimarySelection = stEmptySelection;
+  stPrimarySelectionSize = 0;
+
+  XSetSelectionOwner(stDisplay, xaClipboard, None, ts);
+  XSetSelectionOwner(stDisplay, XA_PRIMARY,   None, ts);
+  XFlush(stDisplay);
 }
 
 
@@ -1221,33 +1267,122 @@ static Atom stringToAtom(char *target, size_t size)
  *
  * selectionName : None (CLIPBOARD and PRIMARY), or XdndSelection
  * type : None (various string), or target type ('image/png' etc.)
- * data : data
+ * data : data, or NULL to clear clipboard
  * ndata : size of the data
- * typeName : 0 (various string), or target name ('image/png' etc.)
+ * typeName : 0 (various string), or target name ('image/png' etc.), or "" (legacy text - automatic formats)
  * ntypeName : length of typeName
  * isDnd : true if XdndSelection, false if CLIPBOARD or PRIMARY
- * isClaiming : true if XGetSelectionOwner is needed
+ * isClaiming : true if XGetSelectionOwner is needed (will also clear previous offers)
  */
-static void
+static sqInt
 display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t nTypeName, int isDnd, int isClaiming)
 {
-  if (allocateSelectionBuffer(ndata))
-    {
-      Atom type= stringToAtom(typeName, nTypeName);
-      stSelectionName= isDnd ? xaXdndSelection : None;
+  sqInt success = 1;
+
+  if (data == NULL) {
+	// clear
+	if (isClaiming) {
+	  relinquishClipboard();
+	} else {
+	  clearOffers();
+	}
+	return success;
+  }
+  
+  /* If claiming, clear previous offers and start fresh */
+  if (isClaiming) {
+    clearOffers();
+  }
+
+  Atom type;
+  stSelectionName= isDnd ? xaXdndSelection : None;
+  
+  /* Empty typeName means legacy text clipboard - provide all text formats */
+  if (nTypeName == 0) {
+    int len= ndata;
+    char *buf;
+    int n;
+    
+    /* Store original data in stPrimarySelection for legacy read operations */
+    if (allocateSelectionBuffer(ndata)) {
       memcpy((void *)stPrimarySelection, data, ndata);
       stPrimarySelection[ndata]= '\0';
-      stSelectionType= type;
-      if (isClaiming) claimSelection();
     }
+    
+    /* Offer UTF8_STRING */
+    buf= (char *)malloc(len * 3 + 1);
+    if (buf) {
+      n= sq2uxUTF8(data, len, buf, len * 3 + 1, 1);
+      if (!addOffer(xaUTF8String, buf, n)) return 0;
+      
+      /* Offer STRING (ISO Latin-1) - reuse same buffer */
+      n= sq2uxText(data, len, buf, len * 3 + 1, 1);
+      if (!addOffer(XA_STRING, buf, n)) return 0;
+      
+      /* Offer COMPOUND_TEXT - use converted buffer
+         If we don't report COMPOUND_TEXT in this list, KMail (and maybe other
+         Qt/KDE apps) don't accept pastes from Squeak. Of course, they'll use
+         UTF8_STRING anyway... */
+      XTextProperty textProperty;
+      char *list[]= { buf, NULL };
+      int xError;
+      
+      /* For COMPOUND_TEXT, we need locale or UTF-8 encoded text */
+      if (localeEncoding == sqTextEncoding) {
+        /* Convert from Squeak to locale encoding first */
+        n= sq2uxText(data, len, buf, len * 3 + 1, 1);
+        list[0]= buf;
+        xError= XmbTextListToTextProperty(stDisplay, list, 1, XCompoundTextStyle, &textProperty);
+      }
+#     if defined(X_HAVE_UTF8_STRING)
+      else if (uxUTF8Encoding == sqTextEncoding) {
+        /* Convert from Squeak to UTF-8 first */
+        n= sq2uxUTF8(data, len, buf, len * 3 + 1, 1);
+        list[0]= buf;
+        xError= Xutf8TextListToTextProperty(stDisplay, list, 1, XCompoundTextStyle, &textProperty);
+      }
+#     endif
+      else {
+        /* Generic conversion via locale */
+        n= sq2uxText(data, len, buf, len * 3 + 1, 1);
+        list[0]= buf;
+        xError= XmbTextListToTextProperty(stDisplay, list, 1, XCompoundTextStyle, &textProperty);
+      }
+      
+      if (Success == xError) {
+        success = addOffer(xaCompoundText, (char *)textProperty.value, textProperty.nitems);
+        XFree((void *)textProperty.value);
+      } else {
+		success = 0;
+	  }
+      
+      free(buf);
+    }
+  }
+  else {
+    /* Typed format: add single offer */
+    type= stringToAtom(typeName, nTypeName);
+    if (!(success = addOffer(type, data, ndata))) {
+      fprintf(stderr, "display_clipboardWriteWithType: failed to add offer for type %s\n", typeName);
+    }
+  }
+
+  if (!success) {
+	return 0;
+  }
+
+  if (isClaiming) claimSelection();
+
+  return 1;
 }
 
 
 static sqInt
 display_clipboardSize(void)
 {
-  if (stOwnsClipboard) return 0;
-  getSelection();
+  if (!stOwnsClipboard) {
+	getSelection();
+  }
   return stPrimarySelectionSize;
 }
 
@@ -1255,8 +1390,7 @@ display_clipboardSize(void)
 static sqInt
 display_clipboardWriteFromAt(sqInt count, sqInt byteArrayIndex, sqInt startIndex)
 {
-  display_clipboardWriteWithType(pointerForOop(byteArrayIndex + startIndex), count, "", 0, 0, 1);
-  return 0;
+  return display_clipboardWriteWithType(pointerForOop(byteArrayIndex + startIndex), count, "", 0, 0, 1);
 }
 
 /* Transfer the X selection into the given byte array; optimise local requests. */
@@ -2442,7 +2576,27 @@ display_clipboardGetTypeNames(void)
     dndGetTargets(&targets, &nTypeNames);
   else 
     {
-      if (stOwnsClipboard) return 0;
+      if (stOwnsClipboard) {
+        /* Serve from local offer table only */
+        SelectionOffer *offer;
+        int count= 0, i= 0;
+        
+        /* Count offers */
+        for (offer= offerTable; offer; offer= offer->next) count++;
+        
+        typeNames= calloc(count + 1, sizeof(char *));
+        if (!typeNames) return 0;
+        
+        for (offer= offerTable; offer; offer= offer->next) {
+          char *atomName= XGetAtomName(stDisplay, offer->type);
+          if (atomName) {
+            typeNames[i++]= strdup(atomName);
+            XFree(atomName);
+          }
+        }
+        typeNames[i]= 0;
+        return typeNames;
+      }
       targets= (Atom *)getSelectionData(xaClipboard, xaTargets, &bytes);
       if (0 == bytes) return 0;
       nTypeNames= bytes / sizeof(Atom);
@@ -2470,7 +2624,20 @@ display_clipboardSizeWithType(char *typeName, int nTypeName)
   isDnd= dndAvailable();
   inputSelection= isDnd ? xaXdndSelection : xaClipboard;
 
-  if ((!isDnd) && stOwnsClipboard) return 0;
+  if ((!isDnd) && stOwnsClipboard) {
+    /* Serve from local offer table */
+    SelectionOffer *offer;
+    type= stringToAtom(typeName, nTypeName);
+    offer= findOffer(type);
+    if (offer) {
+      if (allocateSelectionBuffer(offer->size)) {
+        memcpy(stPrimarySelection, offer->data, offer->size);
+        stPrimarySelection[offer->size]= '\0';
+        return stPrimarySelectionSize;
+      }
+    }
+    return 0;
+  }
 
   chunk= newSelectionChunk();
   type= stringToAtom(typeName, nTypeName);
@@ -3790,6 +3957,7 @@ handleEvent(XEvent *evt)
 	  stOwnsClipboard= 0;
 	  stOwnsSelection= 0;   /* clear both CLIPBOARD and PRIMARY */
 	  usePrimaryFirst= 0;
+	  clearOffers();        /* clear multi-format offers */
 	}
       else if (XA_PRIMARY == evt->xselectionclear.selection)
 	{

--- a/platforms/unix/vm-display-fbdev/sqUnixFBDev.c
+++ b/platforms/unix/vm-display-fbdev/sqUnixFBDev.c
@@ -490,7 +490,7 @@ static sqInt display_clipboardReadIntoAt(sqInt n, sqInt ptr, sqInt off)					{ re
 static char **display_clipboardGetTypeNames(void)								{ return 0; }
 static sqInt  display_clipboardSizeWithType(char *typeName, int ntypeName)					{ return 0; }
 
-static void  display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t ntypeName, int isDnd, int isClaiming) {}
+static sqInt display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t ntypeName, int isDnd, int isClaiming) { return 0; }
 
 static sqInt display_dndOutStart(char *types, int ntypes)	{ return 0; }
 static void  display_dndOutSend(char *bytes, int nbytes)	{ return  ; }

--- a/platforms/unix/vm-display-null/sqUnixDisplayNull.c
+++ b/platforms/unix/vm-display-null/sqUnixDisplayNull.c
@@ -111,9 +111,9 @@ static sqInt display_clipboardSizeWithType(char *typeName, int nTypeName)
   return 0;
 }
 
-static void display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t nTypeName, int isDnd, int isClaiming)
+static sqInt display_clipboardWriteWithType(char *data, size_t ndata, char *typeName, size_t nTypeName, int isDnd, int isClaiming)
 {
-  return;
+  return 0;
 }
 
 static sqInt display_dndOutStart(char *types, int ntypes)	{ return 0; }

--- a/platforms/unix/vm/SqDisplay.h
+++ b/platforms/unix/vm/SqDisplay.h
@@ -48,7 +48,7 @@ struct SqDisplay
   sqInt  (*clipboardReadIntoAt)(sqInt count, sqInt byteArrayIndex, sqInt startIndex);
   char **(*clipboardGetTypeNames)(void);
   sqInt  (*clipboardSizeWithType)(char *typeName, int ntypeName);
-  void   (*clipboardWriteWithType)(char *data, size_t nData, char *typeName, size_t nTypeName, int isDnd, int isClaiming);
+  sqInt  (*clipboardWriteWithType)(char *data, size_t nData, char *typeName, size_t nTypeName, int isDnd, int isClaiming);
   sqInt  (*dndOutStart)(char *types, int ntypes);
   sqInt  (*dndOutAcceptedType)(char *type, int ntype);
   void   (*dndOutSend)(char *bytes, int nbytes);

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -819,10 +819,10 @@ sqInt
 clipboardSizeWithType(char *typeName, int ntypeName)
 { return dpy->clipboardSizeWithType(typeName, ntypeName); }
 
-void
+sqInt
 clipboardWriteWithType(char *data, size_t nData, char *typeName, size_t nTypeNames, int isDnd, int isClaiming)
 {
-  dpy->clipboardWriteWithType(data, nData, typeName, nTypeNames, isDnd, isClaiming);
+  return dpy->clipboardWriteWithType(data, nData, typeName, nTypeNames, isDnd, isClaiming);
 }
 
 sqInt


### PR DESCRIPTION
* Implement clearing of clipboard
* Different string formats are only  offered when calling display_clipboardWriteWithType() with empty type - legacy interface used by old clipboard primitive. Users of ExtendedClipboardPlugin will have to provide different formats on the image side.
* Implement clipboard size/type requests (not sure why legacy clipboard even worked before)

Please review carefully before merging. I have little experience with C, and 80% of this patch came out of GitHub Copilot, even though I of course did my best to review and challenge it. Seems to work fine in practice on Ubuntu 24/GNOME though. Use [System-ct.1490 (inbox)](https://lists.squeakfoundation.org/archives/list/squeak-dev@lists.squeakfoundation.org/thread/4VCNACYPHC5NEW4RVU5QCQQT5ARL3RQJ/) to test this in Squeak.