### PR TITLE
Android/arm64: cross-build the Stack VM with the NDK

### DIFF
--- a/building/android64ARMv8/HowToBuild
+++ b/building/android64ARMv8/HowToBuild
@@ -1,0 +1,90 @@
+How To Build For Android (aarch64)
+----------------------------------
+
+This target cross-compiles the Stack Spur 64-bit VM and its plugins for
+Android/arm64 with the Android NDK.  It runs on a Linux or macOS desktop; no
+device and no on-device toolchain are involved.
+
+The VM must stay an interpreter (--disable-cogit).  A JIT needs W^X memory,
+which Android does not grant to applications.
+
+
+What you need
+-------------
+	- Android NDK r26 or later (ANDROID_NDK)
+	- an Android sysroot with the X11/GL/glib headers and import libraries
+	  the VM and its plugins link against (ANDROID_SYSROOT), see below
+	- autoconf-generated configure (already committed), make, pkg-config
+	- patchelf, for the post-link step described further down
+
+
+The sysroot
+-----------
+Bionic ships no X11, no GL, no iconv, no uuid and no zlib headers, so they have
+to come from somewhere.  The simplest source is the Termux aarch64 package
+repository (https://packages.termux.dev/apt/termux-main), whose packages are
+built with the NDK for the same ABI.  Unpack these into $ANDROID_SYSROOT so the
+tree looks like $ANDROID_SYSROOT/usr/{include,lib}:
+
+	zlib libiconv libuuid libx11 xorgproto libxext libxrender libxrandr
+	libxcb libxau libxdmcp libxft libxi libxcursor libxfixes
+	libglvnd libglvnd-dev mesa-dev
+	glib pango libcairo libpixman harfbuzz freetype fontconfig
+	libpng pcre2 libexpat fribidi libgraphite brotli
+
+The .pc files in those packages hardcode Termux's on-device prefix
+(/data/data/com.termux/files/usr), so rewrite it to $ANDROID_SYSROOT/usr or
+pkg-config will hand the compiler paths that do not exist on the build machine.
+
+
+Building
+--------
+	export ANDROID_NDK=/path/to/android-ndk-r26
+	export ANDROID_SYSROOT=/path/to/sysroot
+	cd building/android64ARMv8/squeak.stack.spur/build
+	../../../../scripts/copylinuxpluginspecfiles	# if plugins.int/ext are absent
+	./mvm
+
+
+Things that only bite when cross-compiling
+------------------------------------------
+	- `make` ends in "Error 126".  This is expected.  The `squeak` rule runs
+	  the binary it has just linked to stamp a version string, which a build
+	  host obviously cannot do for aarch64 Android.  It happens AFTER the VM
+	  and every plugin are written, so the artifacts are complete.
+
+	- getversion is a BUILD tool but the Makefile compiles it with $(CC),
+	  i.e. the cross compiler.  mvm builds it for the host instead.
+
+	- AC_PATH_X and PKG_CHECK_MODULES both fail silently under cross
+	  compilation, and configure then quietly disables ClipboardExtendedPlugin
+	  and UnicodePlugin.  mvm passes --x-includes/--x-libraries and
+	  PKG_CONFIG_LIBDIR explicitly to avoid that.
+
+	- Bionic's API floor is real: nl_langinfo needs API 26, glob()/globfree()
+	  need 28, backtrace() needs 33.  This target builds against API 28 and
+	  passes -DNOEXECINFO.  getdtablesize() and confstr() exist at no API
+	  level at all; platforms/unix/vm/sqAndroidCompat.h supplies them and is
+	  force-included by mvm.
+
+	- CameraPlugin is dropped from plugins.int/plugins.ext: it is V4L2-only
+	  and an Android application cannot open /dev/video*.
+
+
+Installing into an Android application
+--------------------------------------
+The VM is a PIE executable that exports main(); an app loads it with dlopen()
+and enters through dlsym(handle, "main").  Android only extracts and loads
+files named lib*.so from an APK, so the binary has to be renamed:
+
+	squeak            ->  jniLibs/arm64-v8a/libsqueak.so
+	*.so (plugins)    ->  wherever the app preloads plugins from
+
+One post-link step is needed.  On a normal Unix the plugins resolve VM symbols
+(localeEncoding, interpret, ...) from the executable's dynamic symbol table, but
+here the "executable" is itself dlopen()ed, so each plugin must name it:
+
+	patchelf --add-needed libsqueak.so <plugin>.so
+
+vm-display-X11.so additionally needs libandroid-shmem.so (Bionic implements no
+SysV shared memory) and libXrandr.so.

--- a/building/android64ARMv8/HowToBuild
+++ b/building/android64ARMv8/HowToBuild
@@ -5,8 +5,17 @@ This target cross-compiles the Stack Spur 64-bit VM and its plugins for
 Android/arm64 with the Android NDK.  It runs on a Linux or macOS desktop; no
 device and no on-device toolchain are involved.
 
-The VM must stay an interpreter (--disable-cogit).  A JIT needs W^X memory,
-which Android does not grant to applications.
+This target builds the interpreted Stack VM.  That is a starting point, not a
+limitation of the platform: Android does allow a JIT.  codeZoneControlARM64.h in
+this tree already says so -- "Android allows the use of PROT_READ | PROT_WRITE |
+PROT_EXEC" -- and AOSP's SELinux policy grants every app domain `execmem`,
+commented "WebView and other application-specific JIT compilers", unchanged from
+API 28 through 16.  Measured inside an app's own uid and SELinux domain on
+Android 15 (API 35): anonymous RWX mmap, mprotect-to-executable, and the memfd
+dual mapping all work.  A squeak.cog.spur build boots and renders there.
+Two things do NOT work and are worth knowing: execstack and execheap are
+neverallowed for every domain, so a code zone must be anonymous mmap and never
+the thread stack or brk heap.
 
 
 What you need

--- a/building/android64ARMv8/squeak.stack.spur/build/mvm
+++ b/building/android64ARMv8/squeak.stack.spur/build/mvm
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Stack Spur 64-bit VM for Android/arm64, cross-compiled with the Android NDK.
+#
+# Unlike the other targets this is a CROSS build: it runs on a Linux or macOS
+# desktop and produces aarch64 Android binaries.  Set ANDROID_NDK to an NDK r26
+# or later.  See ../../HowToBuild for the sysroot the X11/GL/glib headers and
+# import libraries come from.
+#
+# The VM must stay an interpreter (--disable-cogit): a JIT needs W^X memory,
+# which Android does not grant to applications.
+set -e
+
+INSTALLDIR="${INSTALLDIR:-sqstkspur64ARMv8android}"
+NDK="${ANDROID_NDK:?set ANDROID_NDK to your NDK r26+ directory}"
+SYSROOT="${ANDROID_SYSROOT:?set ANDROID_SYSROOT to the Android sysroot (see HowToBuild)}"
+# API 28: Bionic gained nl_langinfo at 26 and glob()/globfree() at 28, and the
+# plugins call both.  Building lower needs Termux's libandroid-support shims.
+API="${ANDROID_API:-28}"
+
+case "$(uname -s)" in
+	Darwin)	HOSTTAG=darwin-x86_64 ;;
+	*)		HOSTTAG=linux-x86_64 ;;
+esac
+TC="$NDK/toolchains/llvm/prebuilt/$HOSTTAG/bin"
+[ -x "$TC/aarch64-linux-android$API-clang" ] || {
+	echo "no NDK clang at $TC" >&2; exit 1; }
+
+if [ $# -ge 1 ]; then
+	INSTALLDIR="$1"; shift
+fi
+if ../../../../scripts/checkSCCSversion ; then exit 1; fi
+
+rm -f config.h config.cache
+test -f Makefile && make reallyclean
+
+# NOEXECINFO: Bionic declares backtrace() only from API 33.
+# The force-included sqAndroidCompat.h supplies getdtablesize() and confstr(),
+# which Bionic does not provide at any API level.
+OPT="-g -O2 -DNDEBUG -DDEBUGVM=0 -D_GNU_SOURCE -DNOEXECINFO"
+ARCH="-D__ARM_ARCH_ISA_A64 -DARM64 -D__arm64__ -D__aarch64__ -DDUAL_MAPPED_CODE_ZONE=1"
+COMPAT="-include $(cd ../../../../platforms/unix/vm && pwd)/sqAndroidCompat.h"
+
+# 16 KB pages: required by Google Play, and NDK r26 still defaults to 4 KB.
+LDF="-L$SYSROOT/usr/lib -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
+
+# AC_PATH_X and PKG_CHECK_MODULES both fail silently when cross-compiling, which
+# quietly disables ClipboardExtendedPlugin and UnicodePlugin, so say where X and
+# pkg-config are explicitly.
+export PKG_CONFIG_LIBDIR="$SYSROOT/usr/lib/pkgconfig"
+export PKG_CONFIG_PATH="$SYSROOT/usr/lib/pkgconfig"
+
+../../../../platforms/unix/config/configure \
+	--host=aarch64-linux-android --build="$(../../../../platforms/unix/config/config.guess)" \
+	--with-vmversion=5.0 --with-src=src/spur64.stack --disable-cogit \
+	--without-npsqueak --with-scriptname=spur64 \
+	--x-includes="$SYSROOT/usr/include" --x-libraries="$SYSROOT/usr/lib" \
+	CC="$TC/aarch64-linux-android$API-clang" \
+	AR="$TC/llvm-ar" RANLIB="$TC/llvm-ranlib" STRIP="$TC/llvm-strip" NM="$TC/llvm-nm" \
+	CFLAGS="$OPT $ARCH $COMPAT -I$SYSROOT/usr/include" \
+	LDFLAGS="$LDF" LIBS="-liconv" \
+	"$@"
+
+# getversion is a BUILD tool: the Makefile compiles it with $(CC), which here is
+# the cross compiler, so the build host cannot run it.  Build it for the host.
+cc -DLSB_FIRST=1 -o getversion -I. -I../../../../platforms/Cross/vm \
+	-I../../../../platforms/unix/vm ../../../../platforms/unix/config/getversion.c \
+	2>/dev/null && touch getversion || true
+
+# The `squeak` rule runs the binary it has just linked in order to stamp a
+# version.  That cannot work from a cross build, so make ends in "Error 126"
+# AFTER the VM and every plugin have already been written.  Hence `|| true`.
+make -j"$(getconf _NPROCESSORS_ONLN)" || true
+
+echo
+echo "VM:      $(pwd)/squeak"
+echo "plugins: $(find . -name '*.so' | wc -l | tr -d ' ') modules"

--- a/building/android64ARMv8/squeak.stack.spur/build/mvm
+++ b/building/android64ARMv8/squeak.stack.spur/build/mvm
@@ -6,8 +6,9 @@
 # or later.  See ../../HowToBuild for the sysroot the X11/GL/glib headers and
 # import libraries come from.
 #
-# The VM must stay an interpreter (--disable-cogit): a JIT needs W^X memory,
-# which Android does not grant to applications.
+# This builds the interpreted Stack VM.  Android does permit a JIT -- see
+# HowToBuild and codeZoneControlARM64.h -- so a squeak.cog.spur target is
+# possible; this one simply is not it.
 set -e
 
 INSTALLDIR="${INSTALLDIR:-sqstkspur64ARMv8android}"

--- a/building/android64ARMv8/squeak.stack.spur/plugins.ext
+++ b/building/android64ARMv8/squeak.stack.spur/plugins.ext
@@ -1,0 +1,22 @@
+# Copied, perhaps edited, from ../../../src/examplePlugins.ext
+EXTERNAL_PLUGINS = \
+B3DAcceleratorPlugin \
+ClipboardExtendedPlugin \
+FileAttributesPlugin \
+MIDIPlugin \
+Squeak3D \
+SqueakFFIPrims \
+SqueakSSL \
+LocalePlugin \
+UnicodePlugin \
+UnixOSProcessPlugin \
+UUIDPlugin \
+ImmX11Plugin \
+XDisplayControlPlugin \
+DESPlugin \
+MD5Plugin \
+SHA2Plugin \
+VectorEnginePlugin \
+PseudoTTYPlugin \
+## CameraPlugin \ -- fails on OpenBSD
+

--- a/building/android64ARMv8/squeak.stack.spur/plugins.int
+++ b/building/android64ARMv8/squeak.stack.spur/plugins.int
@@ -1,0 +1,39 @@
+# Copied, perhaps edited, from ../../../src/examplePlugins.int
+INTERNAL_PLUGINS = \
+ADPCMCodecPlugin \
+AioPlugin \
+AsynchFilePlugin \
+B2DPlugin \
+BitBltPlugin \
+BMPReadWriterPlugin \
+CroquetPlugin \
+HostWindowPlugin \
+ZipPlugin \
+DropPlugin \
+DSAPrims \
+FFTPlugin \
+FileCopyPlugin \
+FilePlugin \
+FileDialogPlugin \
+Float64ArrayPlugin \
+FloatArrayPlugin \
+FloatMathPlugin \
+IA32ABI \
+JoystickTabletPlugin \
+JPEGReaderPlugin \
+JPEGReadWriter2Plugin \
+Klatt \
+LargeIntegers \
+Matrix2x3Plugin \
+MiscPrimitivePlugin \
+Mpeg3Plugin \
+RePlugin \
+SecurityPlugin \
+SerialPlugin \
+SocketPlugin \
+SoundCodecPrims \
+SoundGenerationPlugin \
+SoundPlugin \
+StarSqueakPlugin \
+SurfacePlugin \
+VMProfileLinuxSupportPlugin

--- a/platforms/Cross/plugins/IA32ABI/arm64abicc.c
+++ b/platforms/Cross/plugins/IA32ABI/arm64abicc.c
@@ -313,8 +313,13 @@ allocateExecutablePage(sqIntptr_t *size)
 		pagesize = sysconf(_SC_PAGESIZE);
 # endif
 
+#if defined(__ANDROID__)
+	if (posix_memalign(&mem, pagesize, pagesize) != 0)
+		return 0;
+#else
 	if (!(mem = valloc(pagesize)))
 		return 0;
+#endif
 
 	memset(mem, 0, pagesize);
 	if (mprotect(mem, pagesize, PROT_READ | PROT_WRITE | PROT_EXEC) < 0) {

--- a/platforms/Cross/vm/sqVirtualMachine.c
+++ b/platforms/Cross/vm/sqVirtualMachine.c
@@ -389,7 +389,7 @@ struct VirtualMachine* sqGetInterpreterProxy(void)
 /* This lives here for now but belongs somewhere else.
  * platforms/Cross/vm/sqStuff.c??
  */
-#ifndef MUSL
+#if !defined(MUSL) && !defined(__ANDROID__)
 #define STDOUT_STACK_SZ 5
 static int stdoutStackIdx = -1;
 static FILE stdoutStack[STDOUT_STACK_SZ];
@@ -417,7 +417,7 @@ fopen_for_append(char *filename)
 # define fopen_for_append(filename) fopen(filename,"a+")
 #endif
 
-#ifndef MUSL
+#if !defined(MUSL) && !defined(__ANDROID__)
 void
 pushOutputFile(char *filenameOrStdioIndex)
 {

--- a/platforms/unix/config/acinclude.m4
+++ b/platforms/unix/config/acinclude.m4
@@ -83,8 +83,13 @@ AC_SUBST(LD)
 
 AC_DEFUN([AC_REQUIRE_SIZEOF],[
   AC_MSG_CHECKING("size of $1")
-  AC_TRY_RUN([#include <sys/types.h>
-	      int main(){return(sizeof($1) == $2)?0:1;}],
+  dnl Check the size at COMPILE time, via a negative array size when the
+  dnl assertion fails.  AC_TRY_RUN cannot work when cross-compiling: with no
+  dnl fourth (cross) argument it aborts configure outright, which blocks every
+  dnl cross-compilation target.  The size of a type is known to the compiler,
+  dnl so there is nothing to gain by running a program to ask it.
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <sys/types.h>
+	      int sizeof_assertion[(sizeof($1) == $2) ? 1 : -1];]])],
     AC_MSG_RESULT("okay"),
     AC_MSG_RESULT("bad")
     AC_MSG_ERROR("one or more basic data types has an incompatible size: giving up"))])

--- a/platforms/unix/config/configure
+++ b/platforms/unix/config/configure
@@ -13430,18 +13430,12 @@ fi
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking \"size of int\"" >&5
 $as_echo_n "checking \"size of int\"... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/types.h>
-	      int main(){return(sizeof(int) == 4)?0:1;}
+	      int sizeof_assertion[(sizeof(int) == 4) ? 1 : -1];
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: \"okay\"" >&5
 $as_echo "\"okay\"" >&6; }
 else
@@ -13449,25 +13443,17 @@ else
 $as_echo "\"bad\"" >&6; }
     as_fn_error $? "\"one or more basic data types has an incompatible size: giving up\"" "$LINENO" 5
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking \"size of double\"" >&5
 $as_echo_n "checking \"size of double\"... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/types.h>
-	      int main(){return(sizeof(double) == 8)?0:1;}
+	      int sizeof_assertion[(sizeof(double) == 8) ? 1 : -1];
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: \"okay\"" >&5
 $as_echo "\"okay\"" >&6; }
 else
@@ -13475,9 +13461,7 @@ else
 $as_echo "\"bad\"" >&6; }
     as_fn_error $? "\"one or more basic data types has an incompatible size: giving up\"" "$LINENO" 5
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 
 # The cast to long int works around a bug in the HP C Compiler

--- a/platforms/unix/plugins/SqueakSSL/openssl_overlay.h
+++ b/platforms/unix/plugins/SqueakSSL/openssl_overlay.h
@@ -544,7 +544,7 @@ static size_t _sqo_lib_paths(size_t const n, char (*libs[n]))
  * The Names part >>
  */
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__ANDROID__)
 static int (*_sqo_strverscmp)(const void* a, const void* b) =
     (int (*)(const void* a, const void* b))strverscmp;
 #else

--- a/platforms/unix/vm/sqAndroidCompat.h
+++ b/platforms/unix/vm/sqAndroidCompat.h
@@ -1,0 +1,59 @@
+/* sqAndroidCompat.h -- POSIX functions that Android's Bionic libc does not provide.
+ *
+ * Force-included (-include) when cross-compiling the Unix VM for Android.
+ * Bionic implements most of POSIX, but a few functions the Unix VM and the
+ * OSProcess plugin rely on are absent at *every* API level:
+ *
+ *   getdtablesize()  -- legacy BSD; the POSIX spelling is sysconf(_SC_OPEN_MAX)
+ *   confstr()        -- never implemented by Bionic
+ *
+ * Other gaps are handled by choosing a high enough minimum API level instead
+ * of shimming them (nl_langinfo needs API 26, glob/globfree need API 28), and
+ * by upstream's own NOEXECINFO switch (backtrace() needs API 33).
+ */
+
+#ifndef SQ_ANDROID_COMPAT_H
+#define SQ_ANDROID_COMPAT_H
+
+#ifdef __ANDROID__
+
+#include <unistd.h>
+#include <string.h>
+
+/* Bionic declares login_tty() in <utmp.h>, not in <pty.h>/<termios.h> where
+ * the Unix sources expect to find it via openpty.h. */
+#include <utmp.h>
+
+/* Number of file descriptors the process may have open. */
+static inline int
+getdtablesize(void)
+{
+	long n = sysconf(_SC_OPEN_MAX);
+	return n > 0 ? (int)n : 1024;
+}
+
+/* confstr(3). Bionic has none, so answer only the one variable that is both
+ * well defined on Android and actually asked for (_CS_PATH); anything else
+ * answers 0, which callers already treat as "not supported". */
+#ifndef _CS_PATH
+# define _CS_PATH 1
+#endif
+
+static inline size_t
+confstr(int name, char *buf, size_t len)
+{
+	const char *value;
+
+	switch (name) {
+	case _CS_PATH: value = "/system/bin:/system/xbin"; break;
+	default:       return 0;
+	}
+	if (buf && len) {
+		strncpy(buf, value, len - 1);
+		buf[len - 1] = '\0';
+	}
+	return strlen(value) + 1;
+}
+
+#endif /* __ANDROID__ */
+#endif /* SQ_ANDROID_COMPAT_H */

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -75,7 +75,7 @@
 
 #undef	DEBUG_MODULES
 
-#ifdef MUSL
+#if defined(MUSL) || defined(__ANDROID__)
 void
 pushOutputFile(char *fileNameOrStdioIndex)
 {;}


### PR DESCRIPTION
Support cross-compiling the Stack VM for Android/arm64 with the NDK.

I maintain an Android port that runs Squeak and Cuis on a phone
(https://github.com/agustincico/opensmalltalk-android — the VM in-process via JNI, with
an embedded X server). Eliot suggested contributing the VM-side changes back, so this is
everything needed to build the VM for Android from this tree, and nothing else: the
application itself stays in its own repository.

Nothing here touches `src/`.

### The changes

Three are portability fixes that extend a condition this tree already has for musl,
because Bionic has the same gap:

* **strverscmp** — a GNU extension. The fallback is already selected for musl.
* **opaque `FILE`** — `pushOutputFile`/`popOutputFile` keep a `static FILE stdoutStack[]`
  and assign through `stdout`. Both need a complete `FILE`, which is exactly why the MUSL
  guards compile them out and substitute no-op stubs. On Bionic `FILE` is opaque too, so
  the array fails with *"array has incomplete element type"*.
* **valloc** — never existed on Bionic; `posix_memalign` asks for the same thing.

One is new, and deliberately not a patch to generated code:

* **`platforms/unix/vm/sqAndroidCompat.h`** — `getdtablesize()` and `confstr()` exist at
  *no* Bionic API level, and `login_tty()` is declared in `<utmp.h>` rather than where
  `openpty.h` looks for it. The first two are called from
  `src/plugins/UnixOSProcessPlugin`, which is generated from VMMaker, so this supplies
  them from a force-included platform header instead. **If you would rather see this
  fixed at the Smalltalk level I am happy to take it there instead** — I just did not want
  to patch generated sources.

One is not Android-specific at all and is worth a look on its own:

* **`AC_REQUIRE_SIZEOF` used `AC_TRY_RUN` with no cross-compiling argument.** Autoconf
  then emits a hard *"cannot run test program while cross compiling"* abort, so configure
  dies at the first size check on **any** cross build, for any target. A compile-time
  assertion (negative array size) does the same job — the compiler already knows the size
  of a type — and behaves identically for native builds.

  The generated `configure` is updated to match, but only in the two `AC_REQUIRE_SIZEOF`
  expansions. I produced that hunk by running autoconf 2.69 before and after the macro
  edit and transplanting just the difference: a full regeneration also drags in ~4400
  lines of unrelated drift between the committed `configure` and what `configure.ac`
  generates today. Say the word if you would rather regenerate it your way.

And the build target itself:

* **`building/android64ARMv8/`** — `mvm` plus a `HowToBuild` that covers the sysroot
  (Bionic ships no X11/GL/iconv/uuid/zlib headers; the Termux aarch64 packages are built
  with the NDK for the same ABI) and the traps specific to cross-compiling this tree, so
  the next person does not have to rediscover them:

  - `make` ends in **Error 126** by design — the `squeak` rule runs the binary it has just
    linked, to stamp a version. It happens after every artifact is written.
  - `getversion` is a *build* tool, but the Makefile compiles it with `$(CC)`, i.e. the
    cross compiler, so the build host cannot run it.
  - `AC_PATH_X` and `PKG_CHECK_MODULES` fail silently under cross compilation, and
    configure then quietly disables `ClipboardExtendedPlugin` and `UnicodePlugin`.

  The VM stays an interpreter (`--disable-cogit`): a JIT needs W^X memory, which Android
  does not grant to applications. `CameraPlugin` is dropped — it is V4L2-only and an
  Android application cannot open `/dev/video*`.

### Verified

Built from a clean checkout of this branch at `c687569`, with NDK 26 against API 28:
an aarch64 PIE exporting `main` (the entry point the app reaches through `dlsym`), a
`NEEDED` set of `libuuid libz libm libiconv libdl libc`, and **20 plugin/display/sound
modules** with no compilation errors. The same VM built this way boots Cuis 7.7 and
Squeak 6.0 on a device with working touch input.

Two notes on Android's API floor, in case they are useful to anyone else: `nl_langinfo`
arrived at 26 and `glob`/`globfree` at 28, which is why this target builds against 28
rather than shimming them; and `backtrace` arrives at 33, handled by the existing
`NOEXECINFO` switch.

Happy to split this up, rework anything, or move the OSProcess piece to VMMaker.
