### PR TITLE
Properly declare getNextWakeupUsecs(), even on non-macs

### DIFF
--- a/platforms/Cross/vm/sq.h
+++ b/platforms/Cross/vm/sq.h
@@ -131,6 +131,7 @@ unsigned int ioMicroMSecs(void);
 void initStackPagesAndContinueIntowith(void (*continuation)(void *), void *);
 // Time API, Cog uses 64-bit microseconds fron 1901 as much as possible
 void forceInterruptCheckFromHeartbeat(void);
+usqLong getNextWakeupUsecs();
 void ioInitTime(void);
 usqLong ioUTCMicrosecondsNow(void);
 usqLong ioUTCMicroseconds(void);

--- a/platforms/Cross/vm/sq.h
+++ b/platforms/Cross/vm/sq.h
@@ -131,7 +131,7 @@ unsigned int ioMicroMSecs(void);
 void initStackPagesAndContinueIntowith(void (*continuation)(void *), void *);
 // Time API, Cog uses 64-bit microseconds fron 1901 as much as possible
 void forceInterruptCheckFromHeartbeat(void);
-usqLong getNextWakeupUsecs();
+usqLong getNextWakeupUsecs(void);
 void ioInitTime(void);
 usqLong ioUTCMicrosecondsNow(void);
 usqLong ioUTCMicroseconds(void);

--- a/platforms/iOS/vm/Common/Classes/sqMacV2Time.c
+++ b/platforms/iOS/vm/Common/Classes/sqMacV2Time.c
@@ -142,7 +142,6 @@ sqInt ioRelinquishProcessorForMicroseconds(sqInt microSeconds) {
 	#pragma unused(microSeconds)
 
 	usqLong	   realTimeToWait,now,next;
-	extern usqLong getNextWakeupUsecs(void);				//This is a VM Callback
 	extern sqInt setInterruptCheckCounter(sqInt value); //This is a VM Callback
 
 	setInterruptCheckCounter(0);

--- a/platforms/minheadless/unix/sqUnixHeartbeat.c
+++ b/platforms/minheadless/unix/sqUnixHeartbeat.c
@@ -248,7 +248,6 @@ sqInt
 ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
     usqLong	realTimeToWait;
-	extern usqLong getNextWakeupUsecs();
 	usqLong nextWakeupUsecs = getNextWakeupUsecs();
 	usqLong utcNow = get64(utcMicrosecondClock);
 

--- a/platforms/unix/misc/threadValidate/sqUnixHeartbeat.c
+++ b/platforms/unix/misc/threadValidate/sqUnixHeartbeat.c
@@ -149,7 +149,6 @@ sqInt
 ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
     usqLong	realTimeToWait;
-	extern usqLong getNextWakeupUsecs();
 	usqLong nextWakeupUsecs = getNextWakeupUsecs();
 	usqLong utcNow = get64(utcMicrosecondClock);
 

--- a/platforms/unix/vm-display-X11/sqUnixX11.c
+++ b/platforms/unix/vm-display-X11/sqUnixX11.c
@@ -5137,7 +5137,6 @@ display_ioBeep(void)
 static sqInt
 display_ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
-  extern usqLong getNextWakeupUsecs(void);
   extern volatile int mainThreadIsIdle;
 
   if (handleEvents())

--- a/platforms/unix/vm-display-null/sqUnixDisplayNull.c
+++ b/platforms/unix/vm-display-null/sqUnixDisplayNull.c
@@ -27,7 +27,6 @@ static sqInt display_ioBeep(void) { return 0; }
 
 static sqInt display_ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
-  extern usqLong getNextWakeupUsecs(void);
   extern volatile int mainThreadIsIdle;
 
   usqLong nextWakeupUsecs = getNextWakeupUsecs();

--- a/platforms/unix/vm/sqUnixHeartbeat.c
+++ b/platforms/unix/vm/sqUnixHeartbeat.c
@@ -308,7 +308,6 @@ sqInt
 ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
     usqLong	realTimeToWait;
-	extern usqLong getNextWakeupUsecs();
 	usqLong utcNow;
 	usqLong nextWakeupUsecs = getNextWakeupUsecs();
 

--- a/platforms/unix/vm/sqUnixITimerHeartbeat.c
+++ b/platforms/unix/vm/sqUnixITimerHeartbeat.c
@@ -237,7 +237,6 @@ sqInt
 ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
     usqLong	realTimeToWait;
-	extern usqLong getNextWakeupUsecs();
 	usqLong nextWakeupUsecs = getNextWakeupUsecs();
 	usqLong utcNow = get64(utcMicrosecondClock);
 

--- a/platforms/unix/vm/sqUnixITimerTickerHeartbeat.c
+++ b/platforms/unix/vm/sqUnixITimerTickerHeartbeat.c
@@ -240,7 +240,6 @@ sqInt
 ioRelinquishProcessorForMicroseconds(sqInt microSeconds)
 {
     usqLong	realTimeToWait;
-	extern usqLong getNextWakeupUsecs();
 	usqLong nextWakeupUsecs = getNextWakeupUsecs();
 	usqLong utcNow = get64(utcMicrosecondClock);
 


### PR DESCRIPTION
This was another bug that clang 14 apparently treated as a warning, but clang 18 treats is as an error.