### PR TITLE
SqueakSSL: Drain pending handshake data after connection success (required for TLS 1.3)

### DIFF
--- a/platforms/iOS/plugins/SqueakSSL/sqMacSSL.c
+++ b/platforms/iOS/plugins/SqueakSSL/sqMacSSL.c
@@ -550,7 +550,7 @@ sqInt sqConnectSSL(sqInt handle, char* srcBuf, sqInt srcLen, char* dstBuf,
     if (status == noErr) {
         sqExtractPeerName(ssl);
     }
-    return SQSSL_OK;
+    return ssl->outLen;
 }
 
 /* sqAcceptSSL: Start/continue an SSL server handshake.
@@ -613,7 +613,7 @@ sqInt sqAcceptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char* dstBuf,
     }
     /* We are connected. Verify the cert. */
     ssl->state = SQSSL_CONNECTED;
-        return SQSSL_OK;
+    return ssl->outLen;
 }
 
 /* sqEncryptSSL: Encrypt data for SSL transmission.

--- a/platforms/unix/plugins/SqueakSSL/sqOBSDOpenSSL.inc
+++ b/platforms/unix/plugins/SqueakSSL/sqOBSDOpenSSL.inc
@@ -498,7 +498,7 @@ sqInt sqConnectSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 	} else {
 		ssl->certFlags = SQSSL_NO_CERTIFICATE;
 	}
-	return 0;
+	return sqCopyBioSSL(ssl, ssl->bioWrite, dstBuf, dstLen);
 }
 
 /* sqAcceptSSL: Start/continue an SSL server handshake.

--- a/platforms/unix/plugins/SqueakSSL/sqUnixOpenSSL.inc
+++ b/platforms/unix/plugins/SqueakSSL/sqUnixOpenSSL.inc
@@ -512,7 +512,7 @@ sqInt sqConnectSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 	} else {
 		ssl->certFlags = SQSSL_NO_CERTIFICATE;
 	}
-	return 0;
+	return sqCopyBioSSL(ssl, ssl->bioWrite, dstBuf, dstLen);
 }
 
 /* sqAcceptSSL: Start/continue an SSL server handshake.

--- a/platforms/win32/plugins/SqueakSSL/sqWin32SSL.c
+++ b/platforms/win32/plugins/SqueakSSL/sqWin32SSL.c
@@ -638,7 +638,7 @@ sqInt sqConnectSSL(sqInt handle, char* srcBuf, sqInt srcLen, char *dstBuf, sqInt
 	/* Extract the peer name */
 	sqExtractPeerName(ssl);
 
-	return SQSSL_OK;
+	return sqCopyDescToken(ssl, ssl->sbdOut, dstBuf, dstLen);
 }
 
 /* sqAcceptSSL: Start/continue an SSL server handshake.


### PR DESCRIPTION
The LibreSSL implementation already does this. Windows and macOS versions of the plugin are currently pinned to TLS 1.2 but can benefit from this patch in the future, too.

On the image side, this change means that code must no longer rely on primitiveConnect returning 0 for testing whether the connection has established but test SQSSL_PROP_SSLSTATE analogously to for primitiveAccept. While this is a breaking change, it is one that was already dictated by TLS 1.3 in the past few years and has caused a red bar on Linux. Platforms that do not use TLS 1.3 (Windows, macOS) are not affected by this change.

Will be complemented by [SqueakSSL-Core-ct.37](https://source.squeak.org/inbox/SqueakSSL-Core-ct.37.diff)/[SqueakSSL-Tests-ct.29](https://source.squeak.org/inbox/SqueakSSL-Tests-ct.29.diff) (Squeak inbox).